### PR TITLE
fix(ci): ignore vendor Three.js code in eslint config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -33,6 +33,7 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    "public/tickets/vendor/**",
   ]),
 ]);
 


### PR DESCRIPTION
ESLint was attempting to lint compiled Three.js vendor code in public/tickets/vendor/, causing CI linter failures. Added public/tickets/vendor/** to globalIgnores in eslint.config.mjs.