### PR TITLE
feat: export Wrapped stories as downloadable image

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "clsx": "^2.1.1",
         "graphql": "^16.14.2",
         "graphql-yoga": "^5.21.2",
+        "html-to-image": "^1.11.13",
         "next": "^16.2.11",
         "react": "19.2.3",
         "react-dom": "19.2.3",
@@ -5500,6 +5501,12 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
       "license": "MIT"
     },
     "node_modules/http-proxy-agent": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "clsx": "^2.1.1",
     "graphql": "^16.14.2",
     "graphql-yoga": "^5.21.2",
+    "html-to-image": "^1.11.13",
     "next": "^16.2.11",
     "react": "19.2.3",
     "react-dom": "19.2.3",

--- a/src/domains/stats/components/WrappedStories.test.tsx
+++ b/src/domains/stats/components/WrappedStories.test.tsx
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { WrappedStories } from './WrappedStories'
+
+vi.mock('html-to-image', () => ({
+  toPng: vi.fn().mockResolvedValue('data:image/png;base64,mock')
+}))
+
+describe('WrappedStories', () => {
+  const slides = [
+    { kind: 'cover' as const, content: <div>Slide 1</div> },
+    { kind: 'shows' as const, content: <div>Slide 2</div> }
+  ]
+
+  it('renders story content and navigation buttons including Descargar', () => {
+    render(<WrappedStories slides={slides} handle="testuser" />)
+    
+    expect(screen.getByText('Slide 1')).toBeInTheDocument()
+    expect(screen.getByText('@testuser')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Descargar' })).toBeInTheDocument()
+  })
+
+  it('triggers download when Descargar button is clicked', async () => {
+    render(<WrappedStories slides={slides} handle="testuser" />)
+    
+    const downloadButton = screen.getByRole('button', { name: 'Descargar' })
+    await userEvent.click(downloadButton)
+    
+    const { toPng } = await import('html-to-image')
+    expect(toPng).toHaveBeenCalled()
+  })
+})

--- a/src/domains/stats/components/WrappedStories.tsx
+++ b/src/domains/stats/components/WrappedStories.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useRef } from 'react'
 import Link from 'next/link'
+import { toPng } from 'html-to-image'
 import { routes } from '@/src/core/lib/routes'
 
 export interface WrappedSlide {
@@ -24,6 +25,8 @@ interface WrappedStoriesProps {
  */
 export function WrappedStories({ slides, handle }: WrappedStoriesProps) {
   const [index, setIndex] = useState(0)
+  const [isExporting, setIsExporting] = useState(false)
+  const cardRef = useRef<HTMLDivElement>(null)
   const total = slides.length
 
   function goTo(next: number) {
@@ -35,8 +38,33 @@ export function WrappedStories({ slides, handle }: WrappedStoriesProps) {
     if (e.key === 'ArrowLeft') goTo(index - 1)
   }
 
+  async function handleExport() {
+    if (!cardRef.current || isExporting) return
+    try {
+      setIsExporting(true)
+      const dataUrl = await toPng(cardRef.current, {
+        cacheBust: true,
+        filter: (node) => {
+          if (node instanceof HTMLElement && node.dataset.noExport === 'true') {
+            return false
+          }
+          return true
+        },
+      })
+      const link = document.createElement('a')
+      link.download = `ritual-wrapped-${handle}-placa-${index + 1}.png`
+      link.href = dataUrl
+      link.click()
+    } catch (err) {
+      console.error('Error al exportar la placa como imagen:', err)
+    } finally {
+      setIsExporting(false)
+    }
+  }
+
   return (
     <div
+      ref={cardRef}
       className="relative mx-auto w-full max-w-sm aspect-[9/16] bg-ritual-panel border border-ritual-border overflow-hidden select-none"
       onKeyDown={handleKeyDown}
       tabIndex={0}
@@ -64,6 +92,7 @@ export function WrappedStories({ slides, handle }: WrappedStoriesProps) {
         onClick={() => goTo(index - 1)}
         disabled={index === 0}
         aria-label="Placa anterior"
+        data-no-export="true"
         className="absolute left-0 top-0 bottom-0 w-1/3 z-10 disabled:cursor-default"
       />
       <button
@@ -71,10 +100,11 @@ export function WrappedStories({ slides, handle }: WrappedStoriesProps) {
         onClick={() => goTo(index + 1)}
         disabled={index === total - 1}
         aria-label="Placa siguiente"
+        data-no-export="true"
         className="absolute right-0 top-0 bottom-0 w-1/3 z-10 disabled:cursor-default"
       />
 
-      <div className="absolute bottom-4 left-0 right-0 z-20 flex items-center justify-center gap-4">
+      <div data-no-export="true" className="absolute bottom-4 left-0 right-0 z-20 flex items-center justify-center gap-3">
         <button
           type="button"
           onClick={() => goTo(index - 1)}
@@ -86,6 +116,14 @@ export function WrappedStories({ slides, handle }: WrappedStoriesProps) {
         <Link href={routes.profile} className="font-label text-[10px] tracking-[0.14em] uppercase text-ritual-red-hover">
           Ver perfil
         </Link>
+        <button
+          type="button"
+          onClick={handleExport}
+          disabled={isExporting}
+          className="font-label text-[10px] tracking-[0.1em] uppercase text-ritual-bone hover:text-ritual-red-hover transition-colors disabled:opacity-30"
+        >
+          {isExporting ? 'Guardando...' : 'Descargar'}
+        </button>
         <button
           type="button"
           onClick={() => goTo(index + 1)}


### PR DESCRIPTION
Agrega la funcionalidad para exportar y descargar las placas de Wrapped como imágenes PNG usando \html-to-image\. Agrega el botón 'Descargar' al visor de historias (\WrappedStories\) excluyendo controles de navegación en la captura de imagen. Closes #30