### PR TITLE
feat(seo): add dynamic og:image and schema.org Event JSON-LD

### DIFF
--- a/app/events/[id]/opengraph-image.tsx
+++ b/app/events/[id]/opengraph-image.tsx
@@ -1,0 +1,90 @@
+import { ImageResponse } from 'next/og'
+import { getEventById } from '@/src/domains/events/data'
+import { formatDate } from '@/src/core/lib/utils'
+
+export const alt = 'Recital en RITUAL'
+export const size = {
+  width: 1200,
+  height: 630,
+}
+export const contentType = 'image/png'
+
+export default async function Image({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const event = await getEventById(id)
+
+  const mainArtist = event?.lineups?.[0]?.artists?.name
+  const title = event?.name || mainArtist || 'Recital'
+  const venue = event?.venues
+    ? [event.venues.name, event.venues.city].filter(Boolean).join(', ')
+    : 'Sede por confirmar'
+  const dateStr = event?.date ? formatDate(event.date) : ''
+  const performers = event?.lineups?.map((l) => l.artists.name).filter(Boolean).join(', ')
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          background: '#09090b',
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          padding: '60px',
+          fontFamily: 'sans-serif',
+          color: '#f4f4f5',
+          border: '8px solid #dc2626',
+        }}
+      >
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <span style={{ fontSize: 32, fontWeight: 900, letterSpacing: '0.2em', color: '#dc2626' }}>
+            RITUAL
+          </span>
+          <span style={{ fontSize: 24, color: '#a1a1aa', letterSpacing: '0.1em' }}>
+            {dateStr}
+          </span>
+        </div>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+          <h1
+            style={{
+              fontSize: 64,
+              fontWeight: 900,
+              textTransform: 'uppercase',
+              margin: 0,
+              lineHeight: 1.1,
+              color: '#ffffff',
+            }}
+          >
+            {title}
+          </h1>
+          <p style={{ fontSize: 32, color: '#a1a1aa', margin: 0 }}>
+            {venue}
+          </p>
+          {performers && performers !== title && (
+            <p style={{ fontSize: 22, color: '#71717a', margin: 0 }}>
+              Lineup: {performers}
+            </p>
+          )}
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            borderTop: '1px solid #27272a',
+            paddingTop: '24px',
+          }}
+        >
+          <span style={{ fontSize: 20, color: '#71717a' }}>Agenda de recitales y memoria en vivo</span>
+          <span style={{ fontSize: 20, color: '#dc2626', fontWeight: 700 }}>RITUAL</span>
+        </div>
+      </div>
+    ),
+    {
+      ...size,
+    }
+  )
+}

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -18,6 +18,7 @@ import { AttendanceStatusButtons } from '@/src/domains/events/components/Attenda
 import { RatingAndReviewForm } from '@/src/domains/events/components/RatingAndReviewForm'
 import { PhotoGallery } from '@/src/domains/events/components/PhotoGallery'
 import { searchSpotifyArtist, getBestSpotifyImage, isSpotifyConfigured } from '@/src/core/lib/spotify'
+import { generateEventJsonLd } from '@/src/domains/events/jsonld'
 
 interface EventDetailPageProps {
   params: Promise<{ id: string }>
@@ -27,12 +28,21 @@ export async function generateMetadata({ params }: EventDetailPageProps): Promis
   const { id } = await params
   const event = await getEventById(id)
   if (!event) return { title: 'Recital no encontrado | RITUAL' }
+  const mainArtist = event.lineups?.[0]?.artists?.name
+  const title = event.name || mainArtist || 'Recital'
   const venueLabel = event.venues
     ? [event.venues.name, event.venues.city].filter(Boolean).join(', ')
     : 'Sede por confirmar'
+  const description = `${title} — ${formatDate(event.date)} · ${venueLabel}`
+
   return {
-    title: `${event.name || 'Recital'} | RITUAL`,
-    description: `${event.name || 'Recital'} — ${formatDate(event.date)} · ${venueLabel}`,
+    title: `${title} | RITUAL`,
+    description,
+    openGraph: {
+      title: `${title} | RITUAL`,
+      description,
+      type: 'website',
+    },
   }
 }
 
@@ -70,9 +80,14 @@ export default async function EventDetailPage({ params }: EventDetailPageProps) 
   const review = attendance?.review?.trim() || null
   const reviewVariant = !review ? 'none' : review.length > 220 ? 'long' : 'short'
   const expensesTotal = expenses.reduce((sum, e) => sum + Number(e.amount), 0)
+  const jsonLd = generateEventJsonLd(event)
 
   return (
     <main className="min-h-screen bg-ritual-bg text-ritual-bone">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
       {/* Hero */}
       <div className="relative h-72 md:h-[28rem] w-full overflow-hidden bg-ritual-panel">
         {heroImage ? (

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -86,7 +86,9 @@ export default async function EventDetailPage({ params }: EventDetailPageProps) 
     <main className="min-h-screen bg-ritual-bg text-ritual-bone">
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        // JSON.stringify doesn't escape "<" — a stored event/artist/venue name containing
+        // "</script>" would otherwise break out of this tag and inject arbitrary script.
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd).replace(/</g, '\\u003c') }}
       />
       {/* Hero */}
       <div className="relative h-72 md:h-[28rem] w-full overflow-hidden bg-ritual-panel">

--- a/src/domains/events/jsonld.test.ts
+++ b/src/domains/events/jsonld.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest'
+import { generateEventJsonLd } from './jsonld'
+import type { EventWithRelations } from '@/src/core/types'
+
+describe('generateEventJsonLd', () => {
+  it('generates schema.org Event JSON-LD structure with venue and lineups', () => {
+    const mockEvent: EventWithRelations = {
+      id: 'event-123',
+      name: 'Los Fundamentalistas en Huracán',
+      date: '2026-11-20',
+      venue_id: 'venue-456',
+      venues: {
+        name: 'Estadio Tomás Adolfo Ducó',
+        city: 'Buenos Aires',
+        country: 'Argentina',
+      },
+      lineups: [
+        {
+          artists: {
+            id: 'artist-1',
+            name: 'Los Fundamentalistas del Aire Acondicionado',
+            genre: 'Rock',
+          },
+        },
+      ],
+    }
+
+    const jsonLd = generateEventJsonLd(mockEvent)
+
+    expect(jsonLd).toEqual({
+      '@context': 'https://schema.org',
+      '@type': 'Event',
+      name: 'Los Fundamentalistas en Huracán',
+      startDate: '2026-11-20',
+      eventAttendanceMode: 'https://schema.org/OfflineEventAttendanceMode',
+      eventStatus: 'https://schema.org/EventScheduled',
+      location: {
+        '@type': 'Place',
+        name: 'Estadio Tomás Adolfo Ducó',
+        address: {
+          '@type': 'PostalAddress',
+          addressLocality: 'Buenos Aires',
+          addressCountry: 'Argentina',
+        },
+      },
+      performer: {
+        '@type': 'PerformingGroup',
+        name: 'Los Fundamentalistas del Aire Acondicionado',
+        genre: 'Rock',
+      },
+      description: expect.stringContaining('Los Fundamentalistas en Huracán'),
+    })
+  })
+
+  it('handles missing venue and lineups gracefully', () => {
+    const mockEvent: EventWithRelations = {
+      id: 'event-999',
+      name: null,
+      date: '2026-12-01',
+      venue_id: null,
+      venues: null,
+      lineups: null,
+    }
+
+    const jsonLd = generateEventJsonLd(mockEvent)
+
+    expect(jsonLd).toEqual({
+      '@context': 'https://schema.org',
+      '@type': 'Event',
+      name: 'Recital',
+      startDate: '2026-12-01',
+      eventAttendanceMode: 'https://schema.org/OfflineEventAttendanceMode',
+      eventStatus: 'https://schema.org/EventScheduled',
+      location: {
+        '@type': 'Place',
+        name: 'Sede por confirmar',
+      },
+      description: expect.stringContaining('Recital'),
+    })
+  })
+
+  it('handles multiple performers', () => {
+    const mockEvent: EventWithRelations = {
+      id: 'event-festival',
+      name: 'Festival Cosquín Rock',
+      date: '2027-02-10',
+      venue_id: 'venue-1',
+      venues: {
+        name: 'Aeroclub Santa María de Punilla',
+        city: 'Córdoba',
+        country: 'Argentina',
+      },
+      lineups: [
+        { artists: { id: 'a1', name: 'Divididos', genre: 'Rock' } },
+        { artists: { id: 'a2', name: 'Ciro y los Persas', genre: 'Rock' } },
+      ],
+    }
+
+    const jsonLd = generateEventJsonLd(mockEvent)
+
+    expect(jsonLd.performer).toEqual([
+      { '@type': 'PerformingGroup', name: 'Divididos', genre: 'Rock' },
+      { '@type': 'PerformingGroup', name: 'Ciro y los Persas', genre: 'Rock' },
+    ])
+  })
+})

--- a/src/domains/events/jsonld.ts
+++ b/src/domains/events/jsonld.ts
@@ -1,0 +1,46 @@
+import type { EventWithRelations } from '@/src/core/types'
+import { formatDate } from '@/src/core/lib/utils'
+
+export function generateEventJsonLd(event: EventWithRelations) {
+  const mainArtist = event.lineups?.[0]?.artists?.name
+  const title = event.name || mainArtist || 'Recital'
+  const venueLabel = event.venues
+    ? [event.venues.name, event.venues.city].filter(Boolean).join(', ')
+    : 'Sede por confirmar'
+  const dateLabel = formatDate(event.date)
+
+  const performers =
+    event.lineups && event.lineups.length > 0
+      ? event.lineups.map((row) => ({
+          '@type': 'PerformingGroup',
+          name: row.artists.name,
+          ...(row.artists.genre ? { genre: row.artists.genre } : {}),
+        }))
+      : undefined
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Event',
+    name: title,
+    startDate: event.date,
+    eventAttendanceMode: 'https://schema.org/OfflineEventAttendanceMode',
+    eventStatus: 'https://schema.org/EventScheduled',
+    location: {
+      '@type': 'Place',
+      name: event.venues?.name || 'Sede por confirmar',
+      ...(event.venues?.city || event.venues?.country
+        ? {
+            address: {
+              '@type': 'PostalAddress',
+              ...(event.venues.city ? { addressLocality: event.venues.city } : {}),
+              ...(event.venues.country ? { addressCountry: event.venues.country } : {}),
+            },
+          }
+        : {}),
+    },
+    ...(performers && performers.length > 0
+      ? { performer: performers.length === 1 ? performers[0] : performers }
+      : {}),
+    description: `${title} — ${dateLabel} · ${venueLabel}`,
+  }
+}


### PR DESCRIPTION
## Summary\nAdds dynamic Open Graph image generation and schema.org Event JSON-LD structured data for event detail pages (/events/[id]), addressing #18.\n\n## Changes\n- **Dynamic OG Image**: Created app/events/[id]/opengraph-image.tsx using Next.js ImageResponse to display event title, date, venue, and performers.\n- **JSON-LD Structured Data**: Added generateEventJsonLd helper (src/domains/events/jsonld.ts) and embedded JSON-LD script into app/events/[id]/page.tsx.\n- **Unit Tests**: Added src/domains/events/jsonld.test.ts.\n\nReferences #18