### PR TITLE
feat(auth): implement password recovery flow

### DIFF
--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -1,0 +1,25 @@
+import { redirect } from 'next/navigation'
+import { createClient } from '@/src/core/lib/supabase/server'
+import { ForgotPasswordForm } from '@/src/domains/auth/components'
+
+export default async function ForgotPasswordPage() {
+    const supabase = await createClient()
+    const { data: { user } } = await supabase.auth.getUser()
+
+    if (user) {
+        redirect('/')
+    }
+
+    return (
+        <main className="min-h-screen flex items-center justify-center bg-ritual-bg px-6 py-24">
+            <div className="w-full max-w-sm">
+                <div className="border border-ritual-border bg-ritual-panel-2 p-8 border-b-[3px] border-b-ritual-red">
+                    <p className="font-label text-[9px] tracking-[0.3em] uppercase text-ritual-red-hover mb-1">Duplicado</p>
+                    <h1 className="font-display text-4xl uppercase text-ritual-bone mb-6">Recuperar clave</h1>
+                    <ForgotPasswordForm />
+                </div>
+                <div className="border-t border-dashed border-ritual-border mt-0" />
+            </div>
+        </main>
+    )
+}

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -1,0 +1,45 @@
+import Link from 'next/link'
+import { createClient } from '@/src/core/lib/supabase/server'
+import { ResetPasswordForm } from '@/src/domains/auth/components'
+import { routes } from '@/src/core/lib/routes'
+
+export default async function ResetPasswordPage() {
+    const supabase = await createClient()
+    const { data: { user } } = await supabase.auth.getUser()
+
+    if (!user) {
+        return (
+            <main className="min-h-screen flex items-center justify-center bg-ritual-bg px-6 py-24">
+                <div className="w-full max-w-sm">
+                    <div className="border border-ritual-border bg-ritual-panel-2 p-8 border-b-[3px] border-b-ritual-red">
+                        <p className="font-label text-[9px] tracking-[0.3em] uppercase text-ritual-red-hover mb-1">Enlace inválido</p>
+                        <h1 className="font-display text-3xl uppercase text-ritual-bone mb-4">Enlace vencido</h1>
+                        <p className="font-body text-sm text-ritual-gray-text mb-6">
+                            El enlace para restablecer tu contraseña es inválido o ya expiró. Por favor solicitá uno nuevo.
+                        </p>
+                        <Link
+                            href={routes.forgotPassword}
+                            className="block w-full text-center bg-ritual-red px-4 py-3 font-figure text-xl tracking-wide text-ritual-bone transition-colors hover:bg-ritual-red-hover"
+                        >
+                            Solicitar nuevo enlace
+                        </Link>
+                    </div>
+                    <div className="border-t border-dashed border-ritual-border mt-0" />
+                </div>
+            </main>
+        )
+    }
+
+    return (
+        <main className="min-h-screen flex items-center justify-center bg-ritual-bg px-6 py-24">
+            <div className="w-full max-w-sm">
+                <div className="border border-ritual-border bg-ritual-panel-2 p-8 border-b-[3px] border-b-ritual-red">
+                    <p className="font-label text-[9px] tracking-[0.3em] uppercase text-ritual-red-hover mb-1">Cambio de acceso</p>
+                    <h1 className="font-display text-4xl uppercase text-ritual-bone mb-6">Nueva clave</h1>
+                    <ResetPasswordForm />
+                </div>
+                <div className="border-t border-dashed border-ritual-border mt-0" />
+            </div>
+        </main>
+    )
+}

--- a/src/core/auth/actions.test.ts
+++ b/src/core/auth/actions.test.ts
@@ -15,17 +15,21 @@ vi.mock('next/navigation', () => ({
   redirect: (...args: unknown[]) => mockRedirect(...args),
 }))
 
-import { login, signup, signout } from '@/src/core/auth/actions'
+import { login, signup, signout, requestPasswordReset, updatePassword } from '@/src/core/auth/actions'
 
 function makeSupabase(opts: {
   signInError?: { message: string } | null
   signUpError?: { message: string } | null
+  resetPasswordError?: { message: string } | null
+  updateUserError?: { message: string } | null
 }) {
   return {
     auth: {
       signInWithPassword: vi.fn(() => Promise.resolve({ error: opts.signInError ?? null })),
       signUp: vi.fn(() => Promise.resolve({ error: opts.signUpError ?? null })),
       signOut: vi.fn(() => Promise.resolve({ error: null })),
+      resetPasswordForEmail: vi.fn(() => Promise.resolve({ error: opts.resetPasswordError ?? null })),
+      updateUser: vi.fn(() => Promise.resolve({ error: opts.updateUserError ?? null })),
     },
   }
 }
@@ -127,5 +131,97 @@ describe('signout', () => {
 
     expect(supabase.auth.signOut).toHaveBeenCalledTimes(1)
     expect(mockRedirect).toHaveBeenCalledWith('/login')
+  })
+})
+
+describe('requestPasswordReset', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns error if email is missing', async () => {
+    const result = await requestPasswordReset(null, makeFormData({ email: '' }))
+    expect(result).toEqual({ error: 'El email es obligatorio.' })
+  })
+
+  it('calls resetPasswordForEmail with correct redirect URL and returns success', async () => {
+    const supabase = makeSupabase({})
+    mockCreateClient.mockReturnValue(Promise.resolve(supabase))
+
+    const result = await requestPasswordReset(null, makeFormData({ email: 'user@example.com' }))
+
+    expect(supabase.auth.resetPasswordForEmail).toHaveBeenCalledWith('user@example.com', {
+      redirectTo: 'http://localhost:3000/auth/callback?next=/reset-password',
+    })
+    expect(result).toEqual({
+      success: 'Si el email está registrado, te enviamos las instrucciones para restablecer tu contraseña.',
+    })
+  })
+
+  it('returns sanitized error when resetPasswordForEmail fails', async () => {
+    const supabase = makeSupabase({
+      resetPasswordError: { message: 'Rate limit exceeded' },
+    })
+    mockCreateClient.mockReturnValue(Promise.resolve(supabase))
+
+    const result = await requestPasswordReset(null, makeFormData({ email: 'user@example.com' }))
+
+    expect(result).toEqual({ error: 'Demasiados intentos. Probá de nuevo en unos minutos.' })
+  })
+})
+
+describe('updatePassword', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns error if password fields are missing', async () => {
+    const result = await updatePassword(null, makeFormData({ password: '', confirmPassword: '' }))
+    expect(result).toEqual({ error: 'Completá todos los campos.' })
+  })
+
+  it('returns error if passwords do not match', async () => {
+    const result = await updatePassword(
+      null,
+      makeFormData({ password: 'newpassword123', confirmPassword: 'differentpassword' })
+    )
+    expect(result).toEqual({ error: 'Las contraseñas no coinciden.' })
+  })
+
+  it('returns error if password is shorter than 6 characters', async () => {
+    const result = await updatePassword(
+      null,
+      makeFormData({ password: '12345', confirmPassword: '12345' })
+    )
+    expect(result).toEqual({ error: 'La contraseña debe tener al menos 6 caracteres.' })
+  })
+
+  it('calls updateUser and returns success when passwords match and are valid', async () => {
+    const supabase = makeSupabase({})
+    mockCreateClient.mockReturnValue(Promise.resolve(supabase))
+
+    const result = await updatePassword(
+      null,
+      makeFormData({ password: 'newpassword123', confirmPassword: 'newpassword123' })
+    )
+
+    expect(supabase.auth.updateUser).toHaveBeenCalledWith({ password: 'newpassword123' })
+    expect(result).toEqual({
+      success: 'Tu contraseña fue actualizada correctamente. Ya podés ingresar.',
+    })
+  })
+
+  it('returns sanitized error when updateUser fails', async () => {
+    const supabase = makeSupabase({
+      updateUserError: { message: 'Auth session missing' },
+    })
+    mockCreateClient.mockReturnValue(Promise.resolve(supabase))
+
+    const result = await updatePassword(
+      null,
+      makeFormData({ password: 'newpassword123', confirmPassword: 'newpassword123' })
+    )
+
+    expect(result).toEqual({ error: 'El enlace de recuperación es inválido o venció. Solicitá uno nuevo.' })
   })
 })

--- a/src/core/auth/actions.ts
+++ b/src/core/auth/actions.ts
@@ -9,6 +9,7 @@ import { sanitizeAuthError } from '@/src/core/lib/validation'
 type AuthActionState = { error: string } | { success: string } | null
 
 const SIGNUP_SUCCESS_MESSAGE = 'Revisá tu email para confirmar la cuenta.'
+const RESET_REQUEST_SUCCESS_MESSAGE = 'Si el email está registrado, te enviamos las instrucciones para restablecer tu contraseña.'
 
 export async function login(prevState: AuthActionState, formData: FormData) {
     const supabase = await createClient()
@@ -62,4 +63,50 @@ export async function signout() {
     await supabase.auth.signOut()
     revalidatePath('/', 'layout')
     redirect('/login')
+}
+
+export async function requestPasswordReset(prevState: AuthActionState, formData: FormData) {
+    const supabase = await createClient()
+
+    const email = formData.get('email') as string
+    if (!email) {
+        return { error: 'El email es obligatorio.' }
+    }
+
+    const { error } = await supabase.auth.resetPasswordForEmail(email, {
+        redirectTo: `${process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000'}/auth/callback?next=${routes.resetPassword}`,
+    })
+
+    if (error) {
+        return { error: sanitizeAuthError(error) }
+    }
+
+    return { success: RESET_REQUEST_SUCCESS_MESSAGE }
+}
+
+export async function updatePassword(prevState: AuthActionState, formData: FormData) {
+    const supabase = await createClient()
+
+    const password = formData.get('password') as string
+    const confirmPassword = formData.get('confirmPassword') as string
+
+    if (!password || !confirmPassword) {
+        return { error: 'Completá todos los campos.' }
+    }
+
+    if (password !== confirmPassword) {
+        return { error: 'Las contraseñas no coinciden.' }
+    }
+
+    if (password.length < 6) {
+        return { error: 'La contraseña debe tener al menos 6 caracteres.' }
+    }
+
+    const { error } = await supabase.auth.updateUser({ password })
+
+    if (error) {
+        return { error: sanitizeAuthError(error) }
+    }
+
+    return { success: 'Tu contraseña fue actualizada correctamente. Ya podés ingresar.' }
 }

--- a/src/core/lib/routes.ts
+++ b/src/core/lib/routes.ts
@@ -49,5 +49,7 @@ export const routes = {
   // Auth
   login: '/login',
   signup: '/signup',
+  forgotPassword: '/forgot-password',
+  resetPassword: '/reset-password',
   profile: '/profile',
 } as const

--- a/src/core/lib/validation.ts
+++ b/src/core/lib/validation.ts
@@ -138,11 +138,17 @@ export function sanitizeAuthError(error: { message?: string } | null | undefined
     if (msg.includes('password should be at least') || msg.includes('password is too short')) {
         return 'La contraseña debe tener al menos 6 caracteres.'
     }
+    if (msg.includes('same password') || msg.includes('should be different')) {
+        return 'La nueva contraseña debe ser diferente a la anterior.'
+    }
     if (msg.includes('unable to validate email address') || msg.includes('invalid email')) {
         return 'El email no es válido.'
     }
     if (msg.includes('rate limit') || msg.includes('too many requests')) {
         return 'Demasiados intentos. Probá de nuevo en unos minutos.'
+    }
+    if (msg.includes('token') || msg.includes('expired') || msg.includes('session') || msg.includes('jwt')) {
+        return 'El enlace de recuperación es inválido o venció. Solicitá uno nuevo.'
     }
 
     if (process.env.NODE_ENV === 'development') return error.message

--- a/src/domains/auth/components/ForgotPasswordForm.tsx
+++ b/src/domains/auth/components/ForgotPasswordForm.tsx
@@ -3,7 +3,7 @@
 import { useActionState } from 'react'
 import { useFormStatus } from 'react-dom'
 import Link from 'next/link'
-import { login } from '@/src/core/auth/actions'
+import { requestPasswordReset } from '@/src/core/auth/actions'
 import { routes } from '@/src/core/lib/routes'
 
 function SubmitButton() {
@@ -14,16 +14,37 @@ function SubmitButton() {
             disabled={pending}
             className="w-full bg-ritual-red px-4 py-3 font-figure text-xl tracking-wide text-ritual-bone transition-colors hover:bg-ritual-red-hover disabled:opacity-50"
         >
-            {pending ? 'Cortando…' : 'Cortar y entrar'}
+            {pending ? 'Enviando…' : 'Enviar instrucciones'}
         </button>
     )
 }
 
-export function LoginForm() {
-    const [state, action] = useActionState(login, null)
+export function ForgotPasswordForm() {
+    const [state, action] = useActionState(requestPasswordReset, null)
+
+    if (state?.success) {
+        return (
+            <div className="border border-ritual-border bg-ritual-surface p-6 text-center space-y-4">
+                <h3 className="font-display text-2xl uppercase text-ritual-bone">Solicitud enviada</h3>
+                <p className="font-body text-sm text-ritual-gray-text">
+                    {state.success}
+                </p>
+                <Link
+                    href={routes.login}
+                    className="inline-block bg-ritual-red px-5 py-2.5 font-label text-[10px] tracking-[0.14em] uppercase text-ritual-bone hover:bg-ritual-red-hover"
+                >
+                    Volver a Ingresar
+                </Link>
+            </div>
+        )
+    }
 
     return (
         <form action={action} className="space-y-5">
+            <p className="font-body text-sm text-ritual-gray-text mb-4">
+                Ingresá tu email registrado y te enviaremos un enlace para restablecer tu contraseña.
+            </p>
+
             <div className="space-y-1.5">
                 <label className="font-label text-[10px] tracking-[0.14em] uppercase text-ritual-gray-text" htmlFor="email">
                     Email
@@ -39,21 +60,6 @@ export function LoginForm() {
                 />
             </div>
 
-            <div className="space-y-1.5">
-                <label className="font-label text-[10px] tracking-[0.14em] uppercase text-ritual-gray-text" htmlFor="password">
-                    Contraseña
-                </label>
-                <input
-                    id="password"
-                    name="password"
-                    type="password"
-                    required
-                    autoComplete="current-password"
-                    className="w-full border-0 border-b border-ritual-border bg-transparent px-0 py-2 font-figure text-xl text-ritual-bone placeholder-ritual-gray-mid focus:border-ritual-red focus:outline-none"
-                    placeholder="••••••••"
-                />
-            </div>
-
             {state?.error && (
                 <p role="alert" className="font-body text-sm text-ritual-red-hover bg-ritual-red/10 border border-ritual-red/20 p-3">
                     {state.error}
@@ -62,18 +68,11 @@ export function LoginForm() {
 
             <SubmitButton />
 
-            <div className="space-y-2 text-center font-label text-xs text-ritual-gray-text pt-4">
-                <div>
-                    <Link href={routes.forgotPassword} className="text-ritual-gray-text hover:text-ritual-bone hover:underline underline-offset-4">
-                        ¿Olvidaste tu contraseña?
-                    </Link>
-                </div>
-                <div>
-                    ¿No tenés talonario?{' '}
-                    <Link href={routes.signup} className="text-ritual-red-hover hover:underline underline-offset-4">
-                        Emitilo acá
-                    </Link>
-                </div>
+            <div className="text-center font-label text-xs text-ritual-gray-text pt-4">
+                ¿Recordaste tu contraseña?{' '}
+                <Link href={routes.login} className="text-ritual-red-hover hover:underline underline-offset-4">
+                    Ingresá
+                </Link>
             </div>
         </form>
     )

--- a/src/domains/auth/components/ResetPasswordForm.tsx
+++ b/src/domains/auth/components/ResetPasswordForm.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+import { useActionState } from 'react'
+import { useFormStatus } from 'react-dom'
+import Link from 'next/link'
+import { updatePassword } from '@/src/core/auth/actions'
+import { routes } from '@/src/core/lib/routes'
+
+function SubmitButton() {
+    const { pending } = useFormStatus()
+    return (
+        <button
+            type="submit"
+            disabled={pending}
+            className="w-full bg-ritual-red px-4 py-3 font-figure text-xl tracking-wide text-ritual-bone transition-colors hover:bg-ritual-red-hover disabled:opacity-50"
+        >
+            {pending ? 'Actualizando…' : 'Guardar nueva contraseña'}
+        </button>
+    )
+}
+
+export function ResetPasswordForm() {
+    const [state, action] = useActionState(updatePassword, null)
+
+    if (state?.success) {
+        return (
+            <div className="border border-ritual-border bg-ritual-surface p-6 text-center space-y-4">
+                <h3 className="font-display text-2xl uppercase text-ritual-bone">Contraseña actualizada</h3>
+                <p className="font-body text-sm text-ritual-gray-text">
+                    {state.success}
+                </p>
+                <Link
+                    href={routes.login}
+                    className="inline-block bg-ritual-red px-5 py-2.5 font-label text-[10px] tracking-[0.14em] uppercase text-ritual-bone hover:bg-ritual-red-hover"
+                >
+                    Ir a Ingresar
+                </Link>
+            </div>
+        )
+    }
+
+    return (
+        <form action={action} className="space-y-5">
+            <div className="space-y-1.5">
+                <label className="font-label text-[10px] tracking-[0.14em] uppercase text-ritual-gray-text" htmlFor="password">
+                    Nueva contraseña
+                </label>
+                <input
+                    id="password"
+                    name="password"
+                    type="password"
+                    required
+                    minLength={6}
+                    autoComplete="new-password"
+                    className="w-full border-0 border-b border-ritual-border bg-transparent px-0 py-2 font-figure text-xl text-ritual-bone placeholder-ritual-gray-mid focus:border-ritual-red focus:outline-none"
+                    placeholder="Mínimo 6 caracteres"
+                />
+            </div>
+
+            <div className="space-y-1.5">
+                <label className="font-label text-[10px] tracking-[0.14em] uppercase text-ritual-gray-text" htmlFor="confirmPassword">
+                    Confirmar contraseña
+                </label>
+                <input
+                    id="confirmPassword"
+                    name="confirmPassword"
+                    type="password"
+                    required
+                    minLength={6}
+                    autoComplete="new-password"
+                    className="w-full border-0 border-b border-ritual-border bg-transparent px-0 py-2 font-figure text-xl text-ritual-bone placeholder-ritual-gray-mid focus:border-ritual-red focus:outline-none"
+                    placeholder="Repetir contraseña"
+                />
+            </div>
+
+            {state?.error && (
+                <p role="alert" className="font-body text-sm text-ritual-red-hover bg-ritual-red/10 border border-ritual-red/20 p-3">
+                    {state.error}
+                </p>
+            )}
+
+            <SubmitButton />
+
+            <div className="text-center font-label text-xs text-ritual-gray-text pt-4">
+                <Link href={routes.login} className="text-ritual-red-hover hover:underline underline-offset-4">
+                    Volver a Ingresar
+                </Link>
+            </div>
+        </form>
+    )
+}

--- a/src/domains/auth/components/index.ts
+++ b/src/domains/auth/components/index.ts
@@ -1,4 +1,6 @@
 export { LoginForm } from './LoginForm'
 export { SignupForm } from './SignupForm'
+export { ForgotPasswordForm } from './ForgotPasswordForm'
+export { ResetPasswordForm } from './ResetPasswordForm'
 export { ProfileForm } from './ProfileForm'
 export { SignOutButton } from './SignOutButton'


### PR DESCRIPTION
### Summary%0AImplements the Supabase password recovery flow (addresses #29).%0A%0A### Changes%0A- **Server Actions**: Added equestPasswordReset (calling esetPasswordForEmail with redirect URL) and updatePassword (calling updateUser). Updated sanitizeAuthError in src/core/lib/validation.ts for password recovery error messages.%0A- **UI Pages & Components**:%0A  - pp/forgot-password/page.tsx & src/domains/auth/components/ForgotPasswordForm.tsx: Password recovery request page and form adhering to the app's visual conventions (%22Duplicado%22 badge and ticket styling).%0A  - pp/reset-password/page.tsx & src/domains/auth/components/ResetPasswordForm.tsx: Reset password confirmation page and form.%0A  - Added forgot password link to LoginForm.tsx and updated outes in src/core/lib/routes.ts.%0A- **Edge Cases Handled**:%0A  - Authenticated users visiting /forgot-password are redirected to /.%0A  - Visiting /reset-password without a valid recovery session presents a clean expired/invalid link view with prompt to request a new link.%0A  - Client and server validation for missing fields, password confirmation mismatch, and password length requirement (<6 chars).%0A- **Tests**: Added unit test suite in src/core/auth/actions.test.ts for equestPasswordReset and updatePassword.