### PR TITLE
Architecture: introduce use-case service layer for expenses (issue #25 PoC)

### DIFF
--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -6,7 +6,7 @@ import { getEventById } from '@/src/domains/events/data'
 import { deleteEvent } from '@/src/domains/events/actions'
 import { getAttendanceForEvent } from '@/src/domains/events/attendance-data'
 import { getEventPhotos } from '@/src/domains/events/photo-actions'
-import { getExpensesForEvent } from '@/src/domains/expenses/data'
+import { listExpensesForEvent } from '@/src/domains/expenses/service'
 import { getCurrentUserId } from '@/src/core/auth/session'
 import { routes } from '@/src/core/lib/routes'
 import { isPastEvent } from '@/src/core/lib/dates'
@@ -57,7 +57,7 @@ export default async function EventDetailPage({ params }: EventDetailPageProps) 
     getEventById(id),
     getAttendanceForEvent(id),
     getEventPhotos(id),
-    getExpensesForEvent(id, userId),
+    listExpensesForEvent(id, userId),
   ])
 
   if (!event) notFound()

--- a/app/expenses/[id]/editar/page.tsx
+++ b/app/expenses/[id]/editar/page.tsx
@@ -1,8 +1,7 @@
 import { notFound } from 'next/navigation'
 import type { Metadata } from 'next'
 import { getCurrentUserId } from '@/src/core/auth/session'
-import { getExpenseById } from '@/src/domains/expenses/data'
-import { getEvents } from '@/src/domains/events/data'
+import { findExpenseById, listEventOptionsForExpensePicker } from '@/src/domains/expenses/service'
 import { updateExpense } from '@/src/domains/expenses/actions'
 import { ExpenseForm } from '@/src/domains/expenses/components'
 import { PageShell } from '@/src/core/components/layout'
@@ -15,7 +14,7 @@ interface EditExpensePageProps {
 export async function generateMetadata({ params }: EditExpensePageProps): Promise<Metadata> {
   const { id } = await params
   const userId = await getCurrentUserId()
-  const expense = await getExpenseById(id, userId)
+  const expense = await findExpenseById(id, userId)
   if (!expense) return { title: 'Gasto no encontrado | RITUAL' }
   return { title: `Editar gasto — $${Number(expense.amount).toLocaleString('es-AR')} | RITUAL` }
 }
@@ -24,8 +23,8 @@ export default async function EditExpensePage({ params }: EditExpensePageProps) 
   const { id } = await params
   const userId = await getCurrentUserId()
   const [expense, events] = await Promise.all([
-    getExpenseById(id, userId),
-    getEvents(),
+    findExpenseById(id, userId),
+    listEventOptionsForExpensePicker(),
   ])
   if (!userId || !expense) notFound()
 

--- a/app/expenses/[id]/page.tsx
+++ b/app/expenses/[id]/page.tsx
@@ -2,7 +2,7 @@ import { notFound } from 'next/navigation'
 import Link from 'next/link'
 import type { Metadata } from 'next'
 import { getCurrentUserId } from '@/src/core/auth/session'
-import { getExpenseById } from '@/src/domains/expenses/data'
+import { findExpenseById } from '@/src/domains/expenses/service'
 import { deleteExpense } from '@/src/domains/expenses/actions'
 import { routes } from '@/src/core/lib/routes'
 import { formatDate } from '@/src/core/lib/utils'
@@ -16,7 +16,7 @@ interface ExpenseDetailPageProps {
 export async function generateMetadata({ params }: ExpenseDetailPageProps): Promise<Metadata> {
   const { id } = await params
   const userId = await getCurrentUserId()
-  const expense = await getExpenseById(id, userId)
+  const expense = await findExpenseById(id, userId)
   if (!expense) return { title: 'Gasto no encontrado | RITUAL' }
   return {
     title: `${expense.category} — $${Number(expense.amount).toLocaleString('es-AR')} | RITUAL`,
@@ -27,7 +27,7 @@ export async function generateMetadata({ params }: ExpenseDetailPageProps): Prom
 export default async function ExpenseDetailPage({ params }: ExpenseDetailPageProps) {
   const { id } = await params
   const userId = await getCurrentUserId()
-  const expense = await getExpenseById(id, userId)
+  const expense = await findExpenseById(id, userId)
 
   if (!expense) notFound()
 

--- a/app/expenses/nuevo/page.tsx
+++ b/app/expenses/nuevo/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next'
-import { getEvents } from '@/src/domains/events/data'
+import { listEventOptionsForExpensePicker } from '@/src/domains/expenses/service'
 import { ExpenseForm } from '@/src/domains/expenses/components'
 import { createExpense } from '@/src/domains/expenses/actions'
 import { PageShell } from '@/src/core/components/layout'
@@ -15,7 +15,7 @@ export const metadata: Metadata = {
  * Carga eventos para opcionalmente asociar el gasto a un recital.
  */
 export default async function NewExpensePage() {
-  const events = await getEvents()
+  const events = await listEventOptionsForExpensePicker()
 
   return (
     <PageShell

--- a/app/expenses/page.tsx
+++ b/app/expenses/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { getCurrentUserId } from '@/src/core/auth/session'
-import { getExpenses, getExpensesSummary } from '@/src/domains/expenses/data'
+import { listExpenses, summarizeExpenses } from '@/src/domains/expenses/service'
 import { routes } from '@/src/core/lib/routes'
 import { formatDate } from '@/src/core/lib/utils'
 import { getExpenseCategory } from '@/src/domains/expenses/categories'
@@ -20,8 +20,8 @@ function formatARS(amount: number) {
 export default async function ExpensesPage() {
   const userId = await getCurrentUserId()
   const [expenses, summary] = await Promise.all([
-    getExpenses(userId),
-    getExpensesSummary(userId),
+    listExpenses(userId),
+    summarizeExpenses(userId),
   ])
 
   const topCategories = Object.entries(summary.byCategory).sort(([, a], [, b]) => b - a)

--- a/app/wrapped/page.tsx
+++ b/app/wrapped/page.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link'
 import { getPersonalStats } from '@/src/domains/stats/data'
 import { buildWrappedSummary } from '@/src/domains/stats/wrapped-view'
 import { getEventsWithAttendance } from '@/src/domains/events/data'
-import { getExpensesSummary } from '@/src/domains/expenses/data'
+import { summarizeExpenses } from '@/src/domains/expenses/service'
 import { getProfile } from '@/src/domains/auth/data'
 import { getCurrentUserId } from '@/src/core/auth/session'
 import { routes } from '@/src/core/lib/routes'
@@ -33,7 +33,7 @@ export default async function WrappedPage({ searchParams }: PageProps) {
     const [stats, allEvents, expensesSummary, profile] = await Promise.all([
         getPersonalStats(),
         getEventsWithAttendance(),
-        getExpensesSummary(userId),
+        summarizeExpenses(userId),
         getProfile(userId ?? undefined),
     ])
 

--- a/src/domains/expenses/service.test.ts
+++ b/src/domains/expenses/service.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('./data', () => ({
+  getExpenses: vi.fn(),
+  getExpenseById: vi.fn(),
+  getExpensesForEvent: vi.fn(),
+  getExpensesSummary: vi.fn(),
+}))
+
+vi.mock('@/src/domains/events/data', () => ({
+  getEvents: vi.fn(),
+}))
+
+import { getExpenses, getExpenseById, getExpensesForEvent, getExpensesSummary } from './data'
+import { getEvents } from '@/src/domains/events/data'
+import {
+  listExpenses,
+  findExpenseById,
+  listExpensesForEvent,
+  summarizeExpenses,
+  listEventOptionsForExpensePicker,
+} from './service'
+
+/**
+ * This service is the seam introduced for issue #25: Server Components and
+ * the GraphQL resolver call these functions instead of importing ./data (or,
+ * for the picker, the events domain's data.ts) directly. These tests only
+ * need to prove each use case delegates to the right data-layer call with
+ * the right arguments — the actual Supabase behavior is already covered by
+ * data.test.ts.
+ */
+describe('expenses service (use-case layer)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('listExpenses delegates to getExpenses with the given userId', async () => {
+    vi.mocked(getExpenses).mockResolvedValue([{ id: 'e1', user_id: 'u1', amount: 100, category: 'Otro', date: '2026-01-01' }])
+
+    const result = await listExpenses('u1')
+
+    expect(getExpenses).toHaveBeenCalledWith('u1')
+    expect(result).toEqual([{ id: 'e1', user_id: 'u1', amount: 100, category: 'Otro', date: '2026-01-01' }])
+  })
+
+  it('findExpenseById delegates to getExpenseById with id and userId', async () => {
+    vi.mocked(getExpenseById).mockResolvedValue(null)
+
+    const result = await findExpenseById('e1', 'u1')
+
+    expect(getExpenseById).toHaveBeenCalledWith('e1', 'u1')
+    expect(result).toBeNull()
+  })
+
+  it('listExpensesForEvent delegates to getExpensesForEvent with eventId and userId', async () => {
+    vi.mocked(getExpensesForEvent).mockResolvedValue([])
+
+    const result = await listExpensesForEvent('ev1', 'u1')
+
+    expect(getExpensesForEvent).toHaveBeenCalledWith('ev1', 'u1')
+    expect(result).toEqual([])
+  })
+
+  it('summarizeExpenses delegates to getExpensesSummary with the given userId', async () => {
+    const summary = { total: 100, byCategory: {}, byYear: {}, count: 1 }
+    vi.mocked(getExpensesSummary).mockResolvedValue(summary)
+
+    const result = await summarizeExpenses('u1')
+
+    expect(getExpensesSummary).toHaveBeenCalledWith('u1')
+    expect(result).toBe(summary)
+  })
+
+  it('listEventOptionsForExpensePicker delegates to the events domain getEvents, with no arguments', async () => {
+    vi.mocked(getEvents).mockResolvedValue([])
+
+    const result = await listEventOptionsForExpensePicker()
+
+    expect(getEvents).toHaveBeenCalledWith()
+    expect(result).toEqual([])
+  })
+})

--- a/src/domains/expenses/service.ts
+++ b/src/domains/expenses/service.ts
@@ -1,0 +1,62 @@
+import {
+  getExpenses,
+  getExpenseById,
+  getExpensesForEvent,
+  getExpensesSummary,
+} from './data'
+import type { ExpenseSummary } from './data'
+import { getEvents } from '@/src/domains/events/data'
+import type { Expense, EventWithRelations } from '@/src/core/types'
+
+export type { ExpenseSummary }
+
+/**
+ * Use-case / application-service layer for the expenses domain.
+ *
+ * Server Components (app/expenses/**, app/wrapped, app/events/[id]) and the
+ * GraphQL resolver (src/graphql/expenses.ts) call through here instead of
+ * importing ./data directly — see issue #25. This is the seam: swapping the
+ * data source or schema later (moving off Supabase, renaming a column) only
+ * requires changes in data.ts and here, never in a page component or the
+ * GraphQL layer.
+ *
+ * Mutations are deliberately NOT wrapped here — actions.ts already plays
+ * that role for writes: it validates input, returns the shared
+ * `ActionResult<T>` shape, and its redirect-free core functions
+ * (insertExpense/modifyExpense/removeExpense) are already reused as-is by
+ * both the Server Actions and the GraphQL mutations. Adding another
+ * pass-through layer in front of it would duplicate that seam, not
+ * strengthen it, so the write side is intentionally left alone.
+ */
+
+/** Lists the current user's expenses, most recent first. */
+export async function listExpenses(userId: string | null): Promise<Expense[]> {
+  return getExpenses(userId)
+}
+
+/** Finds one expense by id, scoped to its owner. */
+export async function findExpenseById(id: string, userId: string | null): Promise<Expense | null> {
+  return getExpenseById(id, userId)
+}
+
+/** Lists the expenses linked to a specific event, scoped to the given user. */
+export async function listExpensesForEvent(eventId: string, userId: string | null): Promise<Expense[]> {
+  return getExpensesForEvent(eventId, userId)
+}
+
+/** Aggregates total/by-category/by-year figures for the current user. */
+export async function summarizeExpenses(userId: string | null): Promise<ExpenseSummary> {
+  return getExpensesSummary(userId)
+}
+
+/**
+ * Event options for the expense form's "recital asociado" picker. This
+ * reads through the events domain's own data module — a cross-domain read,
+ * not a write or a schema change — so it's exposed here rather than forcing
+ * app/expenses/nuevo and app/expenses/[id]/editar to import events/data.ts
+ * directly. The events domain itself is out of scope for this migration
+ * (see the PR description's scope notes).
+ */
+export async function listEventOptionsForExpensePicker(): Promise<EventWithRelations[]> {
+  return getEvents()
+}

--- a/src/graphql/expenses.ts
+++ b/src/graphql/expenses.ts
@@ -1,6 +1,6 @@
 import { builder } from './builder'
-import { getExpenses, getExpenseById, getExpensesSummary } from '@/src/domains/expenses/data'
-import type { ExpenseSummary } from '@/src/domains/expenses/data'
+import { listExpenses, findExpenseById, summarizeExpenses } from '@/src/domains/expenses/service'
+import type { ExpenseSummary } from '@/src/domains/expenses/service'
 import { insertExpense, modifyExpense, removeExpense } from '@/src/domains/expenses/actions'
 import { MutationResultRef, toMutationResult } from './shared'
 
@@ -45,7 +45,7 @@ ExpenseSummaryRef.implement({
 builder.queryField('expenses', (t) =>
     t.field({
         type: [ExpenseRef],
-        resolve: (_root, _args, ctx) => getExpenses(ctx.userId),
+        resolve: (_root, _args, ctx) => listExpenses(ctx.userId),
     })
 )
 
@@ -56,14 +56,14 @@ builder.queryField('expense', (t) =>
         args: {
             id: t.arg.id({ required: true }),
         },
-        resolve: (_root, args, ctx) => getExpenseById(String(args.id), ctx.userId),
+        resolve: (_root, args, ctx) => findExpenseById(String(args.id), ctx.userId),
     })
 )
 
 builder.queryField('expensesSummary', (t) =>
     t.field({
         type: ExpenseSummaryRef,
-        resolve: (_root, _args, ctx) => getExpensesSummary(ctx.userId),
+        resolve: (_root, _args, ctx) => summarizeExpenses(ctx.userId),
     })
 )
 


### PR DESCRIPTION
## What

Introduces a Use Case / Application Service layer for the **expenses** domain, so presentation code (Server Components and the GraphQL resolver) no longer imports `src/domains/expenses/data.ts` directly. Closes the concrete example in #25 for one domain and establishes the pattern to repeat elsewhere.

New file: `src/domains/expenses/service.ts`, exporting `listExpenses`, `findExpenseById`, `listExpensesForEvent`, `summarizeExpenses`, and `listEventOptionsForExpensePicker`. Every former direct `data.ts` import (7 call sites, listed below) now goes through this file instead.

## Why expenses, and why only expenses

The repo has 7 `src/domains/*/data.ts` modules (artists, auth, events, expenses, festivals, stats, venues) — more than the 3-4 the issue's scope guidance treats as "just do them all in one PR." Per that guidance, this PR migrates **one well-bounded, representative domain** as a proof of concept, rather than touching all 7 at once overnight.

I picked **expenses** over the alternatives:
- **events** is the domain literally named in the issue's example (`getEventsWithAttendance`), but it's also the most central/highest-traffic domain in the app (home page, wrapped, festivals, venues all hang off it) — the scope guidance explicitly says to avoid the most central domain for a first pass, so I left it alone here.
- **auth** is explicitly excluded by the task scope.
- **venues**' own list page (`app/venues/page.tsx`) is just a redirect into the shared `/coleccion` aggregator page (artists+venues+festivals+events combined), so it isn't a clean, self-contained UI boundary to migrate in isolation.
- **expenses** has dedicated list/detail/edit/create pages, a self-contained `data.ts` + `actions.ts` + `categories.ts`, and an existing GraphQL resolver mirroring the same read functions — a clean, fully-owned vertical slice that still demonstrates cross-domain consumption (its data is also read from `app/wrapped/page.tsx` and `app/events/[id]/page.tsx`, both updated here too).

## Design

- **Reads only.** `service.ts` wraps the four query functions in `data.ts` (`getExpenses`, `getExpenseById`, `getExpensesForEvent`, `getExpensesSummary`) plus one cross-domain read (`getEvents` from the events domain, used only for the expense form's "recital asociado" picker) — so no `app/expenses/**` page ever imports a `data.ts` from any domain directly anymore.
- **Writes are intentionally NOT wrapped.** `actions.ts` (`insertExpense`/`modifyExpense`/`removeExpense`) already plays the use-case role for mutations: it validates input and returns the shared `ActionResult<T>` shape, and its redirect-free core functions are already reused as-is by both the Server Actions and the GraphQL mutations in `src/graphql/expenses.ts`. Wrapping it again in `service.ts` would duplicate that seam, not strengthen it — this is a judgment call, flagging it explicitly per the task's ask.
- **GraphQL resolver updated too.** `src/graphql/expenses.ts`'s three query resolvers now call `service.ts` instead of `data.ts`, so both presentation surfaces (SSR pages and the GraphQL API) depend on the same stable interface. This does not touch the GraphQL migration itself (no resolver shape, schema, or mutation changed) — out of scope per the task.
- Existing shared patterns (`ActionResult<T>`, `sanitizeError`, `MutationResultRef`/`toMutationResult`) are untouched and still the single source of truth for write results.

### Call sites migrated
- `app/expenses/page.tsx` — `getExpenses`, `getExpensesSummary` → `listExpenses`, `summarizeExpenses`
- `app/expenses/[id]/page.tsx` — `getExpenseById` → `findExpenseById`
- `app/expenses/[id]/editar/page.tsx` — `getExpenseById`, `getEvents` → `findExpenseById`, `listEventOptionsForExpensePicker`
- `app/expenses/nuevo/page.tsx` — `getEvents` → `listEventOptionsForExpensePicker`
- `app/wrapped/page.tsx` — `getExpensesSummary` → `summarizeExpenses`
- `app/events/[id]/page.tsx` — `getExpensesForEvent` → `listExpensesForEvent` (only this one import changed; the rest of that page's own events-domain imports are untouched, out of scope)
- `src/graphql/expenses.ts` — the three query resolvers now call `service.ts`

## Follow-up plan for the remaining domains

Once this pattern is reviewed and accepted, the same shape (`service.ts` per domain, wrapping reads, leaving `actions.ts` as the write-side use-case layer) can be repeated for:
1. **festivals** — smallest remaining domain, similarly self-contained.
2. **venues** — note its list page is folded into `/coleccion`, so migrating it means also touching `app/coleccion/page.tsx`'s multi-domain reads (artists+venues+festivals+events all at once) — bigger blast radius than expenses.
3. **artists** — has extra modules (`enrichment.ts`, `wishlist-actions.ts`) to fit into the same shape.
4. **stats** — mostly aggregation (`aggregate.ts`) over other domains' data; worth deciding whether it needs its own service.ts or just consumes the others'.
5. **events** — do this last and separately, given it's the most central domain and the one most entangled with the ongoing GraphQL migration; do it in its own reviewed PR, not bundled with smaller domains.

## Verified locally on this branch (all green)

- `npm run lint` — 0 errors (2 pre-existing warnings in `public/tickets/three-d-stage.js`, unrelated to this change)
- `npx tsc --noEmit` — clean
- `npm test` — 83 test files, 594 tests passing (added `src/domains/expenses/service.test.ts` covering the new delegation logic)

## Not merging this myself

Per repo convention, this is an architecture change with real judgment calls (domain choice, where the seam sits relative to `actions.ts`) — opening for your review, not merging.