### PR TITLE
fix(deps): bump nanoid to 3.3.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8447,9 +8447,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary
Bumps transitive dependency `nanoid` 3.3.16 → 3.3.18, patching a high-severity Dependabot alert (#55): custom generators can loop indefinitely when `size` is zero.

## Verification
- `npm audit`: 0 vulnerabilities (was 1 high).
- `tsc --noEmit`: clean.
- `npm run lint`: 0 errors (2 pre-existing unrelated warnings).