### PR TITLE
feat(festivals): introduce use-case service layer decoupling UI from data access

### DIFF
--- a/app/coleccion/page.tsx
+++ b/app/coleccion/page.tsx
@@ -3,7 +3,7 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { getArtists } from '@/src/domains/artists/data'
 import { getVenues } from '@/src/domains/venues/data'
-import { getFestivals } from '@/src/domains/festivals/data'
+import { listFestivals } from '@/src/domains/festivals/service'
 import { getEventsWithAttendance } from '@/src/domains/events/data'
 import { getWishlistArtistIds } from '@/src/domains/artists/wishlist-actions'
 import { aggregateEventStats } from '@/src/domains/stats/aggregate'
@@ -215,7 +215,7 @@ const FESTIVAL_STATUS_LABEL: Record<string, string> = {
 }
 
 async function FestivalsTab() {
-    const festivals = await getFestivals()
+    const festivals = await listFestivals()
     const upcoming = festivals.filter((f) => !isPastEvent(f.start_date))
     const past = festivals.filter((f) => isPastEvent(f.start_date))
 
@@ -240,7 +240,7 @@ async function FestivalsTab() {
     )
 }
 
-function FestivalList({ title, festivals }: { title: string; festivals: Awaited<ReturnType<typeof getFestivals>> }) {
+function FestivalList({ title, festivals }: { title: string; festivals: Awaited<ReturnType<typeof listFestivals>> }) {
     return (
         <section>
             <h2 className="font-label text-[10px] tracking-[0.2em] uppercase text-ritual-gray-text mb-4">{title}</h2>

--- a/app/festivals/[id]/page.tsx
+++ b/app/festivals/[id]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from 'next/navigation'
 import Link from 'next/link'
 import type { Metadata } from 'next'
-import { getFestivalById } from '@/src/domains/festivals/data'
+import { findFestivalById } from '@/src/domains/festivals/service'
 import { routes } from '@/src/core/lib/routes'
 import { safeHref } from '@/src/core/lib/validation'
 import { formatDate } from '@/src/core/lib/utils'
@@ -14,7 +14,7 @@ interface FestivalDetailPageProps {
 
 export async function generateMetadata({ params }: FestivalDetailPageProps): Promise<Metadata> {
     const { id } = await params
-    const festival = await getFestivalById(id)
+    const festival = await findFestivalById(id)
     if (!festival) return { title: 'Festival no encontrado | RITUAL' }
     return {
         title: `${festival.name} | RITUAL`,
@@ -24,7 +24,7 @@ export async function generateMetadata({ params }: FestivalDetailPageProps): Pro
 
 export default async function FestivalDetailPage({ params }: FestivalDetailPageProps) {
     const { id } = await params
-    const festival = await getFestivalById(id)
+    const festival = await findFestivalById(id)
     if (!festival) notFound()
 
     const start = new Date(festival.start_date)

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link'
 import { getEventsWithAttendance } from '@/src/domains/events/data'
 import { buildHomeFeed, buildHomeHeroState } from '@/src/domains/events/home-view'
 import { HomeHero } from '@/src/domains/events/components/HomeHero'
-import { getFestivals } from '@/src/domains/festivals/data'
+import { listFestivals } from '@/src/domains/festivals/service'
 import { getWishlistArtistIds } from '@/src/domains/artists/wishlist-actions'
 import { createClient } from '@/src/core/lib/supabase/server'
 import { routes } from '@/src/core/lib/routes'
@@ -74,7 +74,7 @@ async function getNearbyShows(): Promise<NearbyCard[]> {
 }
 
 export default async function HomePage() {
-  const [allEvents, festivals] = await Promise.all([getEventsWithAttendance(), getFestivals()])
+  const [allEvents, festivals] = await Promise.all([getEventsWithAttendance(), listFestivals()])
   const now = new Date()
 
   const { nextShow, byYear, years } = buildHomeFeed(allEvents, 'went', now)

--- a/src/domains/festivals/service.test.ts
+++ b/src/domains/festivals/service.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('./data', () => ({
+  getFestivals: vi.fn(),
+  getFestivalById: vi.fn(),
+}))
+
+import { getFestivals, getFestivalById } from './data'
+import type { Festival } from './data'
+import { listFestivals, findFestivalById } from './service'
+
+/**
+ * This service is the seam introduced for issue #25: Server Components and
+ * the GraphQL resolver call these functions instead of importing ./data
+ * directly. These tests only need to prove each use case delegates to the
+ * right data-layer call with the right arguments — the actual Supabase
+ * behavior is already covered by data.test.ts.
+ */
+describe('festivals service (use-case layer)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  const festival: Festival = {
+    id: 'f1',
+    name: 'Cosquín Rock',
+    edition: '2026',
+    start_date: '2026-02-01',
+    end_date: '2026-02-03',
+    venue_id: 'v1',
+    city: 'Córdoba',
+    country: 'AR',
+    website: null,
+    poster_url: null,
+    notes: null,
+    created_at: '2026-01-01T00:00:00Z',
+    venues: { name: 'Aeródromo', city: 'Santa María de Punilla' },
+    festival_events: [],
+    festival_attendance: [],
+  }
+
+  it('listFestivals delegates to getFestivals with no arguments', async () => {
+    vi.mocked(getFestivals).mockResolvedValue([festival])
+
+    const result = await listFestivals()
+
+    expect(getFestivals).toHaveBeenCalledWith()
+    expect(result).toEqual([festival])
+  })
+
+  it('findFestivalById delegates to getFestivalById with the given id', async () => {
+    vi.mocked(getFestivalById).mockResolvedValue(festival)
+
+    const result = await findFestivalById('f1')
+
+    expect(getFestivalById).toHaveBeenCalledWith('f1')
+    expect(result).toBe(festival)
+  })
+
+  it('findFestivalById returns null when the festival does not exist', async () => {
+    vi.mocked(getFestivalById).mockResolvedValue(null)
+
+    const result = await findFestivalById('missing')
+
+    expect(result).toBeNull()
+  })
+})

--- a/src/domains/festivals/service.ts
+++ b/src/domains/festivals/service.ts
@@ -1,0 +1,36 @@
+import { getFestivals, getFestivalById } from './data'
+import type { Festival } from './data'
+
+export type { Festival }
+
+/**
+ * Use-case / application-service layer for the festivals domain.
+ *
+ * Server Components (app/page, app/coleccion, app/festivals/[id]) and the
+ * GraphQL resolver (src/graphql/festivals.ts) call through here instead of
+ * importing ./data directly — see issue #25. This is the seam: swapping the
+ * data source or schema later (moving off Supabase, renaming a column) only
+ * requires changes in data.ts and here, never in a page component or the
+ * GraphQL layer.
+ *
+ * Unlike expenses, there is no cross-domain "picker" read to expose here:
+ * app/festivals/nuevo doesn't need to read from another domain to render its
+ * form. Mutations are deliberately NOT wrapped here either, for the same
+ * reason as expenses — actions.ts already plays that role for writes: it
+ * validates input, returns the shared `ActionResult<T>` shape, and its
+ * redirect-free core functions (insertFestival/removeFestival/
+ * saveFestivalAttendance/linkEventToFestival) are already reused as-is by
+ * both the Server Actions and the GraphQL mutations. Adding another
+ * pass-through layer in front of it would duplicate that seam, not
+ * strengthen it, so the write side is intentionally left alone.
+ */
+
+/** Lists the current user's festivals, most recent first. */
+export async function listFestivals(): Promise<Festival[]> {
+  return getFestivals()
+}
+
+/** Finds one festival by id, scoped to its owner via RLS. */
+export async function findFestivalById(id: string): Promise<Festival | null> {
+  return getFestivalById(id)
+}

--- a/src/graphql/festivals.ts
+++ b/src/graphql/festivals.ts
@@ -1,6 +1,6 @@
 import { builder } from './builder'
-import { getFestivals, getFestivalById } from '@/src/domains/festivals/data'
-import type { Festival } from '@/src/domains/festivals/data'
+import { listFestivals, findFestivalById } from '@/src/domains/festivals/service'
+import type { Festival } from '@/src/domains/festivals/service'
 import {
     insertFestival,
     removeFestival,
@@ -90,7 +90,7 @@ FestivalRef.implement({
 builder.queryField('festivals', (t) =>
     t.field({
         type: [FestivalRef],
-        resolve: () => getFestivals(),
+        resolve: () => listFestivals(),
     })
 )
 
@@ -101,7 +101,7 @@ builder.queryField('festival', (t) =>
         args: {
             id: t.arg.id({ required: true }),
         },
-        resolve: (_root, args) => getFestivalById(String(args.id)),
+        resolve: (_root, args) => findFestivalById(String(args.id)),
     })
 )
 


### PR DESCRIPTION
## What

Part of #25. Extends the use-case/service layer pattern established in #37 (expenses) to the **festivals** domain — the next domain in that PR's proposed migration order (festivals → venues → artists → stats → events).

New file: `src/domains/festivals/service.ts`, exporting `listFestivals` and `findFestivalById`. Every former direct `src/domains/festivals/data.ts` import (4 call sites, listed below) now goes through this file instead.

## Design

- **Reads only.** `service.ts` wraps the two query functions in `data.ts` (`getFestivals`, `getFestivalById`). No cross-domain "picker" read like expenses had (`listEventOptionsForExpensePicker`) — `app/festivals/nuevo/page.tsx`'s create form doesn't read from any other domain, so there's nothing analogous to expose here.
- **Writes are intentionally NOT wrapped**, same reasoning as expenses: `actions.ts` (`insertFestival`/`removeFestival`/`saveFestivalAttendance`/`linkEventToFestival`) already plays the use-case role for mutations — it validates input, returns the shared `ActionResult<T>` shape, and its redirect-free core functions are already reused as-is by both the Server Actions and the GraphQL mutations in `src/graphql/festivals.ts`. Wrapping it again would duplicate that seam, not strengthen it.
- **GraphQL resolver updated too.** `src/graphql/festivals.ts`'s two query resolvers (`festivals`, `festival`) now call `service.ts` instead of `data.ts`. `src/graphql/festivals.test.ts` needed no changes — it mocks `@/src/domains/festivals/data`, and since `service.ts` is a real (unmocked) pass-through, the mocked data-layer functions still drive the resolver in tests, exactly like the expenses GraphQL test.
- `src/domains/festivals/data.test.ts` is untouched — it still tests `data.ts` directly, same as `expenses/data.test.ts`.

### Call sites migrated
- `app/page.tsx` (home) — `getFestivals` → `listFestivals`
- `app/coleccion/page.tsx` — `getFestivals` → `listFestivals`
- `app/festivals/[id]/page.tsx` — `getFestivalById` → `findFestivalById` (both `generateMetadata` and the page component)
- `src/graphql/festivals.ts` — the two query resolvers now call `service.ts`

`app/festivals/page.tsx` was not touched — it's a bare redirect into `/coleccion?tab=festivales` with no data access. `app/festivals/nuevo/page.tsx` was not touched — it's a client component that only calls `createFestival` (a write, in `actions.ts`), no `data.ts` import.

## Verified locally on this branch (all green)

- `npm run lint` — 0 errors (2 pre-existing warnings in `public/tickets/three-d-stage.js`, unrelated to this change)
- `npx tsc --noEmit` — clean
- `npm test` — 84 test files, 597 tests passing (added `src/domains/festivals/service.test.ts` covering the new delegation logic)

## Not merging this myself

Same as #37 — this is an architecture change with judgment calls (no picker read, exact call-site list) worth a human look before merge.
