### PR TITLE
feat(events): manual ticket link for AllAccess/Passline deep links

### DIFF
--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -12,6 +12,7 @@ import { routes } from '@/src/core/lib/routes'
 import { isPastEvent } from '@/src/core/lib/dates'
 import { formatDate } from '@/src/core/lib/utils'
 import { getExpenseCategory } from '@/src/domains/expenses/categories'
+import { safeHref } from '@/src/core/lib/validation'
 import { LinkButton } from '@/src/core/components/ui'
 import { DeleteEventButton } from '@/src/domains/events/components'
 import { AttendanceStatusButtons } from '@/src/domains/events/components/AttendanceStatusButtons'
@@ -129,6 +130,20 @@ export default async function EventDetailPage({ params }: EventDetailPageProps) 
           </p>
           <AttendanceStatusButtons eventId={event.id} currentStatus={attendance?.status ?? null} isPast={isPast} />
         </section>
+
+        {/* Entradas — link manual (AllAccess, Passline, etc.), no hay búsqueda automática, ver issue #19 */}
+        {!isPast && safeHref(event.ticket_url) && (
+          <section>
+            <a
+              href={safeHref(event.ticket_url)!}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center justify-center font-label text-[10px] tracking-[0.14em] uppercase bg-ritual-red text-ritual-bone hover:bg-ritual-red-hover transition-colors px-6 py-3"
+            >
+              Comprar entradas →
+            </a>
+          </section>
+        )}
 
         {/* Info */}
         <section className="grid sm:grid-cols-2 gap-6 border-t border-ritual-border-subtle pt-8">

--- a/src/core/types/index.ts
+++ b/src/core/types/index.ts
@@ -66,6 +66,13 @@ export interface Event {
   venue_id: string | null
   status?: string
   created_at?: string
+  /**
+   * Link manual a un proveedor de ticketing (AllAccess, Passline, etc.).
+   * No auto-generado: ninguno de los dos expone una API o un patrón de URL
+   * de búsqueda documentado (a diferencia de Ticketmaster), así que lo
+   * completa quien carga el evento — ver issue #19.
+   */
+  ticket_url?: string | null
 }
 
 /**
@@ -83,6 +90,7 @@ export interface EventCreateInput {
   date: string
   venue_id: string
   artist_ids?: string[]
+  ticket_url?: string
 }
 
 /** Payload para actualizar un evento; artist_ids reemplaza todo el lineup. */
@@ -91,6 +99,7 @@ export interface EventUpdateInput {
   date?: string
   venue_id?: string
   artist_ids?: string[]
+  ticket_url?: string
 }
 
 /** Gasto personal (no compartido con otros usuarios). Tabla expenses. */

--- a/src/domains/events/actions.test.ts
+++ b/src/domains/events/actions.test.ts
@@ -424,6 +424,33 @@ describe('insertEvent / modifyEvent / removeEvent', () => {
     expect(mockRedirect).not.toHaveBeenCalled()
   })
 
+  // AllAccess/Passline no tienen API de búsqueda — issue #19 lo resuelve con
+  // un link manual por evento en vez de una integración inventada.
+  it('insertEvent trims and stores a provided ticket_url', async () => {
+    const eventsBuilder = makeQueryBuilder({ data: { id: VALID_EVENT_ID }, error: null })
+    mockCreateClient.mockReturnValue(Promise.resolve({ from: vi.fn(() => eventsBuilder) }))
+
+    await insertEvent({
+      name: 'Show',
+      date: '2024-01-01',
+      venue_id: VALID_VENUE_ID,
+      ticket_url: '  https://www.allaccess.com.ar/event/show  ',
+    } as never)
+
+    expect(eventsBuilder.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ ticket_url: 'https://www.allaccess.com.ar/event/show' })
+    )
+  })
+
+  it('insertEvent stores null when ticket_url is omitted', async () => {
+    const eventsBuilder = makeQueryBuilder({ data: { id: VALID_EVENT_ID }, error: null })
+    mockCreateClient.mockReturnValue(Promise.resolve({ from: vi.fn(() => eventsBuilder) }))
+
+    await insertEvent({ name: 'Show', date: '2024-01-01', venue_id: VALID_VENUE_ID } as never)
+
+    expect(eventsBuilder.insert).toHaveBeenCalledWith(expect.objectContaining({ ticket_url: null }))
+  })
+
   it('modifyEvent updates without redirecting', async () => {
     const eventsBuilder = makeQueryBuilder({ data: null, error: null }) as Record<string, unknown>
     eventsBuilder.update = vi.fn(() => eventsBuilder)
@@ -433,6 +460,29 @@ describe('insertEvent / modifyEvent / removeEvent', () => {
 
     expect(result).toEqual({})
     expect(mockRedirect).not.toHaveBeenCalled()
+    expect(eventsBuilder.update).toHaveBeenCalledWith(expect.not.objectContaining({ ticket_url: expect.anything() }))
+  })
+
+  it('modifyEvent trims and stores a provided ticket_url', async () => {
+    const eventsBuilder = makeQueryBuilder({ data: null, error: null }) as Record<string, unknown>
+    eventsBuilder.update = vi.fn(() => eventsBuilder)
+    mockCreateClient.mockReturnValue(Promise.resolve({ from: vi.fn(() => eventsBuilder) }))
+
+    await modifyEvent(VALID_EVENT_ID, { ticket_url: '  https://www.passline.com/eventos/show  ' })
+
+    expect(eventsBuilder.update).toHaveBeenCalledWith(
+      expect.objectContaining({ ticket_url: 'https://www.passline.com/eventos/show' })
+    )
+  })
+
+  it('modifyEvent clears ticket_url to null when set to an empty string', async () => {
+    const eventsBuilder = makeQueryBuilder({ data: null, error: null }) as Record<string, unknown>
+    eventsBuilder.update = vi.fn(() => eventsBuilder)
+    mockCreateClient.mockReturnValue(Promise.resolve({ from: vi.fn(() => eventsBuilder) }))
+
+    await modifyEvent(VALID_EVENT_ID, { ticket_url: '   ' })
+
+    expect(eventsBuilder.update).toHaveBeenCalledWith(expect.objectContaining({ ticket_url: null }))
   })
 
   it('removeEvent deletes lineups and the event without redirecting', async () => {

--- a/src/domains/events/actions.ts
+++ b/src/domains/events/actions.ts
@@ -46,6 +46,7 @@ export async function insertEvent(formData: EventCreateInput): Promise<ActionRes
       name,
       date: formData.date,
       venue_id: formData.venue_id,
+      ticket_url: formData.ticket_url?.trim() || null,
     })
     .select('id')
     .single()
@@ -194,7 +195,7 @@ export async function modifyEvent(id: string, formData: EventUpdateInput): Promi
   }
 
   const supabase = await createClient()
-  const payload: { name?: string | null; date?: string; venue_id?: string | null } = {}
+  const payload: { name?: string | null; date?: string; venue_id?: string | null; ticket_url?: string | null } = {}
 
   if (formData.name !== undefined) {
     payload.name = sanitizeText(formData.name, MAX_NAME_LENGTH)
@@ -204,6 +205,9 @@ export async function modifyEvent(id: string, formData: EventUpdateInput): Promi
   }
   if (formData.venue_id !== undefined) {
     payload.venue_id = formData.venue_id || null
+  }
+  if (formData.ticket_url !== undefined) {
+    payload.ticket_url = formData.ticket_url.trim() || null
   }
 
   if (Object.keys(payload).length > 0) {

--- a/src/domains/events/components/EventForm.test.tsx
+++ b/src/domains/events/components/EventForm.test.tsx
@@ -58,6 +58,7 @@ describe('EventForm — create mode', () => {
         date: '2024-05-01',
         venue_id: 'v1',
         artist_ids: ['a1'],
+        ticket_url: '',
       })
     })
     await waitFor(() => {
@@ -213,6 +214,33 @@ describe('EventForm — create mode', () => {
     })
   })
 
+  // AllAccess/Passline no tienen API de búsqueda — issue #19 lo resuelve con
+  // un link manual por evento en vez de una integración inventada.
+  it('includes the ticket link when filled', async () => {
+    const insertEvent = vi.fn().mockResolvedValue({ id: 'e-new' })
+    render(
+      <EventForm
+        venues={venues}
+        artists={artists}
+        insertEvent={insertEvent}
+        findOrCreateVenue={noopFindOrCreateVenue}
+        findOrCreateArtist={noopFindOrCreateArtist}
+      />
+    )
+
+    await userEvent.type(screen.getByLabelText(/Nombre del recital/), 'Show')
+    await userEvent.type(screen.getByLabelText(/Fecha/), '2024-05-01')
+    await pickVenue('Niceto')
+    await userEvent.type(screen.getByLabelText(/Link de entradas/), 'https://www.allaccess.com.ar/event/show')
+    await userEvent.click(screen.getByRole('button', { name: 'Guardar y generar el talón' }))
+
+    await waitFor(() => {
+      expect(insertEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ ticket_url: 'https://www.allaccess.com.ar/event/show' })
+      )
+    })
+  })
+
   it('does not touch attendance/memory when no rating was set', async () => {
     const insertEvent = vi.fn().mockResolvedValue({ id: 'e-new' })
     const setAttendanceStatus = vi.fn()
@@ -305,6 +333,23 @@ describe('EventForm — edit mode', () => {
         expect.objectContaining({ name: 'Show existente', artist_ids: ['a1'] })
       )
     })
+  })
+
+  // AllAccess/Passline no tienen API de búsqueda — issue #19 lo resuelve con
+  // un link manual por evento en vez de una integración inventada.
+  it('pre-fills the ticket link when the event already has one', () => {
+    render(
+      <EventForm
+        venues={venues}
+        artists={artists}
+        event={{ ...event, ticket_url: 'https://www.passline.com/eventos/show' }}
+        updateEvent={vi.fn()}
+        findOrCreateVenue={noopFindOrCreateVenue}
+        findOrCreateArtist={noopFindOrCreateArtist}
+      />
+    )
+
+    expect(screen.getByLabelText(/Link de entradas/)).toHaveValue('https://www.passline.com/eventos/show')
   })
 
   it('links "Cancelar" to the event detail page', () => {

--- a/src/domains/events/components/EventForm.tsx
+++ b/src/domains/events/components/EventForm.tsx
@@ -120,11 +120,12 @@ export function EventForm({
     const form = e.currentTarget
     const name = (form.elements.namedItem('name') as HTMLInputElement).value
     const date = (form.elements.namedItem('date') as HTMLInputElement).value
+    const ticket_url = (form.elements.namedItem('ticket_url') as HTMLInputElement).value
     const venue_id = selectedVenue.id
     const artist_ids = selectedArtists.map((a) => a.id)
 
     if (isEdit && event) {
-      const result = await updateEventFn!(event.id, { name, date, venue_id, artist_ids })
+      const result = await updateEventFn!(event.id, { name, date, venue_id, artist_ids, ticket_url })
       if (result?.error) {
         setError(result.error)
         setIsSubmitting(false)
@@ -134,7 +135,7 @@ export function EventForm({
 
     if (!insertEvent) return
 
-    const created = await insertEvent({ name, date, venue_id, artist_ids })
+    const created = await insertEvent({ name, date, venue_id, artist_ids, ticket_url })
     if (created.error || !created.id) {
       setError(created.error ?? 'No se pudo crear el recital.')
       setIsSubmitting(false)
@@ -236,6 +237,20 @@ export function EventForm({
             onCreate={handleCreateArtist}
           />
         </div>
+      </FormField>
+      <FormField
+        label="Link de entradas"
+        id="ticket_url"
+        hint="Opcional — AllAccess, Passline o donde se consigan. No hay búsqueda automática, pegá el link del evento a mano."
+      >
+        <input
+          id="ticket_url"
+          name="ticket_url"
+          type="url"
+          defaultValue={event?.ticket_url ?? ''}
+          placeholder="https://www.allaccess.com.ar/event/..."
+          className={inputClass}
+        />
       </FormField>
 
       {!isEdit && (

--- a/supabase/migrations/20260822120000_events_ticket_url.sql
+++ b/supabase/migrations/20260822120000_events_ticket_url.sql
@@ -1,0 +1,8 @@
+-- issue #19: AllAccess y Passline no exponen una API de búsqueda pública ni
+-- un patrón de URL documentado para armar un deep link (a diferencia de
+-- Ticketmaster, que sí tiene la Discovery API — ver src/core/lib/ticketmaster.ts).
+-- Se verificó manualmente contra ambos sitios: el buscador de cada uno es
+-- client-side y no navega a una URL con query string reconstruible. Por eso
+-- esto es un link manual por evento, no una integración — mismo patrón ya
+-- usado para festivals.website (20260218230000_festivals.sql).
+alter table public.events add column if not exists ticket_url text;


### PR DESCRIPTION
Closes #19

## Summary

- Adds an optional `ticket_url` field on `events`, settable from the event form (create + edit) and shown as a "Comprar entradas →" button on the event detail page when present and the show is upcoming.
- Sanitized at render time with the existing `safeHref()` helper (`src/core/lib/validation.ts`) before being used as an `href` — same pattern already used for `festival.website` and `profile.website`.

## Why a manual field, not an auto-generated deep link

The issue explicitly scopes this to AllAccess/Passline *not* being integrated for search/import like Ticketmaster is — only deep-linking. Before implementing, I verified whether either provider has a documented, constructible search-URL pattern (the same way Ticketmaster's Discovery API works):

- **AllAccess** (`allaccess.com.ar`): has a "Buscar Artista o Evento" search box, but typing a query and submitting (Enter or the search button) never navigates — `window.location.href` stayed on `/` in both cases. It's a client-side-only search with no shareable/constructible result URL. The site also flags automated traffic ("detectamos actividad sospechosa"), reinforcing that this isn't meant to be hit programmatically.
- **Passline** (`passline.com` → `home.passline.com`, country-scoped SPA): same story — typing an artist name into the search box and pressing Enter did not navigate to a query-based URL either.

I drove both sites directly in a browser rather than relying on static HTML/docs (an initial `WebFetch` pass was inconclusive/blocked). Neither exposes a real, verifiable URL scheme I could construct from artist+venue+date. Guessing one anyway risks a link that silently 404s for users, which the issue explicitly warns against. So this ships the honest fallback it names: **an optional, manually-entered link field per event**, not an auto-generated search URL.

## Changes

| File | Change |
|------|--------|
| `supabase/migrations/20260822120000_events_ticket_url.sql` | Adds nullable `ticket_url text` column to `events` |
| `src/core/types/index.ts` | Adds `ticket_url` to `Event`, `EventCreateInput`, `EventUpdateInput` |
| `src/domains/events/actions.ts` | `insertEvent`/`modifyEvent` trim and persist `ticket_url` (empty → `null`) |
| `src/domains/events/components/EventForm.tsx` | New optional "Link de entradas" field (create + edit) |
| `app/events/[id]/page.tsx` | Renders a "Comprar entradas →" button when `safeHref(event.ticket_url)` is truthy and the show hasn't happened yet |
| `src/domains/events/actions.test.ts`, `EventForm.test.tsx` | New tests for the trim/null/pre-fill/submit behavior above |

Note: this repo has no `database.types.ts` checked in (the Supabase-generated types script exists in `package.json` but nothing imports/uses the generated file — the app hand-maintains its types in `src/core/types/index.ts`), so there's no generated-types file to regenerate here.

## Test plan

- [x] `npm run lint` — clean (2 pre-existing unrelated warnings in `public/tickets/three-d-stage.js`)
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 603/603 passing (6 new tests added for this change)
- [x] Manually verified in-browser that neither AllAccess nor Passline's search produces a navigable/constructible result URL (see above)