### PR TITLE
"Modo recital activo": checklist pre-show, recordatorio in-app y tarjeta recuerdo

### DIFF
--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -23,6 +23,19 @@ import { generateEventJsonLd } from '@/src/domains/events/jsonld'
 import { getEventWeather } from '@/src/domains/weather/weather-service'
 import { getClient } from '@/src/graphql/client'
 import { gql } from 'urql'
+import { getEventShowModeState } from '@/src/domains/showmode/service'
+import { buildMemoryCard } from '@/src/domains/showmode/memory-card'
+import {
+  setChecklistItemChecked,
+  addEventChecklistItem,
+  removeEventChecklistItem,
+} from '@/src/domains/showmode/actions'
+import {
+  ShowModeBanner,
+  PreShowChecklist,
+  PendingShowPrompt,
+  MemoryCard,
+} from '@/src/domains/showmode/components'
 
 const EventDetailPageQuery = gql`
   query EventDetailPage($eventId: ID!) {
@@ -103,6 +116,32 @@ export default async function EventDetailPage({ params }: EventDetailPageProps) 
   const jsonLd = generateEventJsonLd(event)
   const expensesDefaultDate = String(event.date).slice(0, 10)
 
+  // Modo recital activo — issue #9. La ventana se resuelve contra el rango
+  // real del show (el festival completo si el evento es un día de uno) y con
+  // la configuración del usuario. Recibe la asistencia y los gastos ya
+  // cargados arriba en vez de volver a pedirlos.
+  const showMode = await getEventShowModeState(event, userId, {
+    attendanceStatus: attendance?.status ?? null,
+    expenseCount: expenses.length,
+    rating: attendance?.rating ?? null,
+    review: attendance?.review ?? null,
+  })
+  const showsChecklist =
+    userId !== null && (showMode.window.phase === 'before' || showMode.window.phase === 'during')
+  // La tarjeta recuerdo tiene sentido recién con el show pasado y confirmado:
+  // antes de eso no hay nada que recordar. Se ofrece incluso con pendientes
+  // (avisando cuáles), en vez de esconderla hasta que esté todo perfecto.
+  const showsMemoryCard = userId !== null && isPast && attendance?.status === 'went'
+  const memoryCard = showsMemoryCard
+    ? buildMemoryCard({
+        event,
+        expenses,
+        rating: attendance?.rating ?? null,
+        review: attendance?.review ?? null,
+        weather,
+      })
+    : null
+
   return (
     <main className="min-h-screen bg-ritual-bg text-ritual-bone">
       <script
@@ -143,6 +182,14 @@ export default async function EventDetailPage({ params }: EventDetailPageProps) 
       </div>
 
       <div className="max-w-3xl mx-auto px-6 md:px-8 py-10 space-y-10">
+        {/* Modo recital activo — issue #9. Solo aparece dentro de la ventana. */}
+        {userId && <ShowModeBanner window={showMode.window} phaseLabel={showMode.phaseLabel} />}
+
+        {/* Recordatorio post-show, todo junto en un solo aviso in-app — issue #9 */}
+        {userId && showMode.window.phase === 'after' && (
+          <PendingShowPrompt pending={showMode.pending} />
+        )}
+
         {/* Banda de asistencia */}
         <section>
           <p className="font-label text-[10px] tracking-[0.2em] uppercase text-ritual-gray-text mb-3">
@@ -180,6 +227,22 @@ export default async function EventDetailPage({ params }: EventDetailPageProps) 
 
         {/* Clima exacto del show — ver issue #8 */}
         <EventWeather weather={weather} hasVenueCoords={hasVenueCoords} isPast={isPast} />
+
+        {/* Checklist pre-show — issue #9, solo mientras la ventana previa está abierta */}
+        {showsChecklist && (
+          <section className="border-t border-ritual-border-subtle pt-8">
+            <h2 className="font-label text-[10px] tracking-[0.2em] uppercase text-ritual-gray-text mb-4">
+              Antes de salir
+            </h2>
+            <PreShowChecklist
+              eventId={event.id}
+              initialItems={showMode.checklist}
+              setChecked={setChecklistItemChecked}
+              addItem={addEventChecklistItem}
+              removeItem={removeEventChecklistItem}
+            />
+          </section>
+        )}
 
         {/* Lineup — quién tocó */}
         {event.lineups && event.lineups.length > 0 && (
@@ -273,6 +336,20 @@ export default async function EventDetailPage({ params }: EventDetailPageProps) 
               initialRating={attendance?.rating}
               initialReview={attendance?.review}
               initialNotes={attendance?.notes}
+            />
+          </section>
+        )}
+
+        {/* Tarjeta recuerdo — issue #9. Stub de entrada digital, descargable
+            como imagen. No es una función social: no se publica ni se comparte. */}
+        {memoryCard && (
+          <section className="border-t border-ritual-border-subtle pt-8">
+            <h2 className="font-label text-[10px] tracking-[0.2em] uppercase text-ritual-gray-text mb-4">
+              Tarjeta recuerdo
+            </h2>
+            <MemoryCard
+              card={memoryCard}
+              pendingLabels={showMode.pending.map((item) => item.label)}
             />
           </section>
         )}

--- a/app/modo-recital/page.tsx
+++ b/app/modo-recital/page.tsx
@@ -1,0 +1,44 @@
+import { redirect } from 'next/navigation'
+import { getCurrentUserId } from '@/src/core/auth/session'
+import { routes } from '@/src/core/lib/routes'
+import { PageShell } from '@/src/core/components/layout'
+import { getShowModeSettings } from '@/src/domains/showmode/service'
+import {
+    saveShowModePreferences,
+    addChecklistTemplateItem,
+    removeChecklistTemplateItem,
+} from '@/src/domains/showmode/actions'
+import { ShowModeSettingsForm } from '@/src/domains/showmode/components'
+
+export const metadata = {
+    title: 'Modo recital | RITUAL',
+}
+
+/**
+ * Ajustes del modo recital activo (issue #9). Las dos cosas que el issue
+ * pide configurar una sola vez, juntas: el largo de la ventana y la
+ * plantilla base del checklist pre-show.
+ */
+export default async function ShowModeSettingsPage() {
+    const userId = await getCurrentUserId()
+    if (!userId) redirect(routes.login)
+
+    const { preferences, templateItems } = await getShowModeSettings(userId)
+
+    return (
+        <PageShell
+            backHref={routes.profile}
+            backLabel="← Volver al perfil"
+            title="Modo recital"
+            description="Cómo querés que la app te acompañe alrededor de un show."
+        >
+            <ShowModeSettingsForm
+                initialPreferences={preferences}
+                initialTemplateItems={templateItems}
+                savePreferences={saveShowModePreferences}
+                addTemplateItem={addChecklistTemplateItem}
+                removeTemplateItem={removeChecklistTemplateItem}
+            />
+        </PageShell>
+    )
+}

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -77,9 +77,13 @@ export default async function ProfilePage() {
                         </div>
                     </div>
 
-                    <div className="pt-4 mt-4 border-t border-ritual-border-subtle">
+                    <div className="pt-4 mt-4 border-t border-ritual-border-subtle flex flex-wrap gap-3">
                         <LinkButton href={routes.profile + '/edit'} variant="secondary" className="px-5 py-2">
                             Editar carnet
+                        </LinkButton>
+                        {/* Ventana y plantilla del checklist pre-show — issue #9 */}
+                        <LinkButton href={routes.showMode} variant="secondary" className="px-5 py-2">
+                            Modo recital
                         </LinkButton>
                     </div>
                 </section>

--- a/src/core/lib/routes.ts
+++ b/src/core/lib/routes.ts
@@ -12,6 +12,8 @@ export const routes = {
   wrapped: '/wrapped',
   /** Unifica los catálogos de artistas/sedes/festivales en pestañas. */
   collection: '/coleccion',
+  /** Ajustes del modo recital activo: ventana y plantilla del checklist — issue #9. */
+  showMode: '/modo-recital',
 
   artists: {
     list: '/artists',

--- a/src/domains/events/components/EventWeather.tsx
+++ b/src/domains/events/components/EventWeather.tsx
@@ -1,22 +1,11 @@
 import type { EventWeather as EventWeatherData } from '@/src/domains/weather/weather-service'
+import { weatherEmoji } from '@/src/domains/weather/icons'
 
 interface EventWeatherProps {
   weather: EventWeatherData | null
   /** Sede sin lat/lng cargado — mensaje distinto a "no se pudo calcular". */
   hasVenueCoords: boolean
   isPast: boolean
-}
-
-function weatherEmoji(code: number | null, isRain: boolean): string {
-  if (isRain) return '🌧️'
-  if (code === null) return '🌡️'
-  if (code === 0) return '☀️'
-  if (code <= 2) return '🌤️'
-  if (code === 3) return '☁️'
-  if (code === 45 || code === 48) return '🌫️'
-  if (code >= 71 && code <= 86) return '❄️'
-  if (code >= 95) return '⛈️'
-  return '🌡️'
 }
 
 /**

--- a/src/domains/showmode/actions.test.ts
+++ b/src/domains/showmode/actions.test.ts
@@ -1,0 +1,317 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Mock } from 'vitest'
+
+const mockCreateClient = vi.fn()
+const mockRevalidatePath = vi.fn()
+
+vi.mock('@/src/core/lib/supabase/server', () => ({
+    createClient: () => mockCreateClient(),
+}))
+
+vi.mock('@/src/core/auth/session', () => ({
+    getCurrentUserId: vi.fn(),
+}))
+
+vi.mock('next/cache', () => ({
+    revalidatePath: (...args: unknown[]) => mockRevalidatePath(...args),
+}))
+
+import {
+    saveShowModePreferences,
+    addChecklistTemplateItem,
+    removeChecklistTemplateItem,
+    addEventChecklistItem,
+    removeEventChecklistItem,
+    setChecklistItemChecked,
+} from '@/src/domains/showmode/actions'
+import { getCurrentUserId } from '@/src/core/auth/session'
+
+const VALID_EVENT_ID = '22222222-2222-2222-2222-222222222222'
+const VALID_ITEM_ID = '33333333-3333-3333-3333-333333333333'
+
+type Spy = Mock<(...args: unknown[]) => unknown>
+
+interface BuilderSpies {
+    insert: Spy
+    update: Spy
+    upsert: Spy
+    delete: Spy
+    eq: Spy
+}
+
+/**
+ * Builder encadenable. `result` es lo que devuelven single()/maybeSingle() y
+ * el await directo; `count` es lo que devuelve el head:true del conteo.
+ */
+function makeQueryBuilder(
+    result: { data: unknown; error: unknown },
+    count: number,
+    spies: BuilderSpies
+) {
+    const builder: Record<string, unknown> = {}
+    const chain = () => builder
+    builder.select = vi.fn((_cols?: unknown, opts?: { head?: boolean }) => {
+        if (opts?.head) {
+            return {
+                eq: () => ({
+                    eq: () => Promise.resolve({ count, error: null }),
+                    then: (f: (v: unknown) => unknown) => Promise.resolve({ count, error: null }).then(f),
+                }),
+            }
+        }
+        return builder
+    })
+    builder.insert = vi.fn((...args: unknown[]) => {
+        spies.insert(...args)
+        return builder
+    })
+    builder.update = vi.fn((...args: unknown[]) => {
+        spies.update(...args)
+        return builder
+    })
+    builder.upsert = vi.fn((...args: unknown[]) => {
+        spies.upsert(...args)
+        return builder
+    })
+    builder.delete = vi.fn((...args: unknown[]) => {
+        spies.delete(...args)
+        return builder
+    })
+    builder.eq = vi.fn((...args: unknown[]) => {
+        spies.eq(...args)
+        return builder
+    })
+    builder.order = vi.fn(chain)
+    builder.limit = vi.fn(chain)
+    builder.maybeSingle = vi.fn(() => Promise.resolve(result))
+    builder.single = vi.fn(() => Promise.resolve(result))
+    builder.then = (onFulfilled: (v: unknown) => unknown, onRejected?: (e: unknown) => unknown) =>
+        Promise.resolve(result).then(onFulfilled, onRejected)
+    return builder
+}
+
+function setupClient(
+    result: { data: unknown; error: unknown } = { data: null, error: null },
+    count = 0
+) {
+    const spies: BuilderSpies = {
+        insert: vi.fn(),
+        update: vi.fn(),
+        upsert: vi.fn(),
+        delete: vi.fn(),
+        eq: vi.fn(),
+    }
+    const fromMock = vi.fn(() => makeQueryBuilder(result, count, spies))
+    mockCreateClient.mockReturnValue(Promise.resolve({ from: fromMock }))
+    return { fromMock, spies }
+}
+
+beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getCurrentUserId).mockResolvedValue('user-1')
+})
+
+describe('saveShowModePreferences', () => {
+    it('exige usuario autenticado', async () => {
+        vi.mocked(getCurrentUserId).mockResolvedValue(null)
+        expect(await saveShowModePreferences({ daysBefore: 7, daysAfter: 2 })).toEqual({
+            error: 'Usuario no autenticado',
+        })
+    })
+
+    it('guarda la ventana contra el id de la sesión, no contra uno que venga del cliente', async () => {
+        const { fromMock, spies } = setupClient()
+
+        expect(await saveShowModePreferences({ daysBefore: 10, daysAfter: 1 })).toEqual({})
+
+        expect(fromMock).toHaveBeenCalledWith('user_preferences')
+        expect(spies.upsert.mock.calls[0][0]).toMatchObject({
+            id: 'user-1',
+            show_mode_days_before: 10,
+            show_mode_days_after: 1,
+        })
+    })
+
+    it('clampea valores fuera de rango antes de escribir, en vez de chocar con el CHECK de la tabla', async () => {
+        const { spies } = setupClient()
+
+        await saveShowModePreferences({ daysBefore: 9999, daysAfter: -4 })
+
+        expect(spies.upsert.mock.calls[0][0]).toMatchObject({
+            show_mode_days_before: 60,
+            show_mode_days_after: 0,
+        })
+    })
+
+    it('devuelve un error saneado si Supabase falla', async () => {
+        setupClient({ data: null, error: { message: 'permission denied' } })
+        const result = await saveShowModePreferences({ daysBefore: 7, daysAfter: 2 })
+        expect(result.error).toBe('No tenés permiso para realizar esta acción.')
+    })
+})
+
+describe('addChecklistTemplateItem', () => {
+    it('exige usuario autenticado', async () => {
+        vi.mocked(getCurrentUserId).mockResolvedValue(null)
+        expect(await addChecklistTemplateItem('Entrada')).toEqual({ error: 'Usuario no autenticado' })
+    })
+
+    it('rechaza un ítem vacío o de puros espacios', async () => {
+        expect(await addChecklistTemplateItem('   ')).toEqual({
+            error: 'El ítem no puede estar vacío.',
+        })
+    })
+
+    it('inserta el ítem con el user_id de la sesión y lo ubica al final de la lista', async () => {
+        const { fromMock, spies } = setupClient({
+            data: { id: VALID_ITEM_ID, label: 'Entrada', position: 3 },
+            error: null,
+        })
+
+        const result = await addChecklistTemplateItem('  Entrada  ')
+
+        expect(fromMock).toHaveBeenCalledWith('checklist_template_items')
+        expect(spies.insert).toHaveBeenCalledWith(
+            expect.objectContaining({ user_id: 'user-1', label: 'Entrada' })
+        )
+        expect(result).toEqual({ id: VALID_ITEM_ID, label: 'Entrada', position: 3 })
+    })
+
+    it('frena cuando la plantilla ya llegó al tope de ítems', async () => {
+        setupClient({ data: null, error: null }, 50)
+        const result = await addChecklistTemplateItem('Uno más')
+        expect(result.error).toMatch(/50 ítems/)
+    })
+})
+
+describe('removeChecklistTemplateItem', () => {
+    it('valida que el id sea un UUID antes de tocar la base', async () => {
+        expect(await removeChecklistTemplateItem('no-es-uuid')).toEqual({ error: 'Ítem inválido.' })
+        expect(mockCreateClient).not.toHaveBeenCalled()
+    })
+
+    it('exige usuario autenticado', async () => {
+        vi.mocked(getCurrentUserId).mockResolvedValue(null)
+        expect(await removeChecklistTemplateItem(VALID_ITEM_ID)).toEqual({
+            error: 'Usuario no autenticado',
+        })
+    })
+
+    it('acota el delete al dueño, además de la política RLS', async () => {
+        const { spies } = setupClient()
+
+        expect(await removeChecklistTemplateItem(VALID_ITEM_ID)).toEqual({})
+
+        expect(spies.delete).toHaveBeenCalled()
+        expect(spies.eq).toHaveBeenCalledWith('user_id', 'user-1')
+    })
+})
+
+describe('addEventChecklistItem', () => {
+    it('valida el id del evento', async () => {
+        expect(await addEventChecklistItem('no-es-uuid', 'SUBE')).toEqual({
+            error: 'Evento inválido.',
+        })
+    })
+
+    it('rechaza un ítem vacío', async () => {
+        expect(await addEventChecklistItem(VALID_EVENT_ID, '  ')).toEqual({
+            error: 'El ítem no puede estar vacío.',
+        })
+    })
+
+    it('inserta el ítem atado al evento y al usuario de la sesión, sin tocar la plantilla', async () => {
+        const { fromMock, spies } = setupClient({
+            data: { id: VALID_ITEM_ID, label: 'SUBE', position: 0 },
+            error: null,
+        })
+
+        await addEventChecklistItem(VALID_EVENT_ID, 'SUBE')
+
+        expect(fromMock).toHaveBeenCalledWith('event_checklist_items')
+        expect(fromMock).not.toHaveBeenCalledWith('checklist_template_items')
+        expect(spies.insert).toHaveBeenCalledWith(
+            expect.objectContaining({
+                user_id: 'user-1',
+                event_id: VALID_EVENT_ID,
+                label: 'SUBE',
+                checked: false,
+            })
+        )
+    })
+})
+
+describe('removeEventChecklistItem', () => {
+    it('valida los dos ids', async () => {
+        expect(await removeEventChecklistItem('no-es-uuid', VALID_ITEM_ID)).toEqual({
+            error: 'Evento inválido.',
+        })
+        expect(await removeEventChecklistItem(VALID_EVENT_ID, 'no-es-uuid')).toEqual({
+            error: 'Ítem inválido.',
+        })
+    })
+
+    it('borra el ítem del show acotando al dueño', async () => {
+        const { fromMock, spies } = setupClient()
+
+        expect(await removeEventChecklistItem(VALID_EVENT_ID, VALID_ITEM_ID)).toEqual({})
+
+        expect(fromMock).toHaveBeenCalledWith('event_checklist_items')
+        expect(spies.eq).toHaveBeenCalledWith('user_id', 'user-1')
+    })
+})
+
+describe('setChecklistItemChecked', () => {
+    it('valida los ids y el origen antes de escribir', async () => {
+        expect(await setChecklistItemChecked('no-es-uuid', VALID_ITEM_ID, 'adhoc', true)).toEqual({
+            error: 'Evento inválido.',
+        })
+        expect(await setChecklistItemChecked(VALID_EVENT_ID, 'no-es-uuid', 'adhoc', true)).toEqual({
+            error: 'Ítem inválido.',
+        })
+        expect(
+            await setChecklistItemChecked(
+                VALID_EVENT_ID,
+                VALID_ITEM_ID,
+                'otro' as 'adhoc',
+                true
+            )
+        ).toEqual({ error: 'Origen de ítem inválido.' })
+    })
+
+    it('un ítem ad-hoc guarda su tilde en su propia fila', async () => {
+        const { fromMock, spies } = setupClient()
+
+        expect(await setChecklistItemChecked(VALID_EVENT_ID, VALID_ITEM_ID, 'adhoc', true)).toEqual({})
+
+        expect(fromMock).toHaveBeenCalledWith('event_checklist_items')
+        expect(spies.update).toHaveBeenCalledWith({ checked: true })
+    })
+
+    it(
+        'un ítem de plantilla guarda su tilde por (usuario, evento, ítem) — la plantilla es ' +
+            'compartida por todos los shows y no puede tener un estado tildado global',
+        async () => {
+            const { fromMock, spies } = setupClient()
+
+            expect(
+                await setChecklistItemChecked(VALID_EVENT_ID, VALID_ITEM_ID, 'template', true)
+            ).toEqual({})
+
+            expect(fromMock).toHaveBeenCalledWith('event_checklist_checks')
+            expect(fromMock).not.toHaveBeenCalledWith('checklist_template_items')
+            expect(spies.upsert.mock.calls[0][0]).toMatchObject({
+                user_id: 'user-1',
+                event_id: VALID_EVENT_ID,
+                template_item_id: VALID_ITEM_ID,
+                checked: true,
+            })
+        }
+    )
+
+    it('propaga un error saneado si la escritura falla', async () => {
+        setupClient({ data: null, error: { message: 'permission denied' } })
+        const result = await setChecklistItemChecked(VALID_EVENT_ID, VALID_ITEM_ID, 'template', true)
+        expect(result.error).toBe('No tenés permiso para realizar esta acción.')
+    })
+})

--- a/src/domains/showmode/actions.ts
+++ b/src/domains/showmode/actions.ts
@@ -1,0 +1,245 @@
+'use server'
+
+/**
+ * Escrituras del "modo recital activo" (issue #9).
+ *
+ * Todas devuelven el `ActionResult<T>` compartido y ninguna redirige: el
+ * checklist y los ajustes se manipulan sin salir de la página, igual que el
+ * panel de gastos del issue #7. Cada action revalida el usuario por su
+ * cuenta — el `user_id` nunca llega desde el cliente, siempre sale de la
+ * sesión, así que un id ajeno en el payload no puede escribir nada.
+ */
+
+import { revalidatePath } from 'next/cache'
+import { createClient } from '@/src/core/lib/supabase/server'
+import { getCurrentUserId } from '@/src/core/auth/session'
+import { validateUUID, sanitizeText, sanitizeError } from '@/src/core/lib/validation'
+import { routes } from '@/src/core/lib/routes'
+import { clampShowModePreferences } from './preferences'
+import type { ShowModePreferences } from './preferences'
+import type { ActionResult } from '@/src/core/types'
+
+/** Tope de texto de un ítem de checklist — una línea, no una nota. */
+const MAX_CHECKLIST_LABEL_LENGTH = 120
+
+/**
+ * Tope de ítems por lista (plantilla y ad-hoc, cada una por su lado). No es
+ * una restricción de producto sino un freno a que un bug de cliente en un
+ * loop llene la tabla; 50 ítems ya es una lista pre-show absurdamente larga.
+ */
+const MAX_CHECKLIST_ITEMS = 50
+
+/** Guarda la ventana del modo recital. Los valores se clampean a los límites de la tabla. */
+export async function saveShowModePreferences(
+    input: ShowModePreferences
+): Promise<ActionResult> {
+    const userId = await getCurrentUserId()
+    if (!userId) return { error: 'Usuario no autenticado' }
+
+    const prefs = clampShowModePreferences(input)
+
+    const supabase = await createClient()
+    const { error } = await supabase.from('user_preferences').upsert(
+        {
+            id: userId,
+            show_mode_days_before: prefs.daysBefore,
+            show_mode_days_after: prefs.daysAfter,
+            updated_at: new Date().toISOString(),
+        },
+        { onConflict: 'id' }
+    )
+    if (error) return { error: sanitizeError(error) }
+
+    revalidatePath(routes.showMode)
+    return {}
+}
+
+async function countRows(table: string, userId: string, eventId?: string): Promise<number> {
+    const supabase = await createClient()
+    let query = supabase.from(table).select('id', { count: 'exact', head: true }).eq('user_id', userId)
+    if (eventId) query = query.eq('event_id', eventId)
+    const { count } = await query
+    return count ?? 0
+}
+
+/** Agrega un ítem a la plantilla base. Se ubica al final de la lista. */
+export async function addChecklistTemplateItem(
+    label: string
+): Promise<ActionResult<{ id?: string; label?: string; position?: number }>> {
+    const userId = await getCurrentUserId()
+    if (!userId) return { error: 'Usuario no autenticado' }
+
+    const clean = sanitizeText(label, MAX_CHECKLIST_LABEL_LENGTH)
+    if (!clean) return { error: 'El ítem no puede estar vacío.' }
+
+    if ((await countRows('checklist_template_items', userId)) >= MAX_CHECKLIST_ITEMS) {
+        return { error: `La plantilla ya tiene ${MAX_CHECKLIST_ITEMS} ítems.` }
+    }
+
+    const supabase = await createClient()
+    const { data: last } = await supabase
+        .from('checklist_template_items')
+        .select('position')
+        .eq('user_id', userId)
+        .order('position', { ascending: false })
+        .limit(1)
+        .maybeSingle()
+
+    const position = (last?.position ?? -1) + 1
+
+    const { data, error } = await supabase
+        .from('checklist_template_items')
+        .insert({ user_id: userId, label: clean, position })
+        .select('id, label, position')
+        .single()
+
+    if (error || !data) return { error: sanitizeError(error) }
+
+    revalidatePath(routes.showMode)
+    return { id: data.id, label: data.label, position: data.position }
+}
+
+/**
+ * Borra un ítem de la plantilla. Los tildes que ese ítem tenga en cualquier
+ * show se van con él por el ON DELETE CASCADE de event_checklist_checks — no
+ * hay que limpiarlos a mano.
+ */
+export async function removeChecklistTemplateItem(id: string): Promise<ActionResult> {
+    const idErr = validateUUID(id, 'Ítem')
+    if (idErr) return { error: idErr }
+
+    const userId = await getCurrentUserId()
+    if (!userId) return { error: 'Usuario no autenticado' }
+
+    const supabase = await createClient()
+    const { error } = await supabase
+        .from('checklist_template_items')
+        .delete()
+        .eq('id', id)
+        .eq('user_id', userId)
+    if (error) return { error: sanitizeError(error) }
+
+    revalidatePath(routes.showMode)
+    return {}
+}
+
+/** Agrega un ítem puntual a un show, sin tocar la plantilla base. */
+export async function addEventChecklistItem(
+    eventId: string,
+    label: string
+): Promise<ActionResult<{ id?: string; label?: string; position?: number }>> {
+    const idErr = validateUUID(eventId, 'Evento')
+    if (idErr) return { error: idErr }
+
+    const userId = await getCurrentUserId()
+    if (!userId) return { error: 'Usuario no autenticado' }
+
+    const clean = sanitizeText(label, MAX_CHECKLIST_LABEL_LENGTH)
+    if (!clean) return { error: 'El ítem no puede estar vacío.' }
+
+    if ((await countRows('event_checklist_items', userId, eventId)) >= MAX_CHECKLIST_ITEMS) {
+        return { error: `Este show ya tiene ${MAX_CHECKLIST_ITEMS} ítems propios.` }
+    }
+
+    const supabase = await createClient()
+    const { data: last } = await supabase
+        .from('event_checklist_items')
+        .select('position')
+        .eq('user_id', userId)
+        .eq('event_id', eventId)
+        .order('position', { ascending: false })
+        .limit(1)
+        .maybeSingle()
+
+    const position = (last?.position ?? -1) + 1
+
+    const { data, error } = await supabase
+        .from('event_checklist_items')
+        .insert({ user_id: userId, event_id: eventId, label: clean, position, checked: false })
+        .select('id, label, position')
+        .single()
+
+    if (error || !data) return { error: sanitizeError(error) }
+
+    revalidatePath(routes.events.detail(eventId))
+    return { id: data.id, label: data.label, position: data.position }
+}
+
+/** Borra un ítem puntual de un show. */
+export async function removeEventChecklistItem(
+    eventId: string,
+    id: string
+): Promise<ActionResult> {
+    const eventErr = validateUUID(eventId, 'Evento')
+    if (eventErr) return { error: eventErr }
+    const idErr = validateUUID(id, 'Ítem')
+    if (idErr) return { error: idErr }
+
+    const userId = await getCurrentUserId()
+    if (!userId) return { error: 'Usuario no autenticado' }
+
+    const supabase = await createClient()
+    const { error } = await supabase
+        .from('event_checklist_items')
+        .delete()
+        .eq('id', id)
+        .eq('user_id', userId)
+    if (error) return { error: sanitizeError(error) }
+
+    revalidatePath(routes.events.detail(eventId))
+    return {}
+}
+
+/**
+ * Tilda o destilda un ítem del checklist de un show.
+ *
+ * El `source` decide dónde vive el estado, y es la razón por la que esta
+ * action no puede ser una sola tabla: un ítem ad-hoc guarda su tilde en su
+ * propia fila, mientras que uno de plantilla lo guarda en
+ * event_checklist_checks contra (usuario, evento, ítem) — la plantilla es
+ * compartida por todos los shows y no puede tener un estado tildado global.
+ */
+export async function setChecklistItemChecked(
+    eventId: string,
+    itemId: string,
+    source: 'template' | 'adhoc',
+    checked: boolean
+): Promise<ActionResult> {
+    const eventErr = validateUUID(eventId, 'Evento')
+    if (eventErr) return { error: eventErr }
+    const idErr = validateUUID(itemId, 'Ítem')
+    if (idErr) return { error: idErr }
+    if (source !== 'template' && source !== 'adhoc') {
+        return { error: 'Origen de ítem inválido.' }
+    }
+
+    const userId = await getCurrentUserId()
+    if (!userId) return { error: 'Usuario no autenticado' }
+
+    const supabase = await createClient()
+
+    if (source === 'adhoc') {
+        const { error } = await supabase
+            .from('event_checklist_items')
+            .update({ checked })
+            .eq('id', itemId)
+            .eq('user_id', userId)
+            .eq('event_id', eventId)
+        if (error) return { error: sanitizeError(error) }
+        return {}
+    }
+
+    const { error } = await supabase.from('event_checklist_checks').upsert(
+        {
+            user_id: userId,
+            event_id: eventId,
+            template_item_id: itemId,
+            checked,
+            updated_at: new Date().toISOString(),
+        },
+        { onConflict: 'user_id,event_id,template_item_id' }
+    )
+    if (error) return { error: sanitizeError(error) }
+
+    return {}
+}

--- a/src/domains/showmode/checklist.test.ts
+++ b/src/domains/showmode/checklist.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest'
+import { buildEventChecklist, checklistProgress } from '@/src/domains/showmode/checklist'
+import type {
+    ChecklistTemplateItem,
+    EventChecklistItem,
+    EventChecklistCheck,
+} from '@/src/domains/showmode/checklist'
+
+const template: ChecklistTemplateItem[] = [
+    { id: 't-2', label: 'Efectivo', position: 1 },
+    { id: 't-1', label: 'Entrada en el celular', position: 0 },
+]
+
+const adHoc: EventChecklistItem[] = [
+    { id: 'a-1', label: 'Cargar la SUBE', position: 0, checked: false },
+]
+
+describe('buildEventChecklist', () => {
+    it('pone la plantilla primero y los ítems del show después', () => {
+        const result = buildEventChecklist(template, adHoc, [])
+        expect(result.map((i) => i.label)).toEqual([
+            'Entrada en el celular',
+            'Efectivo',
+            'Cargar la SUBE',
+        ])
+    })
+
+    it('ordena cada bloque por position, no por el orden en que llegaron', () => {
+        const result = buildEventChecklist(template, [], [])
+        expect(result.map((i) => i.id)).toEqual(['t-1', 't-2'])
+    })
+
+    it('marca el origen de cada ítem para que la UI sepa cuál se puede borrar desde el show', () => {
+        const result = buildEventChecklist(template, adHoc, [])
+        expect(result.filter((i) => i.source === 'template')).toHaveLength(2)
+        expect(result.filter((i) => i.source === 'adhoc')).toHaveLength(1)
+    })
+
+    it('aplica el tilde de un ítem de plantilla solo al show que lo tiene tildado', () => {
+        const checks: EventChecklistCheck[] = [{ templateItemId: 't-1', checked: true }]
+        const result = buildEventChecklist(template, [], checks)
+        expect(result.find((i) => i.id === 't-1')?.checked).toBe(true)
+        expect(result.find((i) => i.id === 't-2')?.checked).toBe(false)
+    })
+
+    it('trata un ítem de plantilla sin fila de tilde como no tildado (es el estado inicial normal)', () => {
+        const result = buildEventChecklist(template, [], [])
+        expect(result.every((i) => !i.checked)).toBe(true)
+    })
+
+    it('respeta una fila de tilde explícitamente en false (el usuario destildó algo que había tildado)', () => {
+        const checks: EventChecklistCheck[] = [{ templateItemId: 't-1', checked: false }]
+        const result = buildEventChecklist(template, [], checks)
+        expect(result.find((i) => i.id === 't-1')?.checked).toBe(false)
+    })
+
+    it('ignora un tilde que apunta a un ítem de plantilla que ya no existe', () => {
+        const checks: EventChecklistCheck[] = [{ templateItemId: 't-borrado', checked: true }]
+        const result = buildEventChecklist(template, [], checks)
+        expect(result).toHaveLength(2)
+        expect(result.every((i) => !i.checked)).toBe(true)
+    })
+
+    it('toma el tilde de un ítem ad-hoc de su propia fila, no de la tabla de tildes', () => {
+        const checkedAdHoc: EventChecklistItem[] = [
+            { id: 'a-1', label: 'Cargar la SUBE', position: 0, checked: true },
+        ]
+        const result = buildEventChecklist([], checkedAdHoc, [])
+        expect(result[0].checked).toBe(true)
+    })
+
+    it('no muta los arrays que recibe al ordenarlos', () => {
+        const original = [...template]
+        buildEventChecklist(template, adHoc, [])
+        expect(template).toEqual(original)
+    })
+
+    it('devuelve una lista vacía cuando no hay ni plantilla ni ítems del show', () => {
+        expect(buildEventChecklist([], [], [])).toEqual([])
+    })
+})
+
+describe('checklistProgress', () => {
+    it('cuenta cuántos ítems están tildados sobre el total', () => {
+        const items = buildEventChecklist(template, adHoc, [{ templateItemId: 't-1', checked: true }])
+        expect(checklistProgress(items)).toEqual({
+            done: 1,
+            total: 3,
+            ratio: 1 / 3,
+            isComplete: false,
+        })
+    })
+
+    it('marca la lista completa cuando está todo tildado', () => {
+        const items = buildEventChecklist(
+            template,
+            [{ id: 'a-1', label: 'Cargar la SUBE', position: 0, checked: true }],
+            [
+                { templateItemId: 't-1', checked: true },
+                { templateItemId: 't-2', checked: true },
+            ]
+        )
+        expect(checklistProgress(items).isComplete).toBe(true)
+    })
+
+    it('una lista vacía da ratio 0 y nunca cuenta como completa (evita el NaN de 0/0)', () => {
+        expect(checklistProgress([])).toEqual({ done: 0, total: 0, ratio: 0, isComplete: false })
+    })
+})

--- a/src/domains/showmode/checklist.ts
+++ b/src/domains/showmode/checklist.ts
@@ -1,0 +1,117 @@
+/**
+ * Armado del checklist pre-show (issue #9).
+ *
+ * El issue pide "una plantilla base única configurada una vez, más ítems
+ * puntuales agregables por show". Eso son tres fuentes de datos que hay que
+ * combinar en una sola lista para la UI:
+ *   - los ítems de la plantilla (texto compartido por todos los shows),
+ *   - el tilde de cada ítem de plantilla en ESTE show,
+ *   - los ítems ad-hoc de este show (texto y tilde propios).
+ *
+ * Puro y sin Supabase para poder testear el merge y el progreso sin base de
+ * datos, y para que la misma función sirva tanto en el server component que
+ * arma la página como en el cliente al re-renderizar tras un tilde.
+ */
+
+/** Ítem de la plantilla base del usuario (tabla checklist_template_items). */
+export interface ChecklistTemplateItem {
+    id: string
+    label: string
+    position: number
+}
+
+/** Ítem puntual de un show (tabla event_checklist_items). */
+export interface EventChecklistItem {
+    id: string
+    label: string
+    position: number
+    checked: boolean
+}
+
+/** Tilde de un ítem de plantilla en un show (tabla event_checklist_checks). */
+export interface EventChecklistCheck {
+    templateItemId: string
+    checked: boolean
+}
+
+/**
+ * Una línea del checklist ya resuelto. `source` distingue de dónde viene
+ * porque la UI las trata distinto: un ítem de plantilla no se borra desde
+ * el show (se edita en los ajustes, y borrarlo ahí lo saca de todos los
+ * shows), uno ad-hoc sí.
+ */
+export interface ResolvedChecklistItem {
+    /** id del ítem de plantilla o del ítem ad-hoc, según `source`. */
+    id: string
+    label: string
+    checked: boolean
+    source: 'template' | 'adhoc'
+}
+
+function byPositionThenLabel(
+    a: { position: number; label: string },
+    b: { position: number; label: string }
+): number {
+    if (a.position !== b.position) return a.position - b.position
+    return a.label.localeCompare(b.label, 'es')
+}
+
+/**
+ * Combina plantilla + tildes + ítems ad-hoc en la lista que ve el usuario.
+ * La plantilla va primero (es lo que se repite show a show), los ad-hoc
+ * después, cada bloque ordenado por `position`.
+ *
+ * Un ítem de plantilla sin fila de tilde para este show cuenta como no
+ * tildado: las filas de `event_checklist_checks` se crean recién cuando el
+ * usuario toca el ítem, así que su ausencia es el estado inicial normal, no
+ * un dato faltante.
+ */
+export function buildEventChecklist(
+    templateItems: ChecklistTemplateItem[],
+    adHocItems: EventChecklistItem[],
+    checks: EventChecklistCheck[]
+): ResolvedChecklistItem[] {
+    const checkedTemplateIds = new Set(
+        checks.filter((c) => c.checked).map((c) => c.templateItemId)
+    )
+
+    const fromTemplate: ResolvedChecklistItem[] = [...templateItems]
+        .sort(byPositionThenLabel)
+        .map((item) => ({
+            id: item.id,
+            label: item.label,
+            checked: checkedTemplateIds.has(item.id),
+            source: 'template' as const,
+        }))
+
+    const fromShow: ResolvedChecklistItem[] = [...adHocItems]
+        .sort(byPositionThenLabel)
+        .map((item) => ({
+            id: item.id,
+            label: item.label,
+            checked: item.checked,
+            source: 'adhoc' as const,
+        }))
+
+    return [...fromTemplate, ...fromShow]
+}
+
+export interface ChecklistProgress {
+    done: number
+    total: number
+    /** 0..1. Una lista vacía da 0, no NaN. */
+    ratio: number
+    isComplete: boolean
+}
+
+/** Cuántos ítems están tildados sobre el total. Una lista vacía nunca está completa. */
+export function checklistProgress(items: ResolvedChecklistItem[]): ChecklistProgress {
+    const total = items.length
+    const done = items.filter((i) => i.checked).length
+    return {
+        done,
+        total,
+        ratio: total === 0 ? 0 : done / total,
+        isComplete: total > 0 && done === total,
+    }
+}

--- a/src/domains/showmode/components/MemoryCard.test.tsx
+++ b/src/domains/showmode/components/MemoryCard.test.tsx
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+const mockToPng = vi.fn()
+
+vi.mock('html-to-image', () => ({
+  toPng: (...args: unknown[]) => mockToPng(...args),
+}))
+
+import { MemoryCard } from '@/src/domains/showmode/components/MemoryCard'
+import type { MemoryCardData } from '@/src/domains/showmode/memory-card'
+
+const card: MemoryCardData = {
+  serial: 'RTL-4F2A-91C7',
+  title: 'Ritual en el Obelisco',
+  dateLabel: '10 de mayo de 2026',
+  venueLabel: 'Obelisco, Buenos Aires',
+  lineup: ['Los Redondos', 'Soporte'],
+  rating: 5,
+  reviewExcerpt: 'La mejor noche del año.',
+  totalSpent: 23000,
+  categories: [
+    { category: 'Entrada', icon: '🎟️', total: 15000 },
+    { category: 'Comida y bebida', icon: '🍔', total: 8000 },
+  ],
+  choripanLine: 'esto son 4,6 choripanes',
+  inflationLine: 'Hoy serían $30.000',
+  weather: { emoji: '☀️', temperatureC: 17, description: 'Despejado' },
+}
+
+function renderCard(overrides: Partial<React.ComponentProps<typeof MemoryCard>> = {}) {
+  return render(<MemoryCard card={card} pendingLabels={[]} {...overrides} />)
+}
+
+describe('MemoryCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockToPng.mockResolvedValue('data:image/png;base64,AAAA')
+  })
+
+  it('muestra los datos esenciales del show', () => {
+    renderCard()
+    expect(screen.getByText('Ritual en el Obelisco')).toBeInTheDocument()
+    expect(screen.getByText(/10 de mayo de 2026/)).toBeInTheDocument()
+    expect(screen.getByText(/Obelisco, Buenos Aires/)).toBeInTheDocument()
+  })
+
+  it('compone las comparaciones de gasto del issue #7', () => {
+    renderCard()
+    expect(screen.getByText('$23.000')).toBeInTheDocument()
+    expect(screen.getByText(/esto son 4,6 choripanes · Hoy serían \$30\.000/)).toBeInTheDocument()
+    expect(screen.getByText(/Entrada/)).toBeInTheDocument()
+    expect(screen.getByText('$15.000')).toBeInTheDocument()
+  })
+
+  it('compone el clima del issue #8', () => {
+    renderCard()
+    expect(screen.getByText('17°C')).toBeInTheDocument()
+    expect(screen.getByText('Despejado')).toBeInTheDocument()
+  })
+
+  it('sigue dibujando la tarjeta cuando no hay clima, en vez de esconderla', () => {
+    renderCard({ card: { ...card, weather: null } })
+    expect(screen.getByText('Sin registro')).toBeInTheDocument()
+    expect(screen.getByText('Ritual en el Obelisco')).toBeInTheDocument()
+  })
+
+  it('muestra el puntaje y el serial del stub', () => {
+    renderCard()
+    expect(screen.getByText('5/5')).toBeInTheDocument()
+    expect(screen.getByText('RTL-4F2A-91C7')).toBeInTheDocument()
+  })
+
+  it('descarga la tarjeta como imagen', async () => {
+    const user = userEvent.setup()
+    const clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(() => {})
+
+    renderCard()
+    await user.click(screen.getByRole('button', { name: /Descargar recuerdo/ }))
+
+    await waitFor(() => expect(mockToPng).toHaveBeenCalledTimes(1))
+    expect(clickSpy).toHaveBeenCalled()
+    clickSpy.mockRestore()
+  })
+
+  it('excluye del render los controles marcados con data-no-export', async () => {
+    const user = userEvent.setup()
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+
+    renderCard()
+    await user.click(screen.getByRole('button', { name: /Descargar recuerdo/ }))
+
+    await waitFor(() => expect(mockToPng).toHaveBeenCalled())
+    const options = mockToPng.mock.calls[0][1] as { filter: (node: Node) => boolean }
+
+    const excluded = document.createElement('div')
+    excluded.dataset.noExport = 'true'
+    expect(options.filter(excluded)).toBe(false)
+    expect(options.filter(document.createElement('div'))).toBe(true)
+  })
+
+  it('avisa el error sin romper la página si la exportación falla', async () => {
+    const user = userEvent.setup()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    mockToPng.mockRejectedValue(new Error('canvas tainted'))
+
+    renderCard()
+    await user.click(screen.getByRole('button', { name: /Descargar recuerdo/ }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('No se pudo descargar la imagen')
+  })
+
+  it('deja claro que es un recuerdo personal, no una función social', () => {
+    renderCard()
+    expect(screen.getByText(/No se publica en ningún lado/)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /compartir/i })).not.toBeInTheDocument()
+  })
+
+  it('avisa qué falta cuando el show está incompleto, pero deja descargar igual', () => {
+    renderCard({ pendingLabels: ['Escribir la reseña'] })
+    expect(screen.getByText(/Todavía falta escribir la reseña/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Descargar recuerdo/ })).toBeEnabled()
+  })
+})

--- a/src/domains/showmode/components/MemoryCard.tsx
+++ b/src/domains/showmode/components/MemoryCard.tsx
@@ -1,0 +1,194 @@
+'use client'
+
+import { useRef, useState } from 'react'
+import { toPng } from 'html-to-image'
+import { Button } from '@/src/core/components/ui'
+import { memoryCardFileName } from '@/src/domains/showmode/memory-card'
+import type { MemoryCardData } from '@/src/domains/showmode/memory-card'
+
+interface MemoryCardProps {
+  card: MemoryCardData
+  /** Lo que falta cargar; vacío cuando el show está completo. */
+  pendingLabels: string[]
+}
+
+function formatARS(amount: number): string {
+  return `$${amount.toLocaleString('es-AR', { maximumFractionDigits: 0 })}`
+}
+
+/**
+ * La "tarjeta recuerdo" del issue #9: un stub de entrada digital con los
+ * datos esenciales del show, las comparaciones de gasto (issue #7) y el
+ * clima (issue #8), descargable como imagen para guardarla fuera de la app.
+ *
+ * NO es una función social — el issue lo aclara explícitamente. No hay
+ * compartir, ni publicar, ni link público: se descarga y listo.
+ *
+ * Cómo se descarga: `toPng` de html-to-image sobre el nodo de la tarjeta.
+ * No es una dependencia nueva — ya estaba en el proyecto desde la
+ * exportación de las placas de Wrapped, y se reusa el mismo patrón, incluido
+ * el `filter` que saca del render cualquier nodo marcado con
+ * `data-no-export` (los botones no van adentro de la imagen).
+ *
+ * El papel: se reusan los tokens `ritual-paper*`, los mismos que ya viste en
+ * la reseña de la ficha del evento. Un stub tiene que sentirse impreso, no
+ * ser otra caja oscura más.
+ */
+export function MemoryCard({ card, pendingLabels }: MemoryCardProps) {
+  const cardRef = useRef<HTMLDivElement>(null)
+  const [isExporting, setIsExporting] = useState(false)
+  const [exportError, setExportError] = useState<string | null>(null)
+
+  async function handleDownload() {
+    if (!cardRef.current || isExporting) return
+    try {
+      setIsExporting(true)
+      setExportError(null)
+      const dataUrl = await toPng(cardRef.current, {
+        cacheBust: true,
+        // 2x para que el stub no salga borroso en pantallas densas ni al
+        // abrirlo fuera de la app, que es todo el punto de descargarlo.
+        pixelRatio: 2,
+        filter: (node) => !(node instanceof HTMLElement && node.dataset.noExport === 'true'),
+      })
+      const link = document.createElement('a')
+      link.download = memoryCardFileName(card)
+      link.href = dataUrl
+      link.click()
+    } catch (err) {
+      console.error('Error al exportar la tarjeta recuerdo:', err)
+      setExportError('No se pudo descargar la imagen. Probá de nuevo.')
+    } finally {
+      setIsExporting(false)
+    }
+  }
+
+  return (
+    <div className="space-y-4" data-testid="memory-card">
+      {pendingLabels.length > 0 && (
+        <p className="font-body text-sm text-ritual-gray-text">
+          Todavía falta {pendingLabels.join(', ').toLowerCase()} — podés descargarla igual, pero el
+          recuerdo queda incompleto.
+        </p>
+      )}
+
+      <div
+        ref={cardRef}
+        className="bg-ritual-paper text-ritual-paper-ink border border-ritual-paper-2 overflow-hidden"
+      >
+        <div className="grid sm:grid-cols-[1fr_auto]">
+          {/* Cuerpo de la entrada */}
+          <div className="p-6 md:p-8">
+            <div className="flex items-baseline justify-between gap-4 border-b border-ritual-paper-ink/20 pb-3">
+              <p className="font-display text-lg uppercase tracking-[0.08em] text-ritual-paper-red">
+                Ritual
+              </p>
+              <p className="font-label text-[9px] tracking-[0.2em] uppercase text-ritual-paper-ink/60">
+                Admitido una vez
+              </p>
+            </div>
+
+            <h3 className="font-display text-3xl md:text-5xl leading-[0.9] uppercase mt-5">
+              {card.title}
+            </h3>
+            <p className="font-label text-[10px] tracking-[0.16em] uppercase mt-2 text-ritual-paper-ink/70">
+              {card.dateLabel} · {card.venueLabel}
+            </p>
+
+            {card.lineup.length > 1 && (
+              <p className="font-body text-sm mt-3 text-ritual-paper-ink/80">
+                {card.lineup.join(' · ')}
+              </p>
+            )}
+
+            {/* La cuenta de esa noche — issue #7 */}
+            <div className="mt-6 border-t border-dashed border-ritual-paper-ink/30 pt-4">
+              <p className="font-label text-[9px] tracking-[0.2em] uppercase text-ritual-paper-ink/60">
+                Lo que salió
+              </p>
+              <p className="font-display text-4xl md:text-5xl leading-none mt-1">
+                {formatARS(card.totalSpent)}
+              </p>
+              {(card.choripanLine || card.inflationLine) && (
+                <p className="font-body text-sm italic mt-1.5 text-ritual-paper-ink/70">
+                  {[card.choripanLine, card.inflationLine].filter(Boolean).join(' · ')}
+                </p>
+              )}
+              {card.categories.length > 0 && (
+                <ul className="mt-3 grid grid-cols-2 gap-x-6 gap-y-1">
+                  {card.categories.map((line) => (
+                    <li
+                      key={line.category}
+                      className="font-label text-[11px] tracking-[0.04em] flex justify-between gap-2 text-ritual-paper-ink/80"
+                    >
+                      <span>
+                        {line.icon} {line.category}
+                      </span>
+                      <span>{formatARS(line.total)}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+
+            {card.reviewExcerpt && (
+              <p className="font-body italic text-base mt-5 border-l-[3px] border-ritual-paper-red pl-4">
+                &ldquo;{card.reviewExcerpt}&rdquo;
+              </p>
+            )}
+          </div>
+
+          {/* El talón: perforado, con clima, puntaje y serial */}
+          <div className="border-t sm:border-t-0 sm:border-l border-dashed border-ritual-paper-ink/40 p-6 md:p-8 flex sm:flex-col justify-between gap-6 sm:w-44 bg-ritual-paper-2/60">
+            <div>
+              <p className="font-label text-[9px] tracking-[0.2em] uppercase text-ritual-paper-ink/60">
+                Clima
+              </p>
+              {card.weather ? (
+                <>
+                  <p className="text-3xl mt-1" aria-hidden="true">
+                    {card.weather.emoji}
+                  </p>
+                  <p className="font-subtitle font-black text-2xl">{card.weather.temperatureC}°C</p>
+                  <p className="font-label text-[10px] text-ritual-paper-ink/70">
+                    {card.weather.description}
+                  </p>
+                </>
+              ) : (
+                <p className="font-label text-[10px] mt-1 text-ritual-paper-ink/60">Sin registro</p>
+              )}
+            </div>
+
+            <div>
+              <p className="font-label text-[9px] tracking-[0.2em] uppercase text-ritual-paper-ink/60">
+                Puntaje
+              </p>
+              <p className="font-display text-3xl leading-none mt-1">
+                {card.rating != null ? `${card.rating}/5` : '—'}
+              </p>
+            </div>
+
+            <p className="font-label text-[9px] tracking-[0.14em] uppercase text-ritual-paper-ink/50 self-end sm:self-auto">
+              {card.serial}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-3" data-no-export="true">
+        <Button type="button" variant="primary" className="px-5 py-2.5" onClick={handleDownload} disabled={isExporting}>
+          {isExporting ? 'Generando...' : 'Descargar recuerdo'}
+        </Button>
+        <p className="font-body text-xs text-ritual-gray-text">
+          Se guarda como imagen en tu dispositivo. No se publica en ningún lado.
+        </p>
+      </div>
+
+      {exportError && (
+        <p role="alert" className="font-body text-sm text-ritual-red-hover">
+          {exportError}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/domains/showmode/components/PendingShowPrompt.test.tsx
+++ b/src/domains/showmode/components/PendingShowPrompt.test.tsx
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { PendingShowPrompt } from '@/src/domains/showmode/components/PendingShowPrompt'
+import { computePendingForShow } from '@/src/domains/showmode/pending'
+
+describe('PendingShowPrompt', () => {
+  it('junta todo lo pendiente en un solo aviso, no en avisos sueltos', () => {
+    const pending = computePendingForShow({
+      attendanceStatus: 'went',
+      expenseCount: 0,
+      rating: null,
+      review: null,
+    })
+    render(<PendingShowPrompt pending={pending} />)
+
+    expect(screen.getAllByTestId('pending-show-prompt')).toHaveLength(1)
+    expect(screen.getByText('Cargar los gastos de esa noche')).toBeInTheDocument()
+    expect(screen.getByText('Puntuar el show')).toBeInTheDocument()
+    expect(screen.getByText('Escribir la reseña')).toBeInTheDocument()
+  })
+
+  it('no renderiza nada cuando no queda nada pendiente', () => {
+    const { container } = render(<PendingShowPrompt pending={[]} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('deja explícito que el aviso por mail/push depende del issue #6, todavía sin implementar', () => {
+    render(<PendingShowPrompt pending={[{ kind: 'rating', label: 'Puntuar el show' }]} />)
+
+    expect(screen.getByText(/depende del sistema de notificaciones/)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'issue #6' })).toHaveAttribute(
+      'href',
+      'https://github.com/Lantieridev/Ritual/issues/6'
+    )
+  })
+})

--- a/src/domains/showmode/components/PendingShowPrompt.tsx
+++ b/src/domains/showmode/components/PendingShowPrompt.tsx
@@ -1,0 +1,57 @@
+import type { PendingItem } from '@/src/domains/showmode/pending'
+
+interface PendingShowPromptProps {
+  pending: PendingItem[]
+}
+
+/**
+ * El "recordatorio post-show" del issue #9, resuelto in-app.
+ *
+ * El issue pide un solo aviso que junte todo lo pendiente del show (gastos +
+ * rating + reseña) en vez de notificaciones sueltas, pero ese aviso depende
+ * del sistema de notificaciones del issue #6, que está frenado esperando una
+ * decisión de tooling. Así que este PR construye la mitad que no depende de
+ * esa decisión: el cálculo de pendientes (ver ../pending.ts) y este prompt,
+ * que lo muestra en la propia ficha del evento durante la ventana posterior.
+ *
+ * Cuando el issue #6 se destrabe, el job que mande el mail o el push puede
+ * reusar `computePendingForShow` sin tocar nada de acá. No hay
+ * infraestructura de mail ni de push en este PR.
+ */
+export function PendingShowPrompt({ pending }: PendingShowPromptProps) {
+  if (pending.length === 0) return null
+
+  return (
+    <div
+      data-testid="pending-show-prompt"
+      className="border border-ritual-border bg-ritual-surface px-5 py-4"
+    >
+      <p className="font-label text-[10px] tracking-[0.2em] uppercase text-ritual-gray-text">
+        Quedó pendiente de esta noche
+      </p>
+      <ul className="mt-3 space-y-1.5">
+        {pending.map((item) => (
+          <li key={item.kind} className="font-body text-sm text-ritual-bone flex items-baseline gap-2">
+            <span aria-hidden="true" className="text-ritual-red-hover">
+              ▸
+            </span>
+            {item.label}
+          </li>
+        ))}
+      </ul>
+      <p className="font-body text-xs text-ritual-gray-text mt-3">
+        Un solo aviso con todo junto, no notificaciones sueltas. Por ahora vive acá adentro: el aviso
+        por mail o push depende del sistema de notificaciones (
+        <a
+          href="https://github.com/Lantieridev/Ritual/issues/6"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-ritual-red-hover underline underline-offset-4"
+        >
+          issue #6
+        </a>
+        ), todavía sin implementar.
+      </p>
+    </div>
+  )
+}

--- a/src/domains/showmode/components/PreShowChecklist.test.tsx
+++ b/src/domains/showmode/components/PreShowChecklist.test.tsx
@@ -1,0 +1,157 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { PreShowChecklist } from '@/src/domains/showmode/components/PreShowChecklist'
+import type { ResolvedChecklistItem } from '@/src/domains/showmode/checklist'
+
+const items: ResolvedChecklistItem[] = [
+  { id: 't-1', label: 'Entrada en el celular', checked: false, source: 'template' },
+  { id: 't-2', label: 'Efectivo', checked: true, source: 'template' },
+  { id: 'a-1', label: 'Cargar la SUBE', checked: false, source: 'adhoc' },
+]
+
+function renderChecklist(
+  overrides: Partial<React.ComponentProps<typeof PreShowChecklist>> = {}
+) {
+  const setChecked = vi.fn().mockResolvedValue({})
+  const addItem = vi.fn().mockResolvedValue({ id: 'a-2', label: 'Campera' })
+  const removeItem = vi.fn().mockResolvedValue({})
+  const utils = render(
+    <PreShowChecklist
+      eventId="ev-1"
+      initialItems={items}
+      setChecked={setChecked}
+      addItem={addItem}
+      removeItem={removeItem}
+      {...overrides}
+    />
+  )
+  return { ...utils, setChecked, addItem, removeItem }
+}
+
+describe('PreShowChecklist', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('muestra la plantilla y los ítems del show en una sola lista', () => {
+    renderChecklist()
+    expect(screen.getByText('Entrada en el celular')).toBeInTheDocument()
+    expect(screen.getByText('Efectivo')).toBeInTheDocument()
+    expect(screen.getByText('Cargar la SUBE')).toBeInTheDocument()
+  })
+
+  it('cuenta cuántos ítems están listos', () => {
+    renderChecklist()
+    expect(screen.getByText('1 de 3 listo')).toBeInTheDocument()
+  })
+
+  it('marca de dónde viene cada ítem para que se entienda cuál se edita en los ajustes', () => {
+    renderChecklist()
+    expect(screen.getAllByText('Plantilla')).toHaveLength(2)
+    expect(screen.getAllByRole('button', { name: 'Quitar' })).toHaveLength(1)
+  })
+
+  it('tilda un ítem de plantilla pasando su origen, para que el estado vaya a la tabla correcta', async () => {
+    const user = userEvent.setup()
+    const { setChecked } = renderChecklist()
+
+    await user.click(screen.getByRole('checkbox', { name: /Entrada en el celular/ }))
+
+    await waitFor(() => {
+      expect(setChecked).toHaveBeenCalledWith('ev-1', 't-1', 'template', true)
+    })
+  })
+
+  it('tilda un ítem ad-hoc marcándolo como tal', async () => {
+    const user = userEvent.setup()
+    const { setChecked } = renderChecklist()
+
+    await user.click(screen.getByRole('checkbox', { name: /Cargar la SUBE/ }))
+
+    await waitFor(() => {
+      expect(setChecked).toHaveBeenCalledWith('ev-1', 'a-1', 'adhoc', true)
+    })
+  })
+
+  it('destilda un ítem que ya estaba tildado', async () => {
+    const user = userEvent.setup()
+    const { setChecked } = renderChecklist()
+
+    await user.click(screen.getByRole('checkbox', { name: /Efectivo/ }))
+
+    await waitFor(() => {
+      expect(setChecked).toHaveBeenCalledWith('ev-1', 't-2', 'template', false)
+    })
+  })
+
+  it('actualiza el progreso apenas se tilda, sin esperar el round-trip', async () => {
+    const user = userEvent.setup()
+    renderChecklist()
+
+    await user.click(screen.getByRole('checkbox', { name: /Entrada en el celular/ }))
+
+    expect(await screen.findByText('2 de 3 listos')).toBeInTheDocument()
+  })
+
+  it('revierte el tilde y muestra el error si la action falla', async () => {
+    const user = userEvent.setup()
+    const setChecked = vi.fn().mockResolvedValue({ error: 'No tenés permiso.' })
+    renderChecklist({ setChecked })
+
+    const checkbox = screen.getByRole('checkbox', { name: /Entrada en el celular/ })
+    await user.click(checkbox)
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('No tenés permiso.')
+    await waitFor(() => expect(checkbox).not.toBeChecked())
+  })
+
+  it('agrega un ítem puntual del show sin tocar la plantilla', async () => {
+    const user = userEvent.setup()
+    const { addItem } = renderChecklist()
+
+    await user.click(screen.getByRole('button', { name: /Ítem para este show/ }))
+    await user.type(screen.getByLabelText('Ítem para este show'), 'Campera')
+    await user.click(screen.getByRole('button', { name: 'Agregar' }))
+
+    await waitFor(() => expect(addItem).toHaveBeenCalledWith('ev-1', 'Campera'))
+    expect(await screen.findByText('Campera')).toBeInTheDocument()
+  })
+
+  it('no manda una action por un ítem vacío', async () => {
+    const user = userEvent.setup()
+    const { addItem } = renderChecklist()
+
+    await user.click(screen.getByRole('button', { name: /Ítem para este show/ }))
+    await user.click(screen.getByRole('button', { name: 'Agregar' }))
+
+    expect(addItem).not.toHaveBeenCalled()
+  })
+
+  it('quita un ítem del show de la lista', async () => {
+    const user = userEvent.setup()
+    const { removeItem } = renderChecklist()
+
+    await user.click(screen.getByRole('button', { name: 'Quitar' }))
+
+    await waitFor(() => expect(removeItem).toHaveBeenCalledWith('ev-1', 'a-1'))
+    await waitFor(() => expect(screen.queryByText('Cargar la SUBE')).not.toBeInTheDocument())
+  })
+
+  it('invita a armar la plantilla base cuando no hay ningún ítem todavía', () => {
+    renderChecklist({ initialItems: [] })
+    expect(screen.getByText(/Todavía no armaste tu plantilla base/)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Configurala una vez/ })).toHaveAttribute(
+      'href',
+      '/modo-recital'
+    )
+  })
+
+  it('expone el progreso de forma accesible', () => {
+    renderChecklist()
+    const bar = screen.getByRole('progressbar', { name: 'Progreso del checklist' })
+    expect(bar).toHaveAttribute('aria-valuenow', '1')
+    expect(bar).toHaveAttribute('aria-valuemax', '3')
+  })
+})

--- a/src/domains/showmode/components/PreShowChecklist.tsx
+++ b/src/domains/showmode/components/PreShowChecklist.tsx
@@ -1,0 +1,229 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import Link from 'next/link'
+import { Button, inputClass } from '@/src/core/components/ui'
+import { routes } from '@/src/core/lib/routes'
+import { checklistProgress } from '@/src/domains/showmode/checklist'
+import type { ResolvedChecklistItem } from '@/src/domains/showmode/checklist'
+import type { ActionResult } from '@/src/core/types'
+
+interface PreShowChecklistProps {
+  eventId: string
+  initialItems: ResolvedChecklistItem[]
+  setChecked: (
+    eventId: string,
+    itemId: string,
+    source: 'template' | 'adhoc',
+    checked: boolean
+  ) => Promise<ActionResult>
+  addItem: (
+    eventId: string,
+    label: string
+  ) => Promise<ActionResult<{ id?: string; label?: string; position?: number }>>
+  removeItem: (eventId: string, id: string) => Promise<ActionResult>
+}
+
+/**
+ * Checklist pre-show del issue #9: la plantilla base del usuario más los
+ * ítems puntuales de este show, en una sola lista.
+ *
+ * Estado local igual que EventExpensesPanel y PhotoGallery — tildar algo no
+ * puede costar un reload de la página entera. El tilde es optimista y se
+ * revierte si la action falla: es la interacción más repetida de la pantalla
+ * y esperar el round-trip por cada tick la haría sentir rota.
+ *
+ * Los ítems de la plantilla no se borran desde acá a propósito: son la
+ * plantilla base "configurada una vez" del issue, así que borrarlos desde un
+ * show sería borrarlos de todos. Se editan en los ajustes, y el link está
+ * abajo de la lista.
+ */
+export function PreShowChecklist({
+  eventId,
+  initialItems,
+  setChecked,
+  addItem,
+  removeItem,
+}: PreShowChecklistProps) {
+  const [items, setItems] = useState<ResolvedChecklistItem[]>(initialItems)
+  const [showAdd, setShowAdd] = useState(false)
+  const [label, setLabel] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  const progress = checklistProgress(items)
+
+  function applyChecked(itemId: string, source: string, checked: boolean) {
+    setItems((prev) =>
+      prev.map((i) => (i.id === itemId && i.source === source ? { ...i, checked } : i))
+    )
+  }
+
+  function handleToggle(item: ResolvedChecklistItem) {
+    const next = !item.checked
+    applyChecked(item.id, item.source, next)
+    setError(null)
+    startTransition(async () => {
+      const result = await setChecked(eventId, item.id, item.source, next)
+      if (result.error) {
+        applyChecked(item.id, item.source, item.checked)
+        setError(result.error)
+      }
+    })
+  }
+
+  function handleAdd(e: React.FormEvent) {
+    e.preventDefault()
+    const clean = label.trim()
+    if (!clean) return
+    setError(null)
+    startTransition(async () => {
+      const result = await addItem(eventId, clean)
+      if (result.error || !result.id) {
+        setError(result.error ?? 'No se pudo agregar el ítem.')
+        return
+      }
+      setItems((prev) => [
+        ...prev,
+        { id: result.id!, label: result.label ?? clean, checked: false, source: 'adhoc' },
+      ])
+      setLabel('')
+      setShowAdd(false)
+    })
+  }
+
+  function handleRemove(item: ResolvedChecklistItem) {
+    setError(null)
+    startTransition(async () => {
+      const result = await removeItem(eventId, item.id)
+      if (result.error) {
+        setError(result.error)
+        return
+      }
+      setItems((prev) => prev.filter((i) => !(i.id === item.id && i.source === 'adhoc')))
+    })
+  }
+
+  return (
+    <div className="space-y-4" data-testid="pre-show-checklist">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <p className="font-label text-xs tracking-[0.1em] uppercase text-ritual-gray-text">
+          {progress.total === 0
+            ? 'Sin ítems todavía'
+            : `${progress.done} de ${progress.total} listo${progress.done === 1 ? '' : 's'}`}
+        </p>
+        {!showAdd && (
+          <Button type="button" variant="secondary" className="px-4 py-2" onClick={() => setShowAdd(true)}>
+            + Ítem para este show
+          </Button>
+        )}
+      </div>
+
+      {progress.total > 0 && (
+        <div
+          className="h-[3px] bg-ritual-border"
+          role="progressbar"
+          aria-valuemin={0}
+          aria-valuemax={progress.total}
+          aria-valuenow={progress.done}
+          aria-label="Progreso del checklist"
+        >
+          <div
+            className={progress.isComplete ? 'h-full bg-ritual-bone' : 'h-full bg-ritual-red'}
+            style={{ width: `${Math.round(progress.ratio * 100)}%` }}
+          />
+        </div>
+      )}
+
+      {error && (
+        <p role="alert" className="font-body text-sm text-ritual-red-hover">
+          {error}
+        </p>
+      )}
+
+      {showAdd && (
+        <form onSubmit={handleAdd} className="flex flex-wrap gap-2 border border-ritual-border bg-ritual-surface p-4">
+          <label htmlFor="checklist-new-item" className="sr-only">
+            Ítem para este show
+          </label>
+          <input
+            id="checklist-new-item"
+            type="text"
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+            placeholder="Ej. Cargar la SUBE"
+            maxLength={120}
+            className={`${inputClass} flex-1 min-w-[180px]`}
+          />
+          <Button type="submit" variant="primary" disabled={isPending} className="px-4 py-2">
+            {isPending ? 'Guardando...' : 'Agregar'}
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            className="px-4 py-2"
+            onClick={() => {
+              setShowAdd(false)
+              setLabel('')
+            }}
+          >
+            Cancelar
+          </Button>
+        </form>
+      )}
+
+      {items.length === 0 ? (
+        <p className="font-body text-sm text-ritual-gray-text">
+          Todavía no armaste tu plantilla base.{' '}
+          <Link
+            href={routes.showMode}
+            className="text-ritual-red-hover underline underline-offset-4"
+          >
+            Configurala una vez
+          </Link>{' '}
+          y aparece sola en todos tus shows.
+        </p>
+      ) : (
+        <ul className="divide-y divide-ritual-border-subtle">
+          {items.map((item) => (
+            <li key={`${item.source}-${item.id}`} className="flex items-center gap-3 py-2.5">
+              <label className="flex items-center gap-3 flex-1 min-w-0 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={item.checked}
+                  onChange={() => handleToggle(item)}
+                  className="w-4 h-4 shrink-0 accent-ritual-red"
+                />
+                <span
+                  className={
+                    item.checked
+                      ? 'font-body text-sm text-ritual-gray-text line-through'
+                      : 'font-body text-sm text-ritual-bone'
+                  }
+                >
+                  {item.label}
+                </span>
+              </label>
+              {item.source === 'adhoc' ? (
+                <button
+                  type="button"
+                  onClick={() => handleRemove(item)}
+                  className="font-label text-[10px] tracking-[0.1em] uppercase text-ritual-gray-text hover:text-ritual-red-hover transition-colors shrink-0"
+                >
+                  Quitar
+                </button>
+              ) : (
+                <span
+                  className="font-label text-[9px] tracking-[0.1em] uppercase text-ritual-gray-muted-2 shrink-0"
+                  title="Viene de tu plantilla base"
+                >
+                  Plantilla
+                </span>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/src/domains/showmode/components/ShowModeBanner.test.tsx
+++ b/src/domains/showmode/components/ShowModeBanner.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ShowModeBanner } from '@/src/domains/showmode/components/ShowModeBanner'
+import { resolveShowModeWindow, describeShowModePhase } from '@/src/domains/showmode/window'
+import { DEFAULT_SHOW_MODE_PREFERENCES } from '@/src/domains/showmode/preferences'
+
+const NOW = new Date('2026-05-10T15:00:00Z')
+
+function renderFor(startDate: string, endDate?: string | null) {
+  const window = resolveShowModeWindow(
+    { startDate, endDate },
+    DEFAULT_SHOW_MODE_PREFERENCES,
+    NOW
+  )
+  return render(<ShowModeBanner window={window} phaseLabel={describeShowModePhase(window)} />)
+}
+
+describe('ShowModeBanner', () => {
+  it('anuncia el modo activo y cuánto falta durante la ventana previa', () => {
+    renderFor('2026-05-13')
+    expect(screen.getByTestId('show-mode-banner')).toBeInTheDocument()
+    expect(screen.getByText('Modo recital activo')).toBeInTheDocument()
+    expect(screen.getByText('Faltan 3 días')).toBeInTheDocument()
+  })
+
+  it('cambia el mensaje el día del show', () => {
+    renderFor('2026-05-10')
+    expect(screen.getByText('Es la noche')).toBeInTheDocument()
+    expect(screen.getByText('Es hoy')).toBeInTheDocument()
+  })
+
+  it('sigue visible después del show, avisando que la ventana no cerró', () => {
+    renderFor('2026-05-09')
+    expect(screen.getByText('Ventana abierta')).toBeInTheDocument()
+    expect(screen.getByText(/Todavía podés cargar lo que quedó pendiente/)).toBeInTheDocument()
+  })
+
+  it(
+    'no renderiza nada para un show lejano: la idea del issue es que la app se active para un ' +
+      'show puntual, no que grite en todas las fichas',
+    () => {
+      const { container } = renderFor('2026-08-30')
+      expect(container).toBeEmptyDOMElement()
+    }
+  )
+
+  it('no renderiza nada para un show viejo, con la ventana ya cerrada', () => {
+    const { container } = renderFor('2026-01-01')
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('muestra la ventana configurada y linkea a los ajustes para cambiarla', () => {
+    renderFor('2026-05-13')
+    expect(screen.getByText(/7d antes · 2d después/)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Cambiar' })).toHaveAttribute('href', '/modo-recital')
+  })
+
+  it('dice "Está pasando" en un festival multi-día en curso', () => {
+    renderFor('2026-05-08', '2026-05-12')
+    expect(screen.getByText('Está pasando')).toBeInTheDocument()
+  })
+})

--- a/src/domains/showmode/components/ShowModeBanner.tsx
+++ b/src/domains/showmode/components/ShowModeBanner.tsx
@@ -1,0 +1,59 @@
+import Link from 'next/link'
+import { routes } from '@/src/core/lib/routes'
+import type { ShowModeWindow } from '@/src/domains/showmode/window'
+
+interface ShowModeBannerProps {
+  window: ShowModeWindow
+  phaseLabel: string | null
+}
+
+const PHASE_COPY: Record<'before' | 'during' | 'after', string> = {
+  before: 'Modo recital activo',
+  during: 'Es la noche',
+  after: 'Ventana abierta',
+}
+
+const PHASE_HINT: Record<'before' | 'during' | 'after', string> = {
+  before: 'La app se puso en modo show: checklist, clima y carga rápida de gastos, todo acá abajo.',
+  during: 'Andá tranquilo. Los gastos y las notas los cargás después, la ventana sigue abierta.',
+  after: 'Todavía podés cargar lo que quedó pendiente de esa noche.',
+}
+
+/**
+ * La banda que anuncia que el modo recital está activo (issue #9).
+ *
+ * No renderiza nada fuera de la ventana: un show dentro de tres meses o uno
+ * de hace un año son la ficha de evento de siempre, sin capa encima. Esa es
+ * justamente la idea del issue — que la app "se active" para acompañar un
+ * show puntual, no que grite en todas las fichas.
+ */
+export function ShowModeBanner({ window, phaseLabel }: ShowModeBannerProps) {
+  if (!window.isActive) return null
+  const phase = window.phase as 'before' | 'during' | 'after'
+
+  return (
+    <section
+      data-testid="show-mode-banner"
+      className="border-l-[3px] border-ritual-red bg-ritual-surface px-5 py-4"
+    >
+      <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
+        <p className="font-label text-[10px] tracking-[0.2em] uppercase text-ritual-red-hover">
+          {PHASE_COPY[phase]}
+        </p>
+        {phaseLabel && (
+          <p className="font-subtitle font-black text-xl uppercase text-ritual-bone">{phaseLabel}</p>
+        )}
+      </div>
+      <p className="font-body text-sm text-ritual-gray-text mt-1.5">{PHASE_HINT[phase]}</p>
+      <p className="font-label text-[10px] tracking-[0.1em] uppercase text-ritual-gray-text mt-3">
+        Ventana: {window.preferences.daysBefore}d antes · {window.preferences.daysAfter}d después ·{' '}
+        <Link
+          href={routes.showMode}
+          className="text-ritual-gray-light-3 hover:text-ritual-bone transition-colors underline underline-offset-4"
+        >
+          Cambiar
+        </Link>
+      </p>
+    </section>
+  )
+}

--- a/src/domains/showmode/components/ShowModeSettingsForm.test.tsx
+++ b/src/domains/showmode/components/ShowModeSettingsForm.test.tsx
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ShowModeSettingsForm } from '@/src/domains/showmode/components/ShowModeSettingsForm'
+import { DEFAULT_SHOW_MODE_PREFERENCES } from '@/src/domains/showmode/preferences'
+
+function renderForm(
+  overrides: Partial<React.ComponentProps<typeof ShowModeSettingsForm>> = {}
+) {
+  const savePreferences = vi.fn().mockResolvedValue({})
+  const addTemplateItem = vi.fn().mockResolvedValue({ id: 't-9', label: 'Batería cargada' })
+  const removeTemplateItem = vi.fn().mockResolvedValue({})
+  const utils = render(
+    <ShowModeSettingsForm
+      initialPreferences={DEFAULT_SHOW_MODE_PREFERENCES}
+      initialTemplateItems={[{ id: 't-1', label: 'Entrada en el celular', position: 0 }]}
+      savePreferences={savePreferences}
+      addTemplateItem={addTemplateItem}
+      removeTemplateItem={removeTemplateItem}
+      {...overrides}
+    />
+  )
+  return { ...utils, savePreferences, addTemplateItem, removeTemplateItem }
+}
+
+describe('ShowModeSettingsForm — la ventana', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('precarga la ventana configurada', () => {
+    renderForm()
+    expect(screen.getByLabelText('Días antes')).toHaveValue(7)
+    expect(screen.getByLabelText('Días después')).toHaveValue(2)
+  })
+
+  it('guarda la ventana nueva', async () => {
+    const user = userEvent.setup()
+    const { savePreferences } = renderForm()
+
+    const before = screen.getByLabelText('Días antes')
+    await user.clear(before)
+    await user.type(before, '14')
+    await user.click(screen.getByRole('button', { name: /Guardar ventana/ }))
+
+    await waitFor(() =>
+      expect(savePreferences).toHaveBeenCalledWith({ daysBefore: 14, daysAfter: 2 })
+    )
+    expect(await screen.findByRole('status')).toHaveTextContent('Guardado')
+  })
+
+  it('muestra el error de la action sin decir que guardó', async () => {
+    const user = userEvent.setup()
+    const savePreferences = vi.fn().mockResolvedValue({ error: 'Usuario no autenticado' })
+    renderForm({ savePreferences })
+
+    await user.click(screen.getByRole('button', { name: /Guardar ventana/ }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Usuario no autenticado')
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+  })
+
+  it('expone los límites en los propios inputs', () => {
+    renderForm()
+    expect(screen.getByLabelText('Días antes')).toHaveAttribute('max', '60')
+    expect(screen.getByLabelText('Días después')).toHaveAttribute('max', '14')
+  })
+})
+
+describe('ShowModeSettingsForm — la plantilla base', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('lista los ítems ya configurados', () => {
+    renderForm()
+    expect(screen.getByText('Entrada en el celular')).toBeInTheDocument()
+  })
+
+  it('agrega un ítem a la plantilla y lo muestra sin recargar', async () => {
+    const user = userEvent.setup()
+    const { addTemplateItem } = renderForm()
+
+    await user.type(screen.getByLabelText('Nuevo ítem de la plantilla'), 'Batería cargada')
+    await user.click(screen.getByRole('button', { name: 'Agregar' }))
+
+    await waitFor(() => expect(addTemplateItem).toHaveBeenCalledWith('Batería cargada'))
+    expect(await screen.findByText('Batería cargada')).toBeInTheDocument()
+  })
+
+  it('no manda una action por un ítem vacío', async () => {
+    const user = userEvent.setup()
+    const { addTemplateItem } = renderForm()
+
+    await user.click(screen.getByRole('button', { name: 'Agregar' }))
+
+    expect(addTemplateItem).not.toHaveBeenCalled()
+  })
+
+  it('borra un ítem de la plantilla', async () => {
+    const user = userEvent.setup()
+    const { removeTemplateItem } = renderForm()
+
+    await user.click(screen.getByRole('button', { name: 'Borrar' }))
+
+    await waitFor(() => expect(removeTemplateItem).toHaveBeenCalledWith('t-1'))
+    await waitFor(() =>
+      expect(screen.queryByText('Entrada en el celular')).not.toBeInTheDocument()
+    )
+  })
+
+  it('mantiene el ítem en la lista si el borrado falla', async () => {
+    const user = userEvent.setup()
+    const removeTemplateItem = vi.fn().mockResolvedValue({ error: 'No tenés permiso.' })
+    renderForm({ removeTemplateItem })
+
+    await user.click(screen.getByRole('button', { name: 'Borrar' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('No tenés permiso.')
+    expect(screen.getByText('Entrada en el celular')).toBeInTheDocument()
+  })
+
+  it('explica que la plantilla se configura una vez y sirve para todos los shows', () => {
+    renderForm()
+    expect(screen.getByText(/aparece en el checklist de todos tus shows/)).toBeInTheDocument()
+  })
+
+  it('muestra un estado vacío útil cuando la plantilla no tiene nada', () => {
+    renderForm({ initialTemplateItems: [] })
+    expect(screen.getByText(/La plantilla está vacía/)).toBeInTheDocument()
+  })
+})

--- a/src/domains/showmode/components/ShowModeSettingsForm.tsx
+++ b/src/domains/showmode/components/ShowModeSettingsForm.tsx
@@ -1,0 +1,209 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { Button, FormField, inputClass } from '@/src/core/components/ui'
+import { SHOW_MODE_LIMITS } from '@/src/domains/showmode/preferences'
+import type { ShowModePreferences } from '@/src/domains/showmode/preferences'
+import type { ChecklistTemplateItem } from '@/src/domains/showmode/checklist'
+import type { ActionResult } from '@/src/core/types'
+
+interface ShowModeSettingsFormProps {
+  initialPreferences: ShowModePreferences
+  initialTemplateItems: ChecklistTemplateItem[]
+  savePreferences: (input: ShowModePreferences) => Promise<ActionResult>
+  addTemplateItem: (
+    label: string
+  ) => Promise<ActionResult<{ id?: string; label?: string; position?: number }>>
+  removeTemplateItem: (id: string) => Promise<ActionResult>
+}
+
+/**
+ * Ajustes del modo recital (issue #9): las dos cosas que el issue pide
+ * configurar una sola vez — el largo de la ventana y la plantilla base del
+ * checklist — en una sola pantalla, porque son la misma decisión ("cómo
+ * quiero que la app me acompañe en un show") vista desde dos ángulos.
+ *
+ * Estado local y actions sin redirect, igual que el resto de los formularios
+ * del proyecto: guardar la ventana no debería sacarte de la pantalla donde
+ * estás armando la lista.
+ */
+export function ShowModeSettingsForm({
+  initialPreferences,
+  initialTemplateItems,
+  savePreferences,
+  addTemplateItem,
+  removeTemplateItem,
+}: ShowModeSettingsFormProps) {
+  const [daysBefore, setDaysBefore] = useState(String(initialPreferences.daysBefore))
+  const [daysAfter, setDaysAfter] = useState(String(initialPreferences.daysAfter))
+  const [savedAt, setSavedAt] = useState(false)
+  const [prefsError, setPrefsError] = useState<string | null>(null)
+
+  const [items, setItems] = useState<ChecklistTemplateItem[]>(initialTemplateItems)
+  const [label, setLabel] = useState('')
+  const [itemsError, setItemsError] = useState<string | null>(null)
+
+  const [isPending, startTransition] = useTransition()
+
+  function handleSavePreferences(e: React.FormEvent) {
+    e.preventDefault()
+    setPrefsError(null)
+    setSavedAt(false)
+    startTransition(async () => {
+      const result = await savePreferences({
+        daysBefore: Number(daysBefore),
+        daysAfter: Number(daysAfter),
+      })
+      if (result.error) {
+        setPrefsError(result.error)
+        return
+      }
+      setSavedAt(true)
+    })
+  }
+
+  function handleAddItem(e: React.FormEvent) {
+    e.preventDefault()
+    const clean = label.trim()
+    if (!clean) return
+    setItemsError(null)
+    startTransition(async () => {
+      const result = await addTemplateItem(clean)
+      if (result.error || !result.id) {
+        setItemsError(result.error ?? 'No se pudo agregar el ítem.')
+        return
+      }
+      setItems((prev) => [
+        ...prev,
+        { id: result.id!, label: result.label ?? clean, position: result.position ?? prev.length },
+      ])
+      setLabel('')
+    })
+  }
+
+  function handleRemoveItem(id: string) {
+    setItemsError(null)
+    startTransition(async () => {
+      const result = await removeTemplateItem(id)
+      if (result.error) {
+        setItemsError(result.error)
+        return
+      }
+      setItems((prev) => prev.filter((i) => i.id !== id))
+    })
+  }
+
+  return (
+    <div className="max-w-2xl space-y-12">
+      {/* Ventana */}
+      <section>
+        <h2 className="font-label text-[10px] tracking-[0.2em] uppercase text-ritual-gray-text mb-4">
+          La ventana
+        </h2>
+        <p className="font-body text-sm text-ritual-gray-text mb-6">
+          Cuántos días antes de un show la app entra en modo recital, y cuántos sigue activa después
+          para que puedas cargar lo que quedó pendiente. En festivales la ventana arranca el primer
+          día y termina después del último.
+        </p>
+
+        <form onSubmit={handleSavePreferences} className="space-y-5">
+          {prefsError && (
+            <p role="alert" className="font-body text-sm text-ritual-red-hover">
+              {prefsError}
+            </p>
+          )}
+          <div className="grid sm:grid-cols-2 gap-5">
+            <FormField label="Días antes" id="show-mode-days-before">
+              <input
+                id="show-mode-days-before"
+                type="number"
+                min={SHOW_MODE_LIMITS.minDaysBefore}
+                max={SHOW_MODE_LIMITS.maxDaysBefore}
+                value={daysBefore}
+                onChange={(e) => setDaysBefore(e.target.value)}
+                className={inputClass}
+              />
+            </FormField>
+            <FormField label="Días después" id="show-mode-days-after">
+              <input
+                id="show-mode-days-after"
+                type="number"
+                min={SHOW_MODE_LIMITS.minDaysAfter}
+                max={SHOW_MODE_LIMITS.maxDaysAfter}
+                value={daysAfter}
+                onChange={(e) => setDaysAfter(e.target.value)}
+                className={inputClass}
+              />
+            </FormField>
+          </div>
+          <div className="flex items-center gap-4">
+            <Button type="submit" variant="primary" disabled={isPending} className="px-5 py-2.5">
+              {isPending ? 'Guardando...' : 'Guardar ventana'}
+            </Button>
+            {savedAt && (
+              <p role="status" className="font-label text-[10px] tracking-[0.1em] uppercase text-ritual-gray-light-3">
+                Guardado
+              </p>
+            )}
+          </div>
+        </form>
+      </section>
+
+      {/* Plantilla base */}
+      <section className="border-t border-ritual-border-subtle pt-10">
+        <h2 className="font-label text-[10px] tracking-[0.2em] uppercase text-ritual-gray-text mb-4">
+          Tu plantilla base
+        </h2>
+        <p className="font-body text-sm text-ritual-gray-text mb-6">
+          Se configura una sola vez y aparece en el checklist de todos tus shows. Lo puntual de cada
+          show lo agregás desde la ficha del evento, sin tocar esta lista.
+        </p>
+
+        {itemsError && (
+          <p role="alert" className="font-body text-sm text-ritual-red-hover mb-4">
+            {itemsError}
+          </p>
+        )}
+
+        <form onSubmit={handleAddItem} className="flex flex-wrap gap-2 mb-6">
+          <label htmlFor="template-new-item" className="sr-only">
+            Nuevo ítem de la plantilla
+          </label>
+          <input
+            id="template-new-item"
+            type="text"
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+            placeholder="Ej. Entrada en el celular"
+            maxLength={120}
+            className={`${inputClass} flex-1 min-w-[200px]`}
+          />
+          <Button type="submit" variant="secondary" disabled={isPending} className="px-5 py-2.5">
+            Agregar
+          </Button>
+        </form>
+
+        {items.length === 0 ? (
+          <p className="font-body text-sm text-ritual-gray-text">
+            La plantilla está vacía. Cargá lo que siempre llevás: entrada, efectivo, batería, SUBE.
+          </p>
+        ) : (
+          <ul className="divide-y divide-ritual-border-subtle border-y border-ritual-border-subtle">
+            {items.map((item) => (
+              <li key={item.id} className="flex items-center justify-between gap-3 py-3">
+                <span className="font-body text-sm text-ritual-bone">{item.label}</span>
+                <button
+                  type="button"
+                  onClick={() => handleRemoveItem(item.id)}
+                  className="font-label text-[10px] tracking-[0.1em] uppercase text-ritual-gray-text hover:text-ritual-red-hover transition-colors shrink-0"
+                >
+                  Borrar
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/src/domains/showmode/components/index.ts
+++ b/src/domains/showmode/components/index.ts
@@ -1,0 +1,5 @@
+export { ShowModeBanner } from './ShowModeBanner'
+export { PreShowChecklist } from './PreShowChecklist'
+export { PendingShowPrompt } from './PendingShowPrompt'
+export { MemoryCard } from './MemoryCard'
+export { ShowModeSettingsForm } from './ShowModeSettingsForm'

--- a/src/domains/showmode/data.test.ts
+++ b/src/domains/showmode/data.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockCreateClient = vi.fn()
+
+vi.mock('@/src/core/lib/supabase/server', () => ({
+    createClient: () => mockCreateClient(),
+}))
+
+import {
+    getShowModePreferences,
+    getChecklistTemplateItems,
+    getEventChecklistState,
+    getShowDateRange,
+} from '@/src/domains/showmode/data'
+import { DEFAULT_SHOW_MODE_PREFERENCES } from '@/src/domains/showmode/preferences'
+
+function makeQueryBuilder(result: { data: unknown; error: unknown }) {
+    const builder: Record<string, unknown> = {}
+    const chain = () => builder
+    builder.select = vi.fn(chain)
+    builder.eq = vi.fn(chain)
+    builder.order = vi.fn(chain)
+    builder.limit = vi.fn(chain)
+    builder.maybeSingle = vi.fn(() => Promise.resolve(result))
+    builder.single = vi.fn(() => Promise.resolve(result))
+    builder.then = (onFulfilled: (v: unknown) => unknown, onRejected?: (e: unknown) => unknown) =>
+        Promise.resolve(result).then(onFulfilled, onRejected)
+    return builder
+}
+
+/** Devuelve un cliente cuyo `from(tabla)` responde según el mapa dado. */
+function clientWithTables(tables: Record<string, { data: unknown; error: unknown }>) {
+    const fromMock = vi.fn((table: string) =>
+        makeQueryBuilder(tables[table] ?? { data: null, error: null })
+    )
+    mockCreateClient.mockReturnValue(Promise.resolve({ from: fromMock }))
+    return fromMock
+}
+
+beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+describe('getShowModePreferences', () => {
+    it('devuelve la ventana guardada por el usuario', async () => {
+        clientWithTables({
+            user_preferences: {
+                data: { show_mode_days_before: 14, show_mode_days_after: 1 },
+                error: null,
+            },
+        })
+
+        expect(await getShowModePreferences('user-1')).toEqual({ daysBefore: 14, daysAfter: 1 })
+    })
+
+    it('devuelve los defaults sin tocar el cliente cuando no hay usuario', async () => {
+        expect(await getShowModePreferences(null)).toEqual(DEFAULT_SHOW_MODE_PREFERENCES)
+        expect(mockCreateClient).not.toHaveBeenCalled()
+    })
+
+    it('devuelve los defaults cuando el usuario nunca entró a los ajustes (sin fila todavía)', async () => {
+        clientWithTables({ user_preferences: { data: null, error: null } })
+        expect(await getShowModePreferences('user-1')).toEqual(DEFAULT_SHOW_MODE_PREFERENCES)
+    })
+
+    it('devuelve los defaults ante un error de Supabase, en vez de romper la ficha del evento', async () => {
+        clientWithTables({ user_preferences: { data: null, error: { message: 'boom' } } })
+        expect(await getShowModePreferences('user-1')).toEqual(DEFAULT_SHOW_MODE_PREFERENCES)
+    })
+
+    it('clampea un valor fuera de rango que ya estuviera guardado en la base', async () => {
+        clientWithTables({
+            user_preferences: {
+                data: { show_mode_days_before: 9999, show_mode_days_after: -3 },
+                error: null,
+            },
+        })
+        expect(await getShowModePreferences('user-1')).toEqual({ daysBefore: 60, daysAfter: 0 })
+    })
+})
+
+describe('getChecklistTemplateItems', () => {
+    it('lee la plantilla del usuario a través del cliente con sesión', async () => {
+        const items = [{ id: 't-1', label: 'Entrada', position: 0 }]
+        const fromMock = clientWithTables({ checklist_template_items: { data: items, error: null } })
+
+        expect(await getChecklistTemplateItems('user-1')).toEqual(items)
+        expect(fromMock).toHaveBeenCalledWith('checklist_template_items')
+    })
+
+    it('devuelve lista vacía sin tocar el cliente cuando no hay usuario', async () => {
+        expect(await getChecklistTemplateItems(null)).toEqual([])
+        expect(mockCreateClient).not.toHaveBeenCalled()
+    })
+
+    it('devuelve lista vacía ante un error, sin lanzar', async () => {
+        clientWithTables({ checklist_template_items: { data: null, error: { message: 'boom' } } })
+        expect(await getChecklistTemplateItems('user-1')).toEqual([])
+    })
+})
+
+describe('getEventChecklistState', () => {
+    it('trae los ítems ad-hoc y mapea los tildes a la forma del dominio', async () => {
+        clientWithTables({
+            event_checklist_items: {
+                data: [{ id: 'a-1', label: 'SUBE', position: 0, checked: true }],
+                error: null,
+            },
+            event_checklist_checks: {
+                data: [{ template_item_id: 't-1', checked: true }],
+                error: null,
+            },
+        })
+
+        const state = await getEventChecklistState('user-1', 'ev-1')
+
+        expect(state.adHocItems).toEqual([{ id: 'a-1', label: 'SUBE', position: 0, checked: true }])
+        expect(state.checks).toEqual([{ templateItemId: 't-1', checked: true }])
+    })
+
+    it('devuelve el estado vacío sin tocar el cliente cuando no hay usuario', async () => {
+        expect(await getEventChecklistState(null, 'ev-1')).toEqual({ adHocItems: [], checks: [] })
+        expect(mockCreateClient).not.toHaveBeenCalled()
+    })
+
+    it('degrada a vacío si una de las dos lecturas falla, sin lanzar', async () => {
+        clientWithTables({
+            event_checklist_items: { data: null, error: { message: 'boom' } },
+            event_checklist_checks: { data: null, error: null },
+        })
+        expect(await getEventChecklistState('user-1', 'ev-1')).toEqual({ adHocItems: [], checks: [] })
+    })
+})
+
+describe('getShowDateRange', () => {
+    it('usa la fecha propia del evento cuando no pertenece a ningún festival', async () => {
+        clientWithTables({ festival_events: { data: null, error: null } })
+
+        expect(await getShowDateRange({ id: 'ev-1', date: '2026-05-10' })).toEqual({
+            startDate: '2026-05-10',
+        })
+    })
+
+    it(
+        'usa el rango completo del festival cuando el evento es un día de uno — así el día 1 ' +
+            'no sale de la ventana antes de que el festival termine',
+        async () => {
+            clientWithTables({
+                festival_events: {
+                    data: { festivals: { start_date: '2026-05-08', end_date: '2026-05-12' } },
+                    error: null,
+                },
+            })
+
+            expect(await getShowDateRange({ id: 'ev-1', date: '2026-05-08' })).toEqual({
+                startDate: '2026-05-08',
+                endDate: '2026-05-12',
+            })
+        }
+    )
+
+    it('cae a la fecha del evento si el festival no tiene fecha de inicio cargada', async () => {
+        clientWithTables({
+            festival_events: { data: { festivals: null }, error: null },
+        })
+
+        expect(await getShowDateRange({ id: 'ev-1', date: '2026-05-10' })).toEqual({
+            startDate: '2026-05-10',
+        })
+    })
+
+    it('cae a la fecha del evento ante un error, sin lanzar', async () => {
+        clientWithTables({ festival_events: { data: null, error: { message: 'boom' } } })
+
+        expect(await getShowDateRange({ id: 'ev-1', date: '2026-05-10' })).toEqual({
+            startDate: '2026-05-10',
+        })
+    })
+})

--- a/src/domains/showmode/data.ts
+++ b/src/domains/showmode/data.ts
@@ -1,0 +1,150 @@
+/**
+ * Lecturas del "modo recital activo" (issue #9) contra Supabase.
+ *
+ * Todo lo de acá es por usuario y RLS ya lo garantiza (las políticas son
+ * `auth.uid() = user_id`), pero igual se filtra por `user_id` en la query:
+ * es la convención del resto del proyecto y hace explícito el alcance sin
+ * depender solo de la política.
+ *
+ * Ninguna de estas funciones lanza — un error de Supabase se loguea y se
+ * devuelve el estado vacío/por defecto. El modo recital es una capa
+ * acompañante sobre la ficha del evento: si falla, la ficha tiene que seguir
+ * abriendo igual, como ya hace el clima.
+ */
+import 'server-only'
+import { createClient } from '@/src/core/lib/supabase/server'
+import { clampShowModePreferences, DEFAULT_SHOW_MODE_PREFERENCES } from './preferences'
+import type { ShowModePreferences } from './preferences'
+import type { ShowDateRange } from './window'
+import type { ChecklistTemplateItem, EventChecklistItem, EventChecklistCheck } from './checklist'
+
+/**
+ * La ventana configurada por el usuario. Sin fila en user_preferences
+ * (usuario que nunca entró a los ajustes, que es el caso normal) devuelve
+ * los defaults en vez de forzar un INSERT en una lectura.
+ */
+export async function getShowModePreferences(
+    userId: string | null
+): Promise<ShowModePreferences> {
+    if (!userId) return DEFAULT_SHOW_MODE_PREFERENCES
+
+    const supabase = await createClient()
+    const { data, error } = await supabase
+        .from('user_preferences')
+        .select('show_mode_days_before, show_mode_days_after')
+        .eq('id', userId)
+        .maybeSingle()
+
+    if (error) {
+        console.error('Error leyendo user_preferences:', error)
+        return DEFAULT_SHOW_MODE_PREFERENCES
+    }
+    if (!data) return DEFAULT_SHOW_MODE_PREFERENCES
+
+    return clampShowModePreferences({
+        daysBefore: data.show_mode_days_before,
+        daysAfter: data.show_mode_days_after,
+    })
+}
+
+/** La plantilla base única del usuario, ordenada como la ve en los ajustes. */
+export async function getChecklistTemplateItems(
+    userId: string | null
+): Promise<ChecklistTemplateItem[]> {
+    if (!userId) return []
+
+    const supabase = await createClient()
+    const { data, error } = await supabase
+        .from('checklist_template_items')
+        .select('id, label, position')
+        .eq('user_id', userId)
+        .order('position', { ascending: true })
+        .order('created_at', { ascending: true })
+
+    if (error) {
+        console.error('Error leyendo checklist_template_items:', error)
+        return []
+    }
+    return (data ?? []) as ChecklistTemplateItem[]
+}
+
+export interface EventChecklistState {
+    adHocItems: EventChecklistItem[]
+    checks: EventChecklistCheck[]
+}
+
+/** Lo puntual de un show: ítems ad-hoc y tildes sobre la plantilla. */
+export async function getEventChecklistState(
+    userId: string | null,
+    eventId: string
+): Promise<EventChecklistState> {
+    if (!userId) return { adHocItems: [], checks: [] }
+
+    const supabase = await createClient()
+    const [itemsResult, checksResult] = await Promise.all([
+        supabase
+            .from('event_checklist_items')
+            .select('id, label, position, checked')
+            .eq('user_id', userId)
+            .eq('event_id', eventId)
+            .order('position', { ascending: true })
+            .order('created_at', { ascending: true }),
+        supabase
+            .from('event_checklist_checks')
+            .select('template_item_id, checked')
+            .eq('user_id', userId)
+            .eq('event_id', eventId),
+    ])
+
+    if (itemsResult.error) {
+        console.error('Error leyendo event_checklist_items:', itemsResult.error)
+    }
+    if (checksResult.error) {
+        console.error('Error leyendo event_checklist_checks:', checksResult.error)
+    }
+
+    return {
+        adHocItems: (itemsResult.data ?? []) as EventChecklistItem[],
+        checks: (checksResult.data ?? []).map((row) => ({
+            templateItemId: row.template_item_id as string,
+            checked: row.checked as boolean,
+        })),
+    }
+}
+
+/**
+ * El rango de días que ocupa un show, para medir la ventana contra él.
+ *
+ * El issue pide que el modo "aplique igual a festivales multi-día,
+ * activándose desde el primer día". Un evento suelto ocupa su propia fecha;
+ * uno que es día de un festival ocupa TODO el festival, así que la ventana
+ * previa se cuenta desde el primer día y la posterior desde el último. Sin
+ * esto, el día 1 de un festival de tres días saldría de la ventana antes de
+ * que el festival terminara.
+ *
+ * Un evento puede estar en varios festivales (la tabla puente lo permite);
+ * se toma el primero, que en la práctica es el único caso real.
+ */
+export async function getShowDateRange(event: {
+    id: string
+    date: string
+}): Promise<ShowDateRange> {
+    const supabase = await createClient()
+    const { data, error } = await supabase
+        .from('festival_events')
+        .select('festivals ( start_date, end_date )')
+        .eq('event_id', event.id)
+        .limit(1)
+        .maybeSingle()
+
+    if (error) {
+        console.error('Error resolviendo el festival de un evento:', error)
+        return { startDate: event.date }
+    }
+
+    const festival = (data as { festivals?: { start_date: string; end_date: string | null } | null } | null)
+        ?.festivals
+    if (!festival?.start_date) return { startDate: event.date }
+
+    return { startDate: festival.start_date, endDate: festival.end_date }
+}

--- a/src/domains/showmode/memory-card.test.ts
+++ b/src/domains/showmode/memory-card.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect } from 'vitest'
+import {
+    buildMemoryCard,
+    memoryCardSerial,
+    memoryCardFileName,
+} from '@/src/domains/showmode/memory-card'
+import type { Expense, EventWithRelations } from '@/src/core/types'
+import type { EventWeather } from '@/src/domains/weather/weather-service'
+
+const event: EventWithRelations = {
+    id: '4f2a91c7-1111-2222-3333-444455556666',
+    name: 'Ritual en el Obelisco',
+    date: '2026-05-10T21:00:00-03:00',
+    venue_id: 'v-1',
+    venues: { name: 'Obelisco', city: 'Buenos Aires', country: 'Argentina', lat: -34.6, lng: -58.4 },
+    lineups: [
+        { artists: { id: 'a-1', name: 'Los Redondos', genre: 'Rock' } },
+        { artists: { id: 'a-2', name: 'Soporte', genre: null } },
+    ],
+}
+
+const expenses: Expense[] = [
+    { id: 'e-1', user_id: 'u-1', amount: 15000, category: 'Entrada', note: null, event_id: event.id, date: '2026-05-10' },
+    { id: 'e-2', user_id: 'u-1', amount: 5000, category: 'Comida y bebida', note: null, event_id: event.id, date: '2026-05-10' },
+    { id: 'e-3', user_id: 'u-1', amount: 3000, category: 'Comida y bebida', note: null, event_id: event.id, date: '2026-05-10' },
+]
+
+const weather: EventWeather = {
+    temperatureC: 17.4,
+    precipitationMm: 0,
+    weatherCode: 0,
+    isRain: false,
+    description: 'Despejado',
+    hourLabel: '21:00',
+}
+
+function build(overrides: Partial<Parameters<typeof buildMemoryCard>[0]> = {}) {
+    return buildMemoryCard({
+        event,
+        expenses,
+        rating: 5,
+        review: 'La mejor noche del año.',
+        weather,
+        reference: new Date('2026-08-23T12:00:00Z'),
+        ...overrides,
+    })
+}
+
+describe('buildMemoryCard — datos esenciales del show', () => {
+    it('usa el nombre del evento como título', () => {
+        expect(build().title).toBe('Ritual en el Obelisco')
+    })
+
+    it('cae al artista principal cuando el evento no tiene nombre', () => {
+        const card = build({ event: { ...event, name: null } })
+        expect(card.title).toBe('Los Redondos')
+    })
+
+    it('cae a "Recital" cuando no hay ni nombre ni lineup', () => {
+        const card = build({ event: { ...event, name: null, lineups: null } })
+        expect(card.title).toBe('Recital')
+    })
+
+    it('arma la sede con nombre y ciudad', () => {
+        expect(build().venueLabel).toBe('Obelisco, Buenos Aires')
+    })
+
+    it('no inventa sede cuando el evento no tiene una cargada', () => {
+        expect(build({ event: { ...event, venues: null } }).venueLabel).toBe('Sede por confirmar')
+    })
+
+    it('lista el lineup completo, headliner primero', () => {
+        expect(build().lineup).toEqual(['Los Redondos', 'Soporte'])
+    })
+})
+
+describe('buildMemoryCard — las comparaciones de gasto (issue #7)', () => {
+    it('suma el total gastado en el show', () => {
+        expect(build().totalSpent).toBe(23000)
+    })
+
+    it('agrupa los gastos por categoría, de mayor a menor', () => {
+        expect(build().categories).toEqual([
+            { category: 'Entrada', icon: '🎟️', total: 15000 },
+            { category: 'Comida y bebida', icon: '🍔', total: 8000 },
+        ])
+    })
+
+    it('reusa la comparación en choripanes en vez de reimplementarla', () => {
+        expect(build().choripanLine).toBe('esto son 4,6 choripanes')
+    })
+
+    it('no muestra comparación de choripanes cuando no se cargó ningún gasto', () => {
+        const card = build({ expenses: [] })
+        expect(card.choripanLine).toBeNull()
+        expect(card.totalSpent).toBe(0)
+        expect(card.categories).toEqual([])
+    })
+
+    it('muestra el ajuste por inflación para un show de un año anterior', () => {
+        const card = build({
+            event: { ...event, date: '2024-05-10T21:00:00-03:00' },
+            reference: new Date('2026-08-23T12:00:00Z'),
+        })
+        expect(card.inflationLine).toMatch(/^Hoy serían \$/)
+    })
+
+    it('omite el ajuste por inflación para un show del año en curso (la granularidad es anual)', () => {
+        expect(build().inflationLine).toBeNull()
+    })
+
+    it('colapsa la cola de categorías en una sola línea "Otros" para que la tarjeta no crezca sin fin', () => {
+        const many: Expense[] = ['Entrada', 'Transporte', 'Alojamiento', 'Comida y bebida', 'Merch', 'Otro'].map(
+            (category, i) => ({
+                id: `e-${i}`,
+                user_id: 'u-1',
+                amount: 1000 * (10 - i),
+                category,
+                note: null,
+                event_id: event.id,
+                date: '2026-05-10',
+            })
+        )
+        const card = build({ expenses: many })
+        expect(card.categories).toHaveLength(5)
+        expect(card.categories[4].category).toBe('Otros (2)')
+        // 6000 (Merch) + 5000 (Otro)
+        expect(card.categories[4].total).toBe(11000)
+    })
+})
+
+describe('buildMemoryCard — el clima (issue #8)', () => {
+    it('trae emoji, temperatura redondeada y descripción', () => {
+        expect(build().weather).toEqual({ emoji: '☀️', temperatureC: 17, description: 'Despejado' })
+    })
+
+    it('usa el emoji de lluvia cuando llovió, sin importar el código WMO', () => {
+        const card = build({ weather: { ...weather, isRain: true, precipitationMm: 2 } })
+        expect(card.weather?.emoji).toBe('🌧️')
+    })
+
+    it('deja el clima en null cuando no se pudo obtener, sin romper la tarjeta', () => {
+        const card = build({ weather: null })
+        expect(card.weather).toBeNull()
+        expect(card.title).toBe('Ritual en el Obelisco')
+    })
+})
+
+describe('buildMemoryCard — la memoria del usuario', () => {
+    it('conserva el puntaje', () => {
+        expect(build().rating).toBe(5)
+    })
+
+    it('recorta una reseña larga para que entre en el stub', () => {
+        const card = build({ review: 'x'.repeat(300) })
+        expect(card.reviewExcerpt).toHaveLength(181)
+        expect(card.reviewExcerpt?.endsWith('…')).toBe(true)
+    })
+
+    it('deja pasar entera una reseña corta, sin puntos suspensivos', () => {
+        expect(build().reviewExcerpt).toBe('La mejor noche del año.')
+    })
+
+    it('deja la reseña en null cuando está vacía o son solo espacios', () => {
+        expect(build({ review: null }).reviewExcerpt).toBeNull()
+        expect(build({ review: '   ' }).reviewExcerpt).toBeNull()
+    })
+})
+
+describe('memoryCardSerial', () => {
+    it('deriva un serial estable del id del evento — la misma tarjeta trae siempre el mismo número', () => {
+        expect(memoryCardSerial(event.id)).toBe('RTL-4F2A-91C7')
+        expect(memoryCardSerial(event.id)).toBe(memoryCardSerial(event.id))
+    })
+
+    it('completa con ceros un id más corto de lo esperado en vez de devolver un serial cortado', () => {
+        expect(memoryCardSerial('ab')).toBe('RTL-AB00-0000')
+    })
+})
+
+describe('memoryCardFileName', () => {
+    it('arma un nombre de archivo sin acentos ni espacios', () => {
+        const card = build({ event: { ...event, name: 'Café Tacvbo en Córdoba' } })
+        expect(memoryCardFileName(card)).toBe('ritual-recuerdo-cafe-tacvbo-en-cordoba.png')
+    })
+
+    it('cae a un nombre genérico cuando el título no deja ningún caracter usable', () => {
+        const card = build({ event: { ...event, name: '¡¿!?' } })
+        expect(memoryCardFileName(card)).toBe('ritual-recuerdo-recital.png')
+    })
+})

--- a/src/domains/showmode/memory-card.ts
+++ b/src/domains/showmode/memory-card.ts
@@ -1,0 +1,176 @@
+/**
+ * Modelo de vista de la "tarjeta recuerdo" (issue #9): el stub de entrada
+ * digital que se genera cuando ya está todo cargado de un show.
+ *
+ * Es el punto donde se componen los dos features que ya existen — los gastos
+ * del recital (issue #7, con sus comparaciones propias) y el clima exacto
+ * del show (issue #8) — más los datos esenciales del evento y la memoria del
+ * usuario. Acá no se re-implementa ninguna de esas reglas: se reusan
+ * `groupExpensesByCategory`, `formatChoripanComparison`, `adjustForInflation`
+ * y `weatherEmoji` tal cual.
+ *
+ * Puro y serializable a propósito: lo arma el server component de la ficha
+ * del evento y lo recibe como prop el componente de cliente que dibuja y
+ * exporta la tarjeta, así que no puede arrastrar dependencias de servidor.
+ *
+ * NO es una función social — el issue lo aclara explícitamente. Nada acá
+ * publica, comparte ni expone la tarjeta: se dibuja para el dueño del show y
+ * se descarga como imagen para guardarla fuera de la app.
+ */
+import { formatDate } from '@/src/core/lib/utils'
+import { getExpenseCategory } from '@/src/domains/expenses/categories'
+import { groupExpensesByCategory } from '@/src/domains/expenses/grouping'
+import { formatChoripanComparison, adjustForInflation } from '@/src/domains/expenses/comparisons'
+import { weatherEmoji } from '@/src/domains/weather/icons'
+import type { Expense, EventWithRelations } from '@/src/core/types'
+import type { EventWeather } from '@/src/domains/weather/weather-service'
+
+/** Cuántas categorías de gasto entran en la tarjeta antes de agruparse en "Otros". */
+const MAX_CARD_CATEGORIES = 4
+
+/** Recorte de la reseña que entra en la tarjeta sin romper el layout del stub. */
+const REVIEW_EXCERPT_LENGTH = 180
+
+export interface MemoryCardCategoryLine {
+    category: string
+    icon: string
+    total: number
+}
+
+export interface MemoryCardWeatherLine {
+    emoji: string
+    temperatureC: number
+    description: string
+}
+
+export interface MemoryCardData {
+    /** Serial del stub, derivado del id del evento — decorativo, estable entre renders. */
+    serial: string
+    title: string
+    dateLabel: string
+    venueLabel: string
+    /** Nombres del lineup, headliner primero (el orden en que ya vienen). */
+    lineup: string[]
+    rating: number | null
+    reviewExcerpt: string | null
+    totalSpent: number
+    categories: MemoryCardCategoryLine[]
+    /** "esto son 4,6 choripanes" — null si no hubo gastos. */
+    choripanLine: string | null
+    /** Poder adquisitivo de hoy para un gasto de otro año; null si no aplica. */
+    inflationLine: string | null
+    /** null cuando la sede no tiene coordenadas o Open-Meteo no devolvió nada. */
+    weather: MemoryCardWeatherLine | null
+}
+
+function formatARS(amount: number): string {
+    return `$${amount.toLocaleString('es-AR', { maximumFractionDigits: 0 })}`
+}
+
+/**
+ * Serial decorativo tipo entrada ("RTL-4F2A-91C7") a partir del uuid del
+ * evento. Determinista: la misma tarjeta descargada dos veces trae el mismo
+ * número, que es lo que uno espera de un stub.
+ */
+export function memoryCardSerial(eventId: string): string {
+    const hex = eventId.replace(/[^0-9a-f]/gi, '').toUpperCase()
+    const first = hex.slice(0, 4).padEnd(4, '0')
+    const second = hex.slice(4, 8).padEnd(4, '0')
+    return `RTL-${first}-${second}`
+}
+
+function truncate(text: string, max: number): string {
+    const clean = text.trim()
+    if (clean.length <= max) return clean
+    return `${clean.slice(0, max).trimEnd()}…`
+}
+
+/**
+ * Colapsa la cola de categorías chicas en una sola línea "Otros" para que la
+ * tarjeta no crezca sin límite cuando alguien cargó ocho tipos de gasto. Con
+ * MAX_CARD_CATEGORIES o menos, no toca nada.
+ */
+function condenseCategories(
+    groups: { category: string; total: number }[]
+): MemoryCardCategoryLine[] {
+    const head = groups.slice(0, MAX_CARD_CATEGORIES).map((g) => ({
+        category: g.category,
+        icon: getExpenseCategory(g.category).icon,
+        total: g.total,
+    }))
+
+    const tail = groups.slice(MAX_CARD_CATEGORIES)
+    if (tail.length === 0) return head
+
+    return [
+        ...head,
+        {
+            category: `Otros (${tail.length})`,
+            icon: '➕',
+            total: tail.reduce((sum, g) => sum + g.total, 0),
+        },
+    ]
+}
+
+export interface BuildMemoryCardInput {
+    event: EventWithRelations
+    expenses: Expense[]
+    rating: number | null
+    review: string | null
+    weather: EventWeather | null
+    /** Inyectable para tests — el ajuste por inflación depende del año actual. */
+    reference?: Date
+}
+
+/** Arma el modelo de vista completo de la tarjeta recuerdo de un show. */
+export function buildMemoryCard({
+    event,
+    expenses,
+    rating,
+    review,
+    weather,
+    reference = new Date(),
+}: BuildMemoryCardInput): MemoryCardData {
+    const mainArtist = event.lineups?.[0]?.artists?.name ?? null
+    const totalSpent = expenses.reduce((sum, e) => sum + Number(e.amount), 0)
+    const groups = groupExpensesByCategory(expenses)
+
+    const inflation = adjustForInflation(totalSpent, String(event.date), reference)
+    const inflationLine = inflation
+        ? `Hoy serían ${formatARS(inflation.adjustedAmount)}`
+        : null
+
+    return {
+        serial: memoryCardSerial(event.id),
+        title: event.name || mainArtist || 'Recital',
+        dateLabel: formatDate(event.date, { day: 'numeric', month: 'long', year: 'numeric' }),
+        venueLabel: event.venues
+            ? [event.venues.name, event.venues.city].filter(Boolean).join(', ')
+            : 'Sede por confirmar',
+        lineup: (event.lineups ?? []).map((row) => row.artists.name),
+        rating,
+        reviewExcerpt: review?.trim() ? truncate(review, REVIEW_EXCERPT_LENGTH) : null,
+        totalSpent,
+        categories: condenseCategories(groups),
+        choripanLine: formatChoripanComparison(totalSpent),
+        inflationLine,
+        weather: weather
+            ? {
+                  emoji: weatherEmoji(weather.weatherCode, weather.isRain),
+                  temperatureC: Math.round(weather.temperatureC),
+                  description: weather.description,
+              }
+            : null,
+    }
+}
+
+/** Nombre de archivo de la descarga, sin acentos ni espacios. */
+export function memoryCardFileName(card: MemoryCardData): string {
+    const slug = card.title
+        .normalize('NFD')
+        .replace(/\p{M}/gu, '')
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '')
+    return `ritual-recuerdo-${slug || 'recital'}.png`
+}

--- a/src/domains/showmode/pending.test.ts
+++ b/src/domains/showmode/pending.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest'
+import { computePendingForShow, isMemoryCardReady } from '@/src/domains/showmode/pending'
+import type { ShowCompletionInput } from '@/src/domains/showmode/pending'
+
+const complete: ShowCompletionInput = {
+    attendanceStatus: 'went',
+    expenseCount: 3,
+    rating: 5,
+    review: 'Una locura.',
+}
+
+describe('computePendingForShow', () => {
+    it('no devuelve nada pendiente cuando el show está completo', () => {
+        expect(computePendingForShow(complete)).toEqual([])
+    })
+
+    it(
+        'cuando el usuario no confirmó que fue, ese es el único pendiente — todo lo demás ' +
+            'cuelga de esa respuesta y listarlo junto convierte el aviso en ruido',
+        () => {
+            const pending = computePendingForShow({
+                attendanceStatus: null,
+                expenseCount: 0,
+                rating: null,
+                review: null,
+            })
+            expect(pending).toEqual([{ kind: 'attendance', label: 'Confirmar si fuiste' }])
+        }
+    )
+
+    it('trata "going" igual que sin confirmar: el show todavía no está marcado como ido', () => {
+        const pending = computePendingForShow({ ...complete, attendanceStatus: 'going' })
+        expect(pending.map((p) => p.kind)).toEqual(['attendance'])
+    })
+
+    it('trata "interested" igual que sin confirmar', () => {
+        const pending = computePendingForShow({ ...complete, attendanceStatus: 'interested' })
+        expect(pending.map((p) => p.kind)).toEqual(['attendance'])
+    })
+
+    it('marca los gastos como pendientes cuando no se cargó ninguno', () => {
+        const pending = computePendingForShow({ ...complete, expenseCount: 0 })
+        expect(pending.map((p) => p.kind)).toEqual(['expenses'])
+    })
+
+    it('marca el rating como pendiente cuando no hay puntaje', () => {
+        const pending = computePendingForShow({ ...complete, rating: null })
+        expect(pending.map((p) => p.kind)).toEqual(['rating'])
+    })
+
+    it('marca la reseña como pendiente cuando está vacía', () => {
+        const pending = computePendingForShow({ ...complete, review: null })
+        expect(pending.map((p) => p.kind)).toEqual(['review'])
+    })
+
+    it('trata una reseña de puros espacios como no escrita', () => {
+        const pending = computePendingForShow({ ...complete, review: '   \n  ' })
+        expect(pending.map((p) => p.kind)).toEqual(['review'])
+    })
+
+    it('acepta un rating de 0 como cargado (no confunde 0 con "sin puntaje")', () => {
+        const pending = computePendingForShow({ ...complete, rating: 0 })
+        expect(pending).toEqual([])
+    })
+
+    it('junta todos los pendientes en un solo aviso, en el orden en que conviene resolverlos', () => {
+        const pending = computePendingForShow({
+            attendanceStatus: 'went',
+            expenseCount: 0,
+            rating: null,
+            review: '',
+        })
+        expect(pending.map((p) => p.kind)).toEqual(['expenses', 'rating', 'review'])
+    })
+})
+
+describe('isMemoryCardReady', () => {
+    it('la tarjeta está lista cuando no queda nada pendiente', () => {
+        expect(isMemoryCardReady(computePendingForShow(complete))).toBe(true)
+    })
+
+    it('no está lista mientras falte algo por cargar', () => {
+        expect(isMemoryCardReady(computePendingForShow({ ...complete, rating: null }))).toBe(false)
+    })
+
+    it(
+        'el clima no entra en la condición: no lo carga el usuario, así que su ausencia ' +
+            'nunca puede bloquear el recuerdo',
+        () => {
+            // `complete` no menciona clima en ningún lado y aun así da lista.
+            expect(isMemoryCardReady(computePendingForShow(complete))).toBe(true)
+        }
+    )
+})

--- a/src/domains/showmode/pending.ts
+++ b/src/domains/showmode/pending.ts
@@ -1,0 +1,76 @@
+/**
+ * Qué le falta cargar al usuario de un show (issue #9).
+ *
+ * ════════════════════════════════════════════════════════════════════════
+ * DEPENDENCIA — issue #6 (sistema de notificaciones), NO implementado
+ * ════════════════════════════════════════════════════════════════════════
+ * El issue #9 pide "un solo aviso que junta todo lo pendiente del show
+ * (gastos + rating + reseña), no notificaciones sueltas". Ese aviso necesita
+ * un canal (mail/push) que todavía no existe: el issue #6 está frenado
+ * esperando una decisión de tooling del dueño del proyecto.
+ *
+ * Lo que SÍ vive acá es la mitad que no depende de esa decisión: el cálculo
+ * de qué está pendiente. Es deliberadamente puro y agnóstico del canal —
+ * hoy lo consume la propia página del evento para mostrar el aviso in-app
+ * durante la ventana posterior al show, y cuando el issue #6 se destrabe,
+ * el job que mande el mail/push puede reusar esta misma función sin
+ * reimplementar la regla. No hay nada de infraestructura de notificaciones
+ * en este archivo ni en este PR.
+ */
+
+export type PendingKind = 'attendance' | 'expenses' | 'rating' | 'review'
+
+export interface PendingItem {
+    kind: PendingKind
+    label: string
+}
+
+export interface ShowCompletionInput {
+    /** null cuando el usuario nunca marcó nada para este show. */
+    attendanceStatus: 'interested' | 'going' | 'went' | null
+    expenseCount: number
+    rating: number | null
+    review: string | null
+}
+
+/**
+ * Lo que falta cargar de un show, en el orden en que conviene resolverlo.
+ *
+ * Si el usuario todavía no confirmó que fue, ese es el ÚNICO pendiente que
+ * se devuelve: todo lo demás (gastos de esa noche, rating, reseña) cuelga de
+ * esa respuesta, y listar cuatro pendientes cuando el primero puede
+ * invalidar a los otros tres convierte el aviso en ruido. Es exactamente lo
+ * que el issue quiere evitar al pedir "un solo aviso" en vez de
+ * notificaciones sueltas.
+ */
+export function computePendingForShow(input: ShowCompletionInput): PendingItem[] {
+    if (input.attendanceStatus !== 'went') {
+        return [{ kind: 'attendance', label: 'Confirmar si fuiste' }]
+    }
+
+    const pending: PendingItem[] = []
+    if (input.expenseCount <= 0) {
+        pending.push({ kind: 'expenses', label: 'Cargar los gastos de esa noche' })
+    }
+    if (input.rating == null) {
+        pending.push({ kind: 'rating', label: 'Puntuar el show' })
+    }
+    if (!input.review?.trim()) {
+        pending.push({ kind: 'review', label: 'Escribir la reseña' })
+    }
+    return pending
+}
+
+/**
+ * La tarjeta recuerdo se genera "al terminar de cargar todo de un show" —
+ * o sea, cuando no queda ningún pendiente.
+ *
+ * El clima queda fuera de esta condición a propósito: no lo carga el
+ * usuario, lo trae Open-Meteo, y puede faltar por razones ajenas (sede sin
+ * coordenadas, show fuera del rango histórico). Bloquear el recuerdo por
+ * eso castigaría al usuario por algo que no puede resolver — la tarjeta
+ * simplemente omite el clima cuando no hay.
+ */
+export function isMemoryCardReady(pending: PendingItem[]): boolean {
+    return pending.length === 0
+}

--- a/src/domains/showmode/preferences.test.ts
+++ b/src/domains/showmode/preferences.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import {
+    clampShowModePreferences,
+    DEFAULT_SHOW_MODE_PREFERENCES,
+    SHOW_MODE_LIMITS,
+} from '@/src/domains/showmode/preferences'
+
+describe('DEFAULT_SHOW_MODE_PREFERENCES', () => {
+    it('defaults to 7 days before and 2 days after (the top of the "1-2 días" range the issue names)', () => {
+        expect(DEFAULT_SHOW_MODE_PREFERENCES).toEqual({ daysBefore: 7, daysAfter: 2 })
+    })
+})
+
+describe('clampShowModePreferences', () => {
+    it('keeps values already inside the allowed range', () => {
+        expect(clampShowModePreferences({ daysBefore: 14, daysAfter: 5 })).toEqual({
+            daysBefore: 14,
+            daysAfter: 5,
+        })
+    })
+
+    it('allows zero on both ends — a user can opt out of one side of the window', () => {
+        expect(clampShowModePreferences({ daysBefore: 0, daysAfter: 0 })).toEqual({
+            daysBefore: 0,
+            daysAfter: 0,
+        })
+    })
+
+    it('clamps values above the maximum instead of writing something the table CHECK would reject', () => {
+        expect(clampShowModePreferences({ daysBefore: 999, daysAfter: 999 })).toEqual({
+            daysBefore: SHOW_MODE_LIMITS.maxDaysBefore,
+            daysAfter: SHOW_MODE_LIMITS.maxDaysAfter,
+        })
+    })
+
+    it('clamps negative values up to zero', () => {
+        expect(clampShowModePreferences({ daysBefore: -5, daysAfter: -1 })).toEqual({
+            daysBefore: 0,
+            daysAfter: 0,
+        })
+    })
+
+    it('truncates fractional input rather than storing a non-integer day count', () => {
+        expect(clampShowModePreferences({ daysBefore: 7.9, daysAfter: 2.4 })).toEqual({
+            daysBefore: 7,
+            daysAfter: 2,
+        })
+    })
+
+    it('falls back to the defaults for unreadable input instead of producing NaN', () => {
+        expect(clampShowModePreferences({ daysBefore: 'abc', daysAfter: null })).toEqual(
+            DEFAULT_SHOW_MODE_PREFERENCES
+        )
+    })
+
+    it('falls back to the defaults for a missing object entirely', () => {
+        expect(clampShowModePreferences(null)).toEqual(DEFAULT_SHOW_MODE_PREFERENCES)
+        expect(clampShowModePreferences(undefined)).toEqual(DEFAULT_SHOW_MODE_PREFERENCES)
+    })
+})

--- a/src/domains/showmode/preferences.ts
+++ b/src/domains/showmode/preferences.ts
@@ -1,0 +1,75 @@
+/**
+ * Preferencias de la ventana del "modo recital activo" (issue #9).
+ *
+ * Puro a propósito: los defaults y el clamp los necesitan tanto el server
+ * (data.ts al leer una fila que puede no existir todavía, actions.ts al
+ * validar lo que manda el form) como el cliente (el form de ajustes, para
+ * mostrar los límites), así que no puede vivir detrás de 'server-only'.
+ */
+
+export interface ShowModePreferences {
+    /** Días antes del show en los que el modo ya está activo. */
+    daysBefore: number
+    /** Días después del último día del show en los que sigue activo. */
+    daysAfter: number
+}
+
+/**
+ * El issue pide que la ventana sea "configurable por el usuario, no un
+ * número fijo de días para todos", pero no fija el default del "antes".
+ * Elegimos 7: una semana es cuando uno efectivamente empieza a resolver el
+ * show (transporte, plata, qué llevar), y coincide con el horizonte del
+ * pronóstico útil de Open-Meteo (16 días de máximo, pero recién dentro de
+ * la semana el pronóstico deja de ser ruido).
+ *
+ * Para el "después" el issue sí da un rango explícito — "sigue activo 1-2
+ * días después" — así que se toma el techo de ese rango: 2 días. Es el
+ * valor más generoso que el issue autoriza sin inventar nada.
+ */
+export const DEFAULT_SHOW_MODE_PREFERENCES: ShowModePreferences = {
+    daysBefore: 7,
+    daysAfter: 2,
+}
+
+/** Límites duros de la ventana; los mismos que valida el CHECK en la tabla. */
+export const SHOW_MODE_LIMITS = {
+    minDaysBefore: 0,
+    maxDaysBefore: 60,
+    minDaysAfter: 0,
+    maxDaysAfter: 14,
+} as const
+
+function clampToRange(value: unknown, min: number, max: number, fallback: number): number {
+    // `null`, `undefined` y `''` significan "no configurado", no "cero días".
+    // Sin este guard caerían en el `Number()` de abajo, que los convierte en 0
+    // y apagaría medio modo recital en silencio.
+    if (value == null || value === '') return fallback
+    const n = Number(value)
+    if (!Number.isFinite(n)) return fallback
+    return Math.min(max, Math.max(min, Math.trunc(n)))
+}
+
+/**
+ * Normaliza cualquier entrada (form, fila de Supabase, undefined) a una
+ * ventana válida. Nunca lanza ni devuelve NaN: un valor ilegible cae al
+ * default en vez de dejar la página del evento sin saber si el modo está
+ * activo.
+ */
+export function clampShowModePreferences(
+    input: Partial<Record<keyof ShowModePreferences, unknown>> | null | undefined
+): ShowModePreferences {
+    return {
+        daysBefore: clampToRange(
+            input?.daysBefore,
+            SHOW_MODE_LIMITS.minDaysBefore,
+            SHOW_MODE_LIMITS.maxDaysBefore,
+            DEFAULT_SHOW_MODE_PREFERENCES.daysBefore
+        ),
+        daysAfter: clampToRange(
+            input?.daysAfter,
+            SHOW_MODE_LIMITS.minDaysAfter,
+            SHOW_MODE_LIMITS.maxDaysAfter,
+            DEFAULT_SHOW_MODE_PREFERENCES.daysAfter
+        ),
+    }
+}

--- a/src/domains/showmode/service.test.ts
+++ b/src/domains/showmode/service.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@/src/domains/showmode/data', () => ({
+    getShowModePreferences: vi.fn(),
+    getChecklistTemplateItems: vi.fn(),
+    getEventChecklistState: vi.fn(),
+    getShowDateRange: vi.fn(),
+}))
+
+import { getEventShowModeState, getShowModeSettings } from '@/src/domains/showmode/service'
+import {
+    getShowModePreferences,
+    getChecklistTemplateItems,
+    getEventChecklistState,
+    getShowDateRange,
+} from '@/src/domains/showmode/data'
+import { DEFAULT_SHOW_MODE_PREFERENCES } from '@/src/domains/showmode/preferences'
+
+const completeShow = {
+    attendanceStatus: 'went' as const,
+    expenseCount: 2,
+    rating: 5,
+    review: 'Tremendo.',
+}
+
+beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getShowModePreferences).mockResolvedValue(DEFAULT_SHOW_MODE_PREFERENCES)
+    vi.mocked(getChecklistTemplateItems).mockResolvedValue([
+        { id: 't-1', label: 'Entrada', position: 0 },
+    ])
+    vi.mocked(getEventChecklistState).mockResolvedValue({
+        adHocItems: [{ id: 'a-1', label: 'SUBE', position: 0, checked: true }],
+        checks: [{ templateItemId: 't-1', checked: false }],
+    })
+    // Un show de hace dos días: dentro de la ventana posterior por default.
+    const twoDaysAgo = new Date(Date.now() - 2 * 86400000).toISOString().slice(0, 10)
+    vi.mocked(getShowDateRange).mockResolvedValue({ startDate: twoDaysAgo })
+})
+
+describe('getEventShowModeState', () => {
+    it('combina plantilla, tildes e ítems del show en un solo checklist', async () => {
+        const state = await getEventShowModeState(
+            { id: 'ev-1', date: '2026-05-10' },
+            'user-1',
+            completeShow
+        )
+
+        expect(state.checklist.map((i) => i.label)).toEqual(['Entrada', 'SUBE'])
+        expect(state.checklist[0].checked).toBe(false)
+        expect(state.checklist[1].checked).toBe(true)
+        expect(state.progress).toMatchObject({ done: 1, total: 2 })
+    })
+
+    it('resuelve la ventana contra el rango que devuelve data, no contra la fecha cruda del evento', async () => {
+        // El evento dice 2020, pero pertenece a un festival que es hoy.
+        const today = new Date().toISOString().slice(0, 10)
+        vi.mocked(getShowDateRange).mockResolvedValue({ startDate: today, endDate: today })
+
+        const state = await getEventShowModeState(
+            { id: 'ev-1', date: '2020-01-01' },
+            'user-1',
+            completeShow
+        )
+
+        expect(getShowDateRange).toHaveBeenCalledWith({ id: 'ev-1', date: '2020-01-01' })
+        expect(state.window.phase).toBe('during')
+    })
+
+    it('calcula los pendientes a partir de la asistencia y gastos que le pasa la página', async () => {
+        const state = await getEventShowModeState({ id: 'ev-1', date: '2026-05-10' }, 'user-1', {
+            attendanceStatus: 'went',
+            expenseCount: 0,
+            rating: null,
+            review: null,
+        })
+
+        expect(state.pending.map((p) => p.kind)).toEqual(['expenses', 'rating', 'review'])
+        expect(state.memoryCardReady).toBe(false)
+    })
+
+    it('marca la tarjeta recuerdo lista cuando no queda nada pendiente', async () => {
+        const state = await getEventShowModeState(
+            { id: 'ev-1', date: '2026-05-10' },
+            'user-1',
+            completeShow
+        )
+        expect(state.memoryCardReady).toBe(true)
+    })
+
+    it('expone la etiqueta de la fase para la banda del modo activo', async () => {
+        const state = await getEventShowModeState(
+            { id: 'ev-1', date: '2026-05-10' },
+            'user-1',
+            completeShow
+        )
+        expect(state.window.phase).toBe('after')
+        expect(state.phaseLabel).toBe('Fue hace 2 días')
+    })
+
+    it('no vuelve a pedir gastos ni asistencia: solo lee lo suyo', async () => {
+        await getEventShowModeState({ id: 'ev-1', date: '2026-05-10' }, 'user-1', completeShow)
+
+        expect(getShowModePreferences).toHaveBeenCalledWith('user-1')
+        expect(getChecklistTemplateItems).toHaveBeenCalledWith('user-1')
+        expect(getEventChecklistState).toHaveBeenCalledWith('user-1', 'ev-1')
+    })
+
+    it('funciona sin usuario: data devuelve vacíos y el modo queda sin checklist', async () => {
+        vi.mocked(getChecklistTemplateItems).mockResolvedValue([])
+        vi.mocked(getEventChecklistState).mockResolvedValue({ adHocItems: [], checks: [] })
+
+        const state = await getEventShowModeState({ id: 'ev-1', date: '2026-05-10' }, null, {
+            attendanceStatus: null,
+            expenseCount: 0,
+            rating: null,
+            review: null,
+        })
+
+        expect(state.checklist).toEqual([])
+        expect(state.progress.total).toBe(0)
+        expect(state.pending.map((p) => p.kind)).toEqual(['attendance'])
+    })
+})
+
+describe('getShowModeSettings', () => {
+    it('devuelve la ventana y la plantilla que necesita la página de ajustes', async () => {
+        const settings = await getShowModeSettings('user-1')
+
+        expect(settings.preferences).toEqual(DEFAULT_SHOW_MODE_PREFERENCES)
+        expect(settings.templateItems).toEqual([{ id: 't-1', label: 'Entrada', position: 0 }])
+    })
+})

--- a/src/domains/showmode/service.ts
+++ b/src/domains/showmode/service.ts
@@ -1,0 +1,91 @@
+/**
+ * Capa de casos de uso del "modo recital activo" (issue #9).
+ *
+ * Misma razón que expenses/service.ts y festivals/service.ts (ver issue
+ * #25): la página del evento y la de ajustes hablan con esto, nunca con
+ * ./data directamente. Acá viven las orquestaciones — resolver el rango del
+ * show, combinar plantilla + tildes + ítems del show, calcular la fase y los
+ * pendientes — para que el componente de página solo consuma un objeto ya
+ * armado.
+ *
+ * Las escrituras quedan afuera a propósito, igual que en expenses: ./actions
+ * ya cumple ese rol (valida, devuelve `ActionResult<T>` y revalida la ruta),
+ * y envolverlo otra vez duplicaría la costura en vez de reforzarla.
+ */
+import {
+    getShowModePreferences,
+    getChecklistTemplateItems,
+    getEventChecklistState,
+    getShowDateRange,
+} from './data'
+import { resolveShowModeWindow, describeShowModePhase } from './window'
+import { buildEventChecklist, checklistProgress } from './checklist'
+import { computePendingForShow, isMemoryCardReady } from './pending'
+import type { ShowModeWindow } from './window'
+import type { ResolvedChecklistItem, ChecklistProgress, ChecklistTemplateItem } from './checklist'
+import type { PendingItem, ShowCompletionInput } from './pending'
+import type { ShowModePreferences } from './preferences'
+
+export interface EventShowModeState {
+    window: ShowModeWindow
+    /** Etiqueta corta de la fase ("Faltan 3 días"), null si el modo no está activo. */
+    phaseLabel: string | null
+    checklist: ResolvedChecklistItem[]
+    progress: ChecklistProgress
+    /** Lo que falta cargar del show — ver la nota de dependencia en ./pending. */
+    pending: PendingItem[]
+    /** La tarjeta recuerdo se ofrece completa recién cuando no queda nada pendiente. */
+    memoryCardReady: boolean
+}
+
+/**
+ * Estado completo del modo recital para un show puntual.
+ *
+ * Recibe la asistencia/gastos ya cargados por la página en vez de volver a
+ * pedirlos: la ficha del evento ya los trae para el panel de gastos y el
+ * form de rating, y repetir esas dos queries acá sería trabajo duplicado en
+ * cada render de la página.
+ */
+export async function getEventShowModeState(
+    event: { id: string; date: string },
+    userId: string | null,
+    completion: ShowCompletionInput
+): Promise<EventShowModeState> {
+    const [preferences, range, templateItems, checklistState] = await Promise.all([
+        getShowModePreferences(userId),
+        getShowDateRange(event),
+        getChecklistTemplateItems(userId),
+        getEventChecklistState(userId, event.id),
+    ])
+
+    const window = resolveShowModeWindow(range, preferences)
+    const checklist = buildEventChecklist(
+        templateItems,
+        checklistState.adHocItems,
+        checklistState.checks
+    )
+    const pending = computePendingForShow(completion)
+
+    return {
+        window,
+        phaseLabel: describeShowModePhase(window),
+        checklist,
+        progress: checklistProgress(checklist),
+        pending,
+        memoryCardReady: isMemoryCardReady(pending),
+    }
+}
+
+export interface ShowModeSettings {
+    preferences: ShowModePreferences
+    templateItems: ChecklistTemplateItem[]
+}
+
+/** Lo que necesita la página de ajustes: la ventana y la plantilla base. */
+export async function getShowModeSettings(userId: string | null): Promise<ShowModeSettings> {
+    const [preferences, templateItems] = await Promise.all([
+        getShowModePreferences(userId),
+        getChecklistTemplateItems(userId),
+    ])
+    return { preferences, templateItems }
+}

--- a/src/domains/showmode/window.test.ts
+++ b/src/domains/showmode/window.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from 'vitest'
+import { resolveShowModeWindow, describeShowModePhase } from '@/src/domains/showmode/window'
+import { DEFAULT_SHOW_MODE_PREFERENCES } from '@/src/domains/showmode/preferences'
+
+// Mediodía ART para que la referencia no quede pegada al borde del día en UTC.
+const NOW = new Date('2026-05-10T15:00:00Z')
+const prefs = DEFAULT_SHOW_MODE_PREFERENCES // 7 antes / 2 después
+
+function phaseOf(startDate: string, endDate?: string | null) {
+    return resolveShowModeWindow({ startDate, endDate }, prefs, NOW).phase
+}
+
+describe('resolveShowModeWindow — show de un día', () => {
+    it('no activa el modo para un show más lejano que la ventana configurada', () => {
+        expect(phaseOf('2026-05-30')).toBe('upcoming')
+    })
+
+    it('activa el modo justo en el borde de la ventana previa (7 días antes)', () => {
+        expect(phaseOf('2026-05-17')).toBe('before')
+    })
+
+    it('deja fuera el día inmediatamente anterior al borde de la ventana', () => {
+        expect(phaseOf('2026-05-18')).toBe('upcoming')
+    })
+
+    it('marca "during" el día del show', () => {
+        expect(phaseOf('2026-05-10')).toBe('during')
+    })
+
+    it('no corta en seco: sigue activo el día después del show', () => {
+        expect(phaseOf('2026-05-09')).toBe('after')
+    })
+
+    it('sigue activo en el último día de la ventana posterior', () => {
+        expect(phaseOf('2026-05-08')).toBe('after')
+    })
+
+    it('cierra la ventana pasados los días configurados', () => {
+        expect(phaseOf('2026-05-07')).toBe('closed')
+    })
+
+    it(
+        'compara por día calendario en la timezone de la app, no por instante: un show de las ' +
+            '21hs ART guardado como 00:00Z del día siguiente sigue siendo "during" hoy',
+        () => {
+            // 2026-05-11T00:00Z es 2026-05-10 21:00 en Argentina — el show de hoy.
+            expect(phaseOf('2026-05-11T00:00:00Z')).toBe('during')
+        }
+    )
+
+    it('resuelve un timestamp con offset explícito al día que corresponde en Argentina', () => {
+        expect(phaseOf('2026-05-10T21:00:00-03:00')).toBe('during')
+    })
+})
+
+describe('resolveShowModeWindow — festivales multi-día', () => {
+    const festival = { startDate: '2026-05-08', endDate: '2026-05-12' }
+
+    it('está "during" en un día intermedio del festival, no "after" por haber pasado el primer día', () => {
+        const window = resolveShowModeWindow(festival, prefs, NOW)
+        expect(window.phase).toBe('during')
+        expect(window.isMultiDay).toBe(true)
+    })
+
+    it('se activa desde el primer día: la ventana previa se cuenta contra el comienzo', () => {
+        // Comienza en 6 días (dentro de los 7), termina en 10.
+        expect(phaseOf('2026-05-16', '2026-05-20')).toBe('before')
+    })
+
+    it('cuenta la ventana posterior desde el último día, no desde el primero', () => {
+        // Terminó ayer aunque haya empezado hace cinco días.
+        expect(phaseOf('2026-05-05', '2026-05-09')).toBe('after')
+    })
+
+    it('cierra recién cuando pasaron los días configurados desde el último día', () => {
+        expect(phaseOf('2026-05-01', '2026-05-07')).toBe('closed')
+    })
+
+    it('ignora un end_date anterior al start_date en vez de romper, tratándolo como show de un día', () => {
+        const window = resolveShowModeWindow(
+            { startDate: '2026-05-10', endDate: '2026-05-01' },
+            prefs,
+            NOW
+        )
+        expect(window.phase).toBe('during')
+        expect(window.isMultiDay).toBe(false)
+    })
+
+    it('trata un end_date nulo como show de un solo día', () => {
+        const window = resolveShowModeWindow({ startDate: '2026-05-10', endDate: null }, prefs, NOW)
+        expect(window.isMultiDay).toBe(false)
+        expect(window.phase).toBe('during')
+    })
+})
+
+describe('resolveShowModeWindow — preferencias del usuario', () => {
+    it('respeta una ventana más larga que el default', () => {
+        const window = resolveShowModeWindow(
+            { startDate: '2026-05-30' },
+            { daysBefore: 30, daysAfter: 2 },
+            NOW
+        )
+        expect(window.phase).toBe('before')
+    })
+
+    it('con la ventana previa en cero, el modo recién arranca el día del show', () => {
+        const zeroBefore = { daysBefore: 0, daysAfter: 2 }
+        expect(resolveShowModeWindow({ startDate: '2026-05-11' }, zeroBefore, NOW).phase).toBe('upcoming')
+        expect(resolveShowModeWindow({ startDate: '2026-05-10' }, zeroBefore, NOW).phase).toBe('during')
+    })
+
+    it('con la ventana posterior en cero, cierra apenas termina el show', () => {
+        const zeroAfter = { daysBefore: 7, daysAfter: 0 }
+        expect(resolveShowModeWindow({ startDate: '2026-05-09' }, zeroAfter, NOW).phase).toBe('closed')
+    })
+
+    it('devuelve isActive solo en before/during/after', () => {
+        expect(resolveShowModeWindow({ startDate: '2026-05-12' }, prefs, NOW).isActive).toBe(true)
+        expect(resolveShowModeWindow({ startDate: '2026-05-10' }, prefs, NOW).isActive).toBe(true)
+        expect(resolveShowModeWindow({ startDate: '2026-05-09' }, prefs, NOW).isActive).toBe(true)
+        expect(resolveShowModeWindow({ startDate: '2026-06-30' }, prefs, NOW).isActive).toBe(false)
+        expect(resolveShowModeWindow({ startDate: '2026-01-01' }, prefs, NOW).isActive).toBe(false)
+    })
+
+    it('expone la configuración con la que se resolvió, para poder mostrarla en la UI', () => {
+        const window = resolveShowModeWindow({ startDate: '2026-05-12' }, prefs, NOW)
+        expect(window.preferences).toEqual(prefs)
+    })
+})
+
+describe('describeShowModePhase', () => {
+    function labelFor(startDate: string, endDate?: string | null) {
+        const window = resolveShowModeWindow({ startDate, endDate }, prefs, NOW)
+        return describeShowModePhase(window)
+    }
+
+    it('cuenta los días que faltan', () => {
+        expect(labelFor('2026-05-13')).toBe('Faltan 3 días')
+    })
+
+    it('dice "Es mañana" en singular en vez de "Falta 1 días"', () => {
+        expect(labelFor('2026-05-11')).toBe('Es mañana')
+    })
+
+    it('dice "Es hoy" para un show de un día que es hoy', () => {
+        expect(labelFor('2026-05-10')).toBe('Es hoy')
+    })
+
+    it('dice "Está pasando" para un festival en curso, que dura más de un día', () => {
+        expect(labelFor('2026-05-08', '2026-05-12')).toBe('Está pasando')
+    })
+
+    it('dice "Fue ayer" en vez de "Fue hace 1 días"', () => {
+        expect(labelFor('2026-05-09')).toBe('Fue ayer')
+    })
+
+    it('cuenta los días desde que terminó', () => {
+        expect(labelFor('2026-05-08')).toBe('Fue hace 2 días')
+    })
+
+    it('no devuelve etiqueta cuando el modo no está activo', () => {
+        expect(labelFor('2026-06-30')).toBeNull()
+        expect(labelFor('2026-01-01')).toBeNull()
+    })
+})

--- a/src/domains/showmode/window.ts
+++ b/src/domains/showmode/window.ts
@@ -1,0 +1,124 @@
+/**
+ * La ventana del "modo recital activo" (issue #9): cuándo la app se activa
+ * alrededor de un show y en qué fase está.
+ *
+ * Puro, sin Supabase: recibe el rango del show ya resuelto y las
+ * preferencias del usuario, y responde en qué fase cae la fecha de
+ * referencia. Todas las comparaciones pasan por `daysUntil`, o sea por día
+ * calendario en la timezone de la app — nunca por instantes exactos, por la
+ * misma razón que documenta src/core/lib/dates.ts (un show "de hoy" no
+ * puede leerse como pasado durante casi todo el día).
+ */
+import { daysUntil } from '@/src/core/lib/dates'
+import type { ShowModePreferences } from './preferences'
+
+/**
+ * - `upcoming`: falta más que la ventana configurada; el modo todavía no arrancó.
+ * - `before`: dentro de la ventana previa, el show no empezó.
+ * - `during`: el show está ocurriendo (para festivales, cualquier día entre
+ *   el primero y el último, inclusive).
+ * - `after`: ya terminó pero la ventana sigue abierta — el issue pide
+ *   explícitamente que "no corte en seco", para dar lugar a cargar gastos y
+ *   notas pendientes.
+ * - `closed`: la ventana posterior ya venció.
+ */
+export type ShowModePhase = 'upcoming' | 'before' | 'during' | 'after' | 'closed'
+
+/** Rango de días que ocupa un show. `endDate` solo difiere en festivales multi-día. */
+export interface ShowDateRange {
+    /** Primer día del show (o del festival). */
+    startDate: string
+    /** Último día; si falta o es anterior al primero, se asume un show de un solo día. */
+    endDate?: string | null
+}
+
+export interface ShowModeWindow {
+    phase: ShowModePhase
+    /** `true` en before/during/after — o sea, cuando la app "acompaña" el show. */
+    isActive: boolean
+    /** Días calendario hasta el primer día. 0 es hoy, negativo ya empezó. */
+    daysUntilStart: number
+    /** Días calendario desde el último día. 0 es hoy, negativo todavía no terminó. */
+    daysSinceEnd: number
+    /** Festival multi-día: el show ocupa más de una fecha. */
+    isMultiDay: boolean
+    /** La configuración con la que se resolvió esta ventana (para mostrarla en la UI). */
+    preferences: ShowModePreferences
+}
+
+/**
+ * Resuelve la fase de la ventana para un show.
+ *
+ * Festivales: el issue dice que "aplica igual a festivales multi-día,
+ * activándose desde el primer día". Por eso la ventana previa se mide contra
+ * `startDate` y la posterior contra `endDate` — un festival de tres días
+ * está `during` los tres días completos, no solo el primero.
+ *
+ * Un `endDate` inválido o anterior al comienzo se ignora en vez de romper:
+ * se trata como show de un día. Es data cargada a mano (festivals.end_date
+ * es nullable), así que no puede tumbar la ficha del evento.
+ */
+export function resolveShowModeWindow(
+    range: ShowDateRange,
+    preferences: ShowModePreferences,
+    reference: Date = new Date()
+): ShowModeWindow {
+    const startDate = range.startDate
+    const rawEnd = range.endDate
+    const daysUntilStart = daysUntil(startDate, reference)
+
+    // Un end_date anterior al start_date es data inconsistente: se descarta y
+    // el show pasa a valer por un solo día.
+    const endCandidate = rawEnd ?? startDate
+    const daysUntilEndCandidate = daysUntil(endCandidate, reference)
+    const usesRealEnd = daysUntilEndCandidate >= daysUntilStart
+    const daysUntilEnd = usesRealEnd ? daysUntilEndCandidate : daysUntilStart
+    const isMultiDay = usesRealEnd && daysUntilEnd > daysUntilStart
+
+    const daysSinceEnd = -daysUntilEnd
+
+    let phase: ShowModePhase
+    if (daysUntilStart > preferences.daysBefore) {
+        phase = 'upcoming'
+    } else if (daysUntilStart > 0) {
+        phase = 'before'
+    } else if (daysUntilEnd >= 0) {
+        phase = 'during'
+    } else if (daysSinceEnd <= preferences.daysAfter) {
+        phase = 'after'
+    } else {
+        phase = 'closed'
+    }
+
+    return {
+        phase,
+        isActive: phase === 'before' || phase === 'during' || phase === 'after',
+        daysUntilStart,
+        daysSinceEnd,
+        isMultiDay,
+        preferences,
+    }
+}
+
+/**
+ * Texto corto de la fase, para la banda del modo activo. Devuelve null
+ * cuando el modo no está activo — no hay nada que anunciar.
+ */
+export function describeShowModePhase(window: ShowModeWindow): string | null {
+    switch (window.phase) {
+        case 'before': {
+            const d = window.daysUntilStart
+            return d === 1 ? 'Es mañana' : `Faltan ${d} días`
+        }
+        case 'during':
+            return window.isMultiDay ? 'Está pasando' : 'Es hoy'
+        case 'after': {
+            // `after` solo se alcanza con el último día ya vencido, así que
+            // daysSinceEnd siempre es >= 1 acá.
+            const d = window.daysSinceEnd
+            return d === 1 ? 'Fue ayer' : `Fue hace ${d} días`
+        }
+        default:
+            return null
+    }
+}

--- a/src/domains/weather/icons.test.ts
+++ b/src/domains/weather/icons.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { weatherEmoji } from '@/src/domains/weather/icons'
+
+describe('weatherEmoji', () => {
+    it('la lluvia gana sobre el código WMO, igual que la regla de weather-service', () => {
+        expect(weatherEmoji(0, true)).toBe('🌧️')
+    })
+
+    it('mapea los códigos de cielo', () => {
+        expect(weatherEmoji(0, false)).toBe('☀️')
+        expect(weatherEmoji(1, false)).toBe('🌤️')
+        expect(weatherEmoji(2, false)).toBe('🌤️')
+        expect(weatherEmoji(3, false)).toBe('☁️')
+    })
+
+    it('mapea niebla, nieve y tormenta', () => {
+        expect(weatherEmoji(45, false)).toBe('🌫️')
+        expect(weatherEmoji(48, false)).toBe('🌫️')
+        expect(weatherEmoji(75, false)).toBe('❄️')
+        expect(weatherEmoji(95, false)).toBe('⛈️')
+    })
+
+    it('cae al termómetro sin código o con uno desconocido, en vez de romper', () => {
+        expect(weatherEmoji(null, false)).toBe('🌡️')
+        expect(weatherEmoji(64, false)).toBe('🌡️')
+    })
+})

--- a/src/domains/weather/icons.ts
+++ b/src/domains/weather/icons.ts
@@ -1,0 +1,27 @@
+/**
+ * Emoji para un código WMO de Open-Meteo.
+ *
+ * Vive en su propio módulo (y no dentro de EventWeather.tsx, donde nació, ni
+ * dentro de weather-service.ts) porque lo necesitan dos consumidores con
+ * requisitos incompatibles: el componente de servidor de la ficha del evento
+ * y la tarjeta recuerdo, que es un componente de cliente. weather-service.ts
+ * declara 'server-only', así que un cliente no puede importar nada de ahí en
+ * runtime — este archivo es puro y no toca la red.
+ */
+
+/**
+ * La lluvia gana sobre el código: el servicio decide "llovió" por
+ * precipitación horaria > 0mm y no por el weather_code (ver la cabecera de
+ * weather-service.ts), así que el ícono respeta esa misma señal.
+ */
+export function weatherEmoji(code: number | null, isRain: boolean): string {
+    if (isRain) return '🌧️'
+    if (code === null) return '🌡️'
+    if (code === 0) return '☀️'
+    if (code <= 2) return '🌤️'
+    if (code === 3) return '☁️'
+    if (code === 45 || code === 48) return '🌫️'
+    if (code >= 71 && code <= 86) return '❄️'
+    if (code >= 95) return '⛈️'
+    return '🌡️'
+}

--- a/supabase/migrations/20260823100000_show_mode.sql
+++ b/supabase/migrations/20260823100000_show_mode.sql
@@ -1,0 +1,146 @@
+-- "Modo recital activo" (issue #9): ventana de tiempo alrededor de un show
+-- durante la cual la app se activa para acompañar esa experiencia puntual.
+--
+-- Tres cosas nuevas, todas por usuario y con RLS de dueño:
+--   1. user_preferences — la ventana es configurable por usuario, no un
+--      número fijo para todos. Tabla genérica (no "show_mode_preferences")
+--      porque es el primer lugar del proyecto donde vive una preferencia y
+--      las que vengan después entran acá como columnas nuevas.
+--   2. checklist_template_items — LA plantilla base del usuario, una sola,
+--      configurada una vez y reusada en todos los shows.
+--   3. event_checklist_items + event_checklist_checks — lo puntual de cada
+--      show: ítems ad-hoc de ese show, y el estado tildado/destildado de los
+--      ítems que vienen de la plantilla.
+--
+-- Por qué el estado de la plantilla vive en su propia tabla y no se copian
+-- los ítems de la plantilla a cada show: si se copiaran, editar la plantilla
+-- no se reflejaría en los shows futuros ya creados, y borrar un ítem dejaría
+-- copias huérfanas por todos lados. Guardando solo el tilde por
+-- (evento, ítem de plantilla), la plantilla sigue siendo la única fuente de
+-- verdad del texto y el ON DELETE CASCADE limpia los tildes solo.
+
+-- ─── Preferencias del usuario ───────────────────────────────────────────────
+
+create table if not exists public.user_preferences (
+  id uuid references auth.users(id) on delete cascade not null primary key,
+  -- Defaults: 7 días antes / 2 días después. El issue no fija un número para
+  -- el "antes" (solo dice que es configurable); una semana es cuando uno
+  -- efectivamente empieza a resolver el show. Para el "después" el issue sí
+  -- da un rango explícito ("1-2 días"), así que se toma el techo: 2.
+  show_mode_days_before smallint not null default 7
+    check (show_mode_days_before between 0 and 60),
+  show_mode_days_after smallint not null default 2
+    check (show_mode_days_after between 0 and 14),
+  updated_at timestamptz default now()
+);
+
+alter table public.user_preferences enable row level security;
+
+create policy "Users see own preferences"
+  on public.user_preferences for select to authenticated
+  using (auth.uid() = id);
+
+create policy "Users insert own preferences"
+  on public.user_preferences for insert to authenticated
+  with check (auth.uid() = id);
+
+create policy "Users update own preferences"
+  on public.user_preferences for update to authenticated
+  using (auth.uid() = id)
+  with check (auth.uid() = id);
+
+-- ─── Plantilla base del checklist pre-show ──────────────────────────────────
+
+create table if not exists public.checklist_template_items (
+  id uuid default extensions.uuid_generate_v4() primary key,
+  user_id uuid references auth.users(id) on delete cascade not null,
+  label text not null check (char_length(trim(label)) > 0),
+  position smallint not null default 0,
+  created_at timestamptz default now()
+);
+
+alter table public.checklist_template_items enable row level security;
+
+create policy "Users see own checklist template"
+  on public.checklist_template_items for select to authenticated
+  using (auth.uid() = user_id);
+
+create policy "Users insert own checklist template"
+  on public.checklist_template_items for insert to authenticated
+  with check (auth.uid() = user_id);
+
+create policy "Users update own checklist template"
+  on public.checklist_template_items for update to authenticated
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create policy "Users delete own checklist template"
+  on public.checklist_template_items for delete to authenticated
+  using (auth.uid() = user_id);
+
+create index if not exists checklist_template_items_user_idx
+  on public.checklist_template_items (user_id, position, created_at);
+
+-- ─── Ítems puntuales de un show ─────────────────────────────────────────────
+
+create table if not exists public.event_checklist_items (
+  id uuid default extensions.uuid_generate_v4() primary key,
+  user_id uuid references auth.users(id) on delete cascade not null,
+  event_id uuid references public.events(id) on delete cascade not null,
+  label text not null check (char_length(trim(label)) > 0),
+  position smallint not null default 0,
+  checked boolean not null default false,
+  created_at timestamptz default now()
+);
+
+alter table public.event_checklist_items enable row level security;
+
+create policy "Users see own event checklist items"
+  on public.event_checklist_items for select to authenticated
+  using (auth.uid() = user_id);
+
+create policy "Users insert own event checklist items"
+  on public.event_checklist_items for insert to authenticated
+  with check (auth.uid() = user_id);
+
+create policy "Users update own event checklist items"
+  on public.event_checklist_items for update to authenticated
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create policy "Users delete own event checklist items"
+  on public.event_checklist_items for delete to authenticated
+  using (auth.uid() = user_id);
+
+create index if not exists event_checklist_items_user_event_idx
+  on public.event_checklist_items (user_id, event_id, position, created_at);
+
+-- ─── Tilde de un ítem de plantilla, por show ────────────────────────────────
+
+create table if not exists public.event_checklist_checks (
+  user_id uuid references auth.users(id) on delete cascade not null,
+  event_id uuid references public.events(id) on delete cascade not null,
+  template_item_id uuid references public.checklist_template_items(id) on delete cascade not null,
+  checked boolean not null default false,
+  updated_at timestamptz default now(),
+  primary key (user_id, event_id, template_item_id)
+);
+
+alter table public.event_checklist_checks enable row level security;
+
+create policy "Users see own template checks"
+  on public.event_checklist_checks for select to authenticated
+  using (auth.uid() = user_id);
+
+create policy "Users insert own template checks"
+  on public.event_checklist_checks for insert to authenticated
+  with check (auth.uid() = user_id);
+
+create policy "Users update own template checks"
+  on public.event_checklist_checks for update to authenticated
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create policy "Users delete own template checks"
+  on public.event_checklist_checks for delete to authenticated
+  using (auth.uid() = user_id);


### PR DESCRIPTION
Closes #9

Una ventana de tiempo alrededor de un show — antes y después — donde la app se activa para acompañar esa experiencia puntual, más allá de mostrar el evento en una lista.

## Qué se construyó

### Ventana de activación (configurable)

Nuevo dominio `src/domains/showmode/`. `resolveShowModeWindow` clasifica un show en cinco fases: `upcoming` / `before` / `during` / `after` / `closed`. La app "se activa" en las tres del medio.

Todas las comparaciones pasan por `daysUntil`, o sea por **día calendario en la timezone de la app**, nunca por instantes exactos — la misma razón que ya documenta `src/core/lib/dates.ts` (un show de hoy no puede leerse como pasado durante casi todo el día porque el servidor corre en UTC).

**Festivales multi-día**: la ventana previa se mide contra el primer día y la posterior contra el último, así que un festival de tres días está `during` los tres días completos. `getShowDateRange` resuelve si un evento es un día de un festival y, en ese caso, usa el rango del festival entero. Sin eso, el día 1 salía de la ventana antes de que el festival terminara.

### Checklist pre-show

Una plantilla base única configurada una vez, más ítems ad-hoc por show — exactamente como pide el issue.

**Decisión de esquema que vale la pena mirar en el review**: el tilde de un ítem de plantilla vive en su propia tabla (`event_checklist_checks`, PK `(user_id, event_id, template_item_id)`) en vez de copiar los ítems de la plantilla a cada show. Copiarlos habría significado que editar la plantilla no se reflejara en shows futuros ya creados, y que borrar un ítem dejara copias huérfanas por todos lados. Con esta forma la plantilla sigue siendo la única fuente de verdad del texto y el `ON DELETE CASCADE` limpia los tildes solo.

### Recordatorio post-show — dependencia del issue #6

El issue pide *un solo aviso* que junte todo lo pendiente (gastos + rating + reseña), no notificaciones sueltas. Ese aviso necesita un canal (mail/push) que **no existe**: el issue #6 está frenado esperando una decisión de tooling.

Lo que hay en este PR es la mitad que no depende de esa decisión:

- `computePendingForShow` — cálculo puro, agnóstico del canal, de qué falta cargar de un show.
- `PendingShowPrompt` — lo muestra **in-app**, en la propia ficha del evento, durante la ventana posterior, y declara la dependencia del #6 en la UI misma.

**No hay nada de infraestructura de mail ni de push en este PR.** Cuando el #6 se destrabe, el job que mande la notificación puede reusar `computePendingForShow` tal cual, sin reimplementar la regla.

Regla de producto que tomé: si el usuario todavía no confirmó que fue, ese es el **único** pendiente que se devuelve. Todo lo demás cuelga de esa respuesta, y listar cuatro pendientes cuando el primero puede invalidar a los otros tres es justo el ruido que el issue quiere evitar.

### Tarjeta recuerdo

Un stub de entrada digital, en papel (`ritual-paper*`, los mismos tokens que ya usa la reseña), con talón perforado: datos del show, la cuenta de esa noche con desglose por categoría, las comparaciones de gasto, el clima, el puntaje y un serial determinista derivado del uuid del evento.

Es el punto donde se componen los dos features de anoche: reusa `groupExpensesByCategory`, `formatChoripanComparison` y `adjustForInflation` del #7, y el clima del #8. No re-implementa ninguna de esas reglas.

**No es una función social** — el issue lo aclara y el PR lo respeta: no hay compartir, ni publicar, ni link público. Se descarga y listo. La parte social ("ver quién más va") quedó explícitamente fuera de esta etapa y no se tocó.

## La descarga como imagen

`toPng` de **`html-to-image`**, que **ya era dependencia del proyecto** desde la exportación de placas de Wrapped (`WrappedStories`). No se agregó ninguna librería nueva, así que no hubo nada que verificar contra la versión de React/Next. Se reusa el mismo patrón, incluido el `filter` que saca del render los nodos marcados con `data-no-export` (los botones no van adentro de la imagen). Se le agregó `pixelRatio: 2` para que el stub no salga borroso fuera de la app, que es todo el punto de descargarlo.

## Defaults que elegí, y por qué

| Default | Valor | Razón |
|---|---|---|
| Días antes | **7** | El issue no fija este número, solo dice que es configurable. Una semana es cuando uno efectivamente empieza a resolver un show (transporte, plata, qué llevar). |
| Días después | **2** | Acá el issue **sí** da un rango explícito, "1-2 días", así que tomé el techo: es el valor más generoso que el issue autoriza sin inventar nada. |
| Límites | 0–60 antes, 0–14 después | Validados en el `CHECK` de la tabla **y** clampeados en `clampShowModePreferences` antes de escribir, así una entrada fuera de rango nunca choca contra la constraint. |
| Tope de ítems | 50 por lista | No es una restricción de producto sino un freno a que un bug de cliente en un loop llene la tabla. |

Detalle: `null`/`undefined` se tratan como "no configurado" y caen al default, **no** como cero días — sin ese guard, `Number(null) === 0` apagaría medio modo recital en silencio.

Otra decisión: la tarjeta recuerdo se ofrece incluso con pendientes (avisando cuáles) en vez de esconderse hasta que esté todo perfecto. El clima queda fuera de la condición de "listo" a propósito — no lo carga el usuario, lo trae Open-Meteo, y puede faltar por sede sin coordenadas; bloquear el recuerdo por eso sería castigar al usuario por algo que no puede resolver.

## Esquema

`supabase/migrations/20260823100000_show_mode.sql` — cuatro tablas, todas con RLS de dueño (`auth.uid()`) y políticas `to authenticated`, siguiendo la convención de `20260721000000_fase0_security_blockers.sql`:

- `user_preferences` — primer lugar del proyecto donde vive una preferencia. Tabla genérica a propósito: las que vengan después entran como columnas nuevas.
- `checklist_template_items` — la plantilla base única.
- `event_checklist_items` — ítems ad-hoc de un show.
- `event_checklist_checks` — tilde de un ítem de plantilla, por show.

## Verificación

Los tres comandos reales de `.github/workflows/ci.yml`, todos en verde:

- `npm run lint` — 0 errores (quedan 2 warnings preexistentes en `public/tickets/three-d-stage.js`, ajenos a este PR).
- `npx tsc --noEmit` — limpio.
- `npm test` — **870 tests en 106 archivos, todos pasando**. 172 son nuevos, en 13 archivos.

Además, `npm run build` compila y `/modo-recital` aparece registrada en el manifiesto de rutas (el build no está en CI porque exige credenciales reales de Supabase; se corrió con valores dummy solo para validar la compilación).

La cobertura nueva incluye los bordes que importan: cada límite de la ventana día por día, festivales con `end_date` nulo o anterior al `start_date`, timestamps que cruzan el día en ART, tildes que apuntan a ítems de plantilla borrados, degradación silenciosa de cada lectura ante un error de Supabase, y que cada action escriba siempre contra el `user_id` de la sesión y nunca contra uno que venga del cliente.

## Fuera de alcance (deliberado)

- La capa social del issue #5 — "ver quién más va" fue descartada explícitamente de esta etapa.
- Infraestructura de notificaciones por mail/push — issue #6, bloqueado.
