### PR TITLE
test(expenses): restore the coverage dropped by the GraphQL migration (#44)

### DIFF
--- a/src/domains/expenses/components/DeleteExpenseAction.test.tsx
+++ b/src/domains/expenses/components/DeleteExpenseAction.test.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { Expense } from '@/src/core/types'
+
+const push = vi.fn()
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push }),
+}))
+
+const deleteExpenseMock = vi.fn()
+vi.mock('urql', async () => {
+  const actual = await vi.importActual<typeof import('urql')>('urql')
+  return { ...actual, useMutation: () => [{ fetching: false }, deleteExpenseMock] }
+})
+
+import { DeleteExpenseAction } from '@/src/domains/expenses/components/DeleteExpenseAction'
+
+const expense = { id: 'x1', amount: 1500, category: 'Entrada' } as Expense
+
+/**
+ * The expense detail page's delete used to be a Server Action that ended in
+ * `redirect('/expenses')`. After the GraphQL migration (#44) the mutation
+ * returns to the client and this wrapper does the navigating, so the
+ * redirect assertion the deleted actions.test.ts carried lives here now.
+ */
+describe('DeleteExpenseAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    deleteExpenseMock.mockResolvedValue({ data: { deleteExpense: {} } })
+  })
+
+  it('fires the delete mutation with the expense id and returns to the list on success', async () => {
+    render(<DeleteExpenseAction expense={expense} />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Eliminar gasto' }))
+    await userEvent.click(screen.getByRole('button', { name: /Sí, eliminar/ }))
+
+    await waitFor(() => {
+      expect(deleteExpenseMock).toHaveBeenCalledWith({ id: 'x1' })
+    })
+    await waitFor(() => expect(push).toHaveBeenCalledWith('/expenses'))
+  })
+
+  it('surfaces the error and stays on the page when the deletion is rejected', async () => {
+    deleteExpenseMock.mockResolvedValue({
+      data: { deleteExpense: { error: 'No tenés permiso para realizar esta acción.' } },
+    })
+    render(<DeleteExpenseAction expense={expense} />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Eliminar gasto' }))
+    await userEvent.click(screen.getByRole('button', { name: /Sí, eliminar/ }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('No tenés permiso para realizar esta acción.')
+    })
+    expect(push).not.toHaveBeenCalled()
+  })
+
+  it('does not fire the mutation until the confirmation is accepted', async () => {
+    render(<DeleteExpenseAction expense={expense} />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Eliminar gasto' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Cancelar' }))
+
+    expect(deleteExpenseMock).not.toHaveBeenCalled()
+    expect(push).not.toHaveBeenCalled()
+  })
+})

--- a/src/domains/expenses/components/EventExpensesPanel.test.tsx
+++ b/src/domains/expenses/components/EventExpensesPanel.test.tsx
@@ -1,0 +1,221 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { Expense } from '@/src/core/types'
+
+// El panel dejó de recibir las escrituras por prop: dispara las tres
+// mutations de gastos directo, así que los dobles se enganchan en
+// useMutation y se enrutan por el nombre de la operación.
+const createExpenseMock = vi.fn()
+const updateExpenseMock = vi.fn()
+const deleteExpenseMock = vi.fn()
+
+vi.mock('urql', async () => {
+  const actual = await vi.importActual<typeof import('urql')>('urql')
+  return {
+    ...actual,
+    useMutation: (doc: { definitions?: Array<{ name?: { value?: string } }> }) => {
+      const name = doc.definitions?.[0]?.name?.value
+      if (name === 'CreateExpense') return [{ fetching: false }, createExpenseMock]
+      if (name === 'UpdateExpense') return [{ fetching: false }, updateExpenseMock]
+      return [{ fetching: false }, deleteExpenseMock]
+    },
+  }
+})
+
+import { EventExpensesPanel } from '@/src/domains/expenses/components/EventExpensesPanel'
+
+const baseExpenses: Expense[] = [
+  { id: 'x1', user_id: 'u1', amount: 5000, category: 'Comida y bebida', note: null, event_id: 'ev-1', date: '2026-05-01' },
+  { id: 'x2', user_id: 'u1', amount: 3000, category: 'Comida y bebida', note: 'Birra', event_id: 'ev-1', date: '2026-05-01' },
+  { id: 'x3', user_id: 'u1', amount: 15000, category: 'Entrada', note: null, event_id: 'ev-1', date: '2026-05-01' },
+]
+
+function renderPanel(overrides: Partial<React.ComponentProps<typeof EventExpensesPanel>> = {}) {
+  return render(
+    <EventExpensesPanel
+      eventId="ev-1"
+      initialExpenses={baseExpenses}
+      defaultDate="2026-05-01"
+      spendEstimate={null}
+      detailHref="/events/ev-1/gastos"
+      {...overrides}
+    />
+  )
+}
+
+describe('EventExpensesPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows the total, item count and grouped categories ("Comida y bebida: $8.000 · 2 ítems")', () => {
+    renderPanel()
+
+    expect(screen.getByText('$23.000')).toBeInTheDocument()
+    expect(screen.getByText(/3 ítems/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Comida y bebida: \$8\.000 · 2 ítems/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Entrada: \$15\.000 · 1 ítem$/ })).toBeInTheDocument()
+  })
+
+  it('shows the choripán comparison for the total', () => {
+    renderPanel()
+    // total 23000 / 5000 reference = 4.6 -> rounded to one decimal
+    expect(screen.getByText(/esto son 4,6 choripanes/)).toBeInTheDocument()
+  })
+
+  it('shows an empty state and no groups when there are no expenses', () => {
+    renderPanel({ initialExpenses: [] })
+    expect(screen.getByText('Todavía no cargaste gastos para este show.')).toBeInTheDocument()
+    expect(screen.getByText(/0 ítems/)).toBeInTheDocument()
+  })
+
+  it('links to the full breakdown view', () => {
+    renderPanel()
+    expect(screen.getByRole('link', { name: /Ver desglose completo/ })).toHaveAttribute('href', '/events/ev-1/gastos')
+  })
+
+  it('shows the soft suggestion as informational text, never as a warning, when given an estimate', () => {
+    renderPanel({ spendEstimate: { averageTotal: 12000, eventsConsidered: 3 } })
+    const hint = screen.getByText(/Sueles gastar un promedio de \$12\.000/)
+    expect(hint).toHaveTextContent('solo de referencia, no un límite')
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('renders no soft suggestion when there is no estimate', () => {
+    renderPanel({ spendEstimate: null })
+    expect(screen.queryByText(/Sueles gastar/)).not.toBeInTheDocument()
+  })
+
+  it('expands and collapses a category group on click, revealing individual expenses only while expanded', async () => {
+    renderPanel()
+
+    expect(screen.queryByText('Birra')).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: /Comida y bebida: \$8\.000/ }))
+    expect(screen.getByText('Birra')).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: /Comida y bebida: \$8\.000/ }))
+    expect(screen.queryByText('Birra')).not.toBeInTheDocument()
+  })
+
+  it('quick-add: toggling it in, adding an expense inserts it, updates the total and groups, and expands its category', async () => {
+    createExpenseMock.mockResolvedValue({ data: { createExpense: { id: 'x4' } } })
+    renderPanel()
+
+    await userEvent.click(screen.getByRole('button', { name: '+ Cargar gasto' }))
+    await userEvent.type(screen.getByLabelText('Monto'), '2000')
+    await userEvent.selectOptions(screen.getByLabelText('Categoría'), 'Merch')
+    await userEvent.click(screen.getByRole('button', { name: 'Guardar gasto' }))
+
+    await waitFor(() => {
+      expect(createExpenseMock).toHaveBeenCalledWith({
+        input: expect.objectContaining({ amount: 2000, category: 'Merch', eventId: 'ev-1', date: '2026-05-01' }),
+      })
+    })
+
+    // Total grows from $23.000 to $25.000, and the new category shows up expanded.
+    expect(screen.getByText('$25.000')).toBeInTheDocument()
+    expect(screen.getByText(/4 ítems/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Merch: \$2\.000 · 1 ítem$/ })).toBeInTheDocument()
+    // Quick-add form closes after a successful add.
+    expect(screen.queryByRole('button', { name: 'Guardar gasto' })).not.toBeInTheDocument()
+  })
+
+  it('quick-add: a rejected insert leaves the total and the item count untouched', async () => {
+    createExpenseMock.mockResolvedValue({
+      data: { createExpense: { error: 'El monto debe ser mayor a 0.' } },
+    })
+    renderPanel()
+
+    await userEvent.click(screen.getByRole('button', { name: '+ Cargar gasto' }))
+    await userEvent.type(screen.getByLabelText('Monto'), '2000')
+    await userEvent.selectOptions(screen.getByLabelText('Categoría'), 'Merch')
+    await userEvent.click(screen.getByRole('button', { name: 'Guardar gasto' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('El monto debe ser mayor a 0.')
+    })
+    expect(screen.getByText('$23.000')).toBeInTheDocument()
+    expect(screen.getByText(/3 ítems/)).toBeInTheDocument()
+  })
+
+  it('quick-add: "Cancelar" hides the form without inserting anything', async () => {
+    renderPanel()
+
+    await userEvent.click(screen.getByRole('button', { name: '+ Cargar gasto' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Cancelar' }))
+
+    expect(createExpenseMock).not.toHaveBeenCalled()
+    expect(screen.getByRole('button', { name: '+ Cargar gasto' })).toBeInTheDocument()
+  })
+
+  it('inline edit: editing an expense updates it in place without any navigation', async () => {
+    updateExpenseMock.mockResolvedValue({ data: { updateExpense: {} } })
+    renderPanel()
+
+    await userEvent.click(screen.getByRole('button', { name: /Entrada: \$15\.000/ }))
+    await userEvent.click(screen.getByRole('button', { name: 'Editar' }))
+
+    const amountInput = screen.getByLabelText('Monto')
+    await userEvent.clear(amountInput)
+    await userEvent.type(amountInput, '16000')
+    await userEvent.click(screen.getByRole('button', { name: 'Guardar' }))
+
+    await waitFor(() => {
+      expect(updateExpenseMock).toHaveBeenCalledWith({
+        id: 'x3',
+        input: { amount: 16000, category: 'Entrada', note: '' },
+      })
+    })
+    expect(screen.getByText('$24.000')).toBeInTheDocument() // new grand total
+  })
+
+  it('inline edit: a rejected update keeps the old amount and shows the error', async () => {
+    updateExpenseMock.mockResolvedValue({
+      data: { updateExpense: { error: 'El monto debe ser mayor a 0.' } },
+    })
+    renderPanel()
+
+    await userEvent.click(screen.getByRole('button', { name: /Entrada: \$15\.000/ }))
+    await userEvent.click(screen.getByRole('button', { name: 'Editar' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Guardar' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('El monto debe ser mayor a 0.')
+    })
+    expect(screen.getByText('$23.000')).toBeInTheDocument()
+  })
+
+  it('inline delete: confirming removal takes the expense out of its group and out of the total', async () => {
+    deleteExpenseMock.mockResolvedValue({ data: { deleteExpense: {} } })
+    renderPanel()
+
+    await userEvent.click(screen.getByRole('button', { name: /Entrada: \$15\.000/ }))
+    await userEvent.click(screen.getByRole('button', { name: 'Eliminar gasto' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Sí, eliminar' }))
+
+    await waitFor(() => {
+      expect(deleteExpenseMock).toHaveBeenCalledWith({ id: 'x3' })
+    })
+    expect(screen.getByText('$8.000')).toBeInTheDocument()
+    expect(screen.queryByText(/Entrada:/)).not.toBeInTheDocument()
+  })
+
+  it('inline delete: a failed removal keeps the expense and shows the error', async () => {
+    deleteExpenseMock.mockResolvedValue({
+      data: { deleteExpense: { error: 'No se pudo eliminar.' } },
+    })
+    renderPanel()
+
+    await userEvent.click(screen.getByRole('button', { name: /Entrada: \$15\.000/ }))
+    await userEvent.click(screen.getByRole('button', { name: 'Eliminar gasto' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Sí, eliminar' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('No se pudo eliminar.')
+    })
+    expect(screen.getByText('$23.000')).toBeInTheDocument()
+  })
+})

--- a/src/domains/expenses/components/ExpenseForm.test.tsx
+++ b/src/domains/expenses/components/ExpenseForm.test.tsx
@@ -1,0 +1,207 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { Expense, EventWithRelations } from '@/src/core/types'
+
+const push = vi.fn()
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push }),
+}))
+
+// Las escrituras dejaron de llegar por prop: el form dispara las mutations
+// directo, así que el doble se engancha en useMutation y se enruta por el
+// nombre de la operación.
+const createExpenseMock = vi.fn()
+const updateExpenseMock = vi.fn()
+
+vi.mock('urql', async () => {
+  const actual = await vi.importActual<typeof import('urql')>('urql')
+  return {
+    ...actual,
+    useMutation: (doc: { definitions?: Array<{ name?: { value?: string } }> }) =>
+      doc.definitions?.[0]?.name?.value === 'CreateExpense'
+        ? [{ fetching: false }, createExpenseMock]
+        : [{ fetching: false }, updateExpenseMock],
+  }
+})
+
+import { ExpenseForm } from '@/src/domains/expenses/components/ExpenseForm'
+
+const events = [{ id: 'e1', name: 'Show en Niceto', date: '2024-05-01' }] as EventWithRelations[]
+
+describe('ExpenseForm — create mode', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    createExpenseMock.mockResolvedValue({ data: { createExpense: { id: 'x-new' } } })
+  })
+
+  it('submits the entered fields, mapping blank optionals to undefined', async () => {
+    render(<ExpenseForm events={events} />)
+
+    await userEvent.type(screen.getByLabelText(/Monto/), '1500')
+    await userEvent.selectOptions(screen.getByLabelText(/Categoría/), 'Entrada')
+    await userEvent.click(screen.getByRole('button', { name: 'Agregar gasto' }))
+
+    await waitFor(() => {
+      expect(createExpenseMock).toHaveBeenCalledWith({
+        input: expect.objectContaining({
+          amount: 1500,
+          category: 'Entrada',
+          note: undefined,
+          eventId: undefined,
+        }),
+      })
+    })
+  })
+
+  it('links the expense to the selected event', async () => {
+    render(<ExpenseForm events={events} />)
+
+    await userEvent.type(screen.getByLabelText(/Monto/), '1500')
+    await userEvent.selectOptions(screen.getByLabelText(/Categoría/), 'Entrada')
+    await userEvent.selectOptions(screen.getByLabelText(/Recital asociado/), 'e1')
+    await userEvent.click(screen.getByRole('button', { name: 'Agregar gasto' }))
+
+    await waitFor(() => {
+      expect(createExpenseMock).toHaveBeenCalledWith({
+        input: expect.objectContaining({ eventId: 'e1' }),
+      })
+    })
+  })
+
+  it('sends the date field, defaulted to today when the user leaves it alone', async () => {
+    render(<ExpenseForm events={events} />)
+
+    await userEvent.type(screen.getByLabelText(/Monto/), '1500')
+    await userEvent.selectOptions(screen.getByLabelText(/Categoría/), 'Entrada')
+    await userEvent.click(screen.getByRole('button', { name: 'Agregar gasto' }))
+
+    await waitFor(() => {
+      const { input } = createExpenseMock.mock.calls[0][0]
+      expect(input.date).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+    })
+  })
+
+  // Sustituye al `redirect('/expenses')` que hacía la Server Action antes de
+  // la migración a GraphQL: ahora navega el cliente.
+  it('navigates to the expenses list once creation succeeds', async () => {
+    render(<ExpenseForm events={events} />)
+
+    await userEvent.type(screen.getByLabelText(/Monto/), '1500')
+    await userEvent.selectOptions(screen.getByLabelText(/Categoría/), 'Entrada')
+    await userEvent.click(screen.getByRole('button', { name: 'Agregar gasto' }))
+
+    await waitFor(() => expect(push).toHaveBeenCalledWith('/expenses'))
+  })
+
+  it('shows the error and re-enables the form when creation fails', async () => {
+    createExpenseMock.mockResolvedValue({
+      data: { createExpense: { error: 'El monto debe ser mayor a 0.' } },
+    })
+    render(<ExpenseForm events={events} />)
+
+    await userEvent.type(screen.getByLabelText(/Monto/), '1500')
+    await userEvent.selectOptions(screen.getByLabelText(/Categoría/), 'Entrada')
+    await userEvent.click(screen.getByRole('button', { name: 'Agregar gasto' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('El monto debe ser mayor a 0.')
+    })
+    expect(screen.getByRole('button', { name: 'Agregar gasto' })).toBeEnabled()
+    expect(push).not.toHaveBeenCalled()
+  })
+
+  it('links "Cancelar" to the expenses list', () => {
+    render(<ExpenseForm events={events} />)
+    expect(screen.getByRole('link', { name: 'Cancelar' })).toHaveAttribute('href', '/expenses')
+  })
+})
+
+describe('ExpenseForm — edit mode', () => {
+  const expense = {
+    id: 'x1',
+    amount: 2000,
+    category: 'Comida y bebida',
+    note: 'Cena post-show',
+    date: '2024-05-01',
+    event_id: 'e1',
+  } as Expense
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    updateExpenseMock.mockResolvedValue({ data: { updateExpense: {} } })
+  })
+
+  it('pre-fills the form fields from the existing expense', () => {
+    render(<ExpenseForm events={events} expense={expense} />)
+
+    expect(screen.getByLabelText(/Monto/)).toHaveValue(2000)
+    expect(screen.getByLabelText('Nota')).toHaveValue('Cena post-show')
+    expect(screen.getByLabelText(/Categoría/)).toHaveValue('Comida y bebida')
+    expect(screen.getByLabelText(/Recital asociado/)).toHaveValue('e1')
+    expect(screen.getByRole('button', { name: 'Guardar cambios' })).toBeInTheDocument()
+  })
+
+  it('calls the update mutation with the expense id on submit', async () => {
+    render(<ExpenseForm events={events} expense={expense} />)
+
+    await userEvent.clear(screen.getByLabelText(/Monto/))
+    await userEvent.type(screen.getByLabelText(/Monto/), '2500')
+    await userEvent.click(screen.getByRole('button', { name: 'Guardar cambios' }))
+
+    await waitFor(() => {
+      expect(updateExpenseMock).toHaveBeenCalledWith({
+        id: 'x1',
+        input: expect.objectContaining({ amount: 2500 }),
+      })
+    })
+    expect(createExpenseMock).not.toHaveBeenCalled()
+  })
+
+  // Sustituye al `redirect('/expenses/x1')` de la Server Action de edición.
+  it('navigates to the expense detail once the update succeeds', async () => {
+    render(<ExpenseForm events={events} expense={expense} />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Guardar cambios' }))
+
+    await waitFor(() => expect(push).toHaveBeenCalledWith('/expenses/x1'))
+  })
+
+  it('shows the error and re-enables the form when the update fails', async () => {
+    updateExpenseMock.mockResolvedValue({
+      data: { updateExpense: { error: 'Gasto inválido.' } },
+    })
+    render(<ExpenseForm events={events} expense={expense} />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Guardar cambios' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('Gasto inválido.')
+    })
+    expect(screen.getByRole('button', { name: 'Guardar cambios' })).toBeEnabled()
+    expect(push).not.toHaveBeenCalled()
+  })
+
+  it('links "Cancelar" to the expense detail page', () => {
+    render(<ExpenseForm events={events} expense={expense} />)
+    expect(screen.getByRole('link', { name: 'Cancelar' })).toHaveAttribute('href', '/expenses/x1')
+  })
+
+  // El detalle y el editor leen la fila por GraphQL, que expone `eventId`;
+  // el resto de la app todavía pasa la fila snake_case de Supabase. El form
+  // tiene que pre-seleccionar el recital en los dos casos.
+  it('pre-selects the linked event when the row came from GraphQL (camelCase eventId)', () => {
+    const graphQLExpense = {
+      id: 'x1',
+      amount: 2000,
+      category: 'Entrada',
+      note: null,
+      date: '2024-05-01',
+      eventId: 'e1',
+    } as unknown as Expense
+    render(<ExpenseForm events={events} expense={graphQLExpense} />)
+
+    expect(screen.getByLabelText(/Recital asociado/)).toHaveValue('e1')
+  })
+})

--- a/src/domains/expenses/components/ExpenseQuickAdd.test.tsx
+++ b/src/domains/expenses/components/ExpenseQuickAdd.test.tsx
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ExpenseQuickAdd } from '@/src/domains/expenses/components/ExpenseQuickAdd'
+
+/**
+ * The quick-add still receives its write as a prop — EventExpensesPanel owns
+ * the urql mutation and hands down a plain async function — so the double is
+ * a bare vi.fn() here. What changed with the GraphQL migration (#44) is the
+ * payload key: the panel forwards this object straight into
+ * ExpenseCreateInput, so the field is `eventId`, not `event_id`.
+ */
+function renderQuickAdd(
+  overrides: Partial<React.ComponentProps<typeof ExpenseQuickAdd>> = {}
+) {
+  return render(
+    <ExpenseQuickAdd
+      eventId="ev-1"
+      defaultDate="2026-05-01"
+      insertExpense={vi.fn()}
+      onAdded={vi.fn()}
+      onCancel={vi.fn()}
+      {...overrides}
+    />
+  )
+}
+
+describe('ExpenseQuickAdd', () => {
+  it('submits amount + category + the event id + the default date, with note omitted by default', async () => {
+    const insertExpense = vi.fn().mockResolvedValue({ id: 'exp-1' })
+    renderQuickAdd({ insertExpense })
+
+    await userEvent.type(screen.getByLabelText('Monto'), '1500')
+    await userEvent.selectOptions(screen.getByLabelText('Categoría'), 'Entrada')
+    await userEvent.click(screen.getByRole('button', { name: 'Guardar gasto' }))
+
+    await waitFor(() => {
+      expect(insertExpense).toHaveBeenCalledWith({
+        amount: 1500,
+        category: 'Entrada',
+        note: undefined,
+        eventId: 'ev-1',
+        date: '2026-05-01',
+      })
+    })
+  })
+
+  it('has no date input — the date is silently defaulted, never asked of the user', () => {
+    renderQuickAdd()
+    expect(screen.queryByLabelText(/fecha/i)).not.toBeInTheDocument()
+  })
+
+  it('keeps the note field collapsed until "+ Agregar nota" is clicked, then includes it trimmed', async () => {
+    const insertExpense = vi.fn().mockResolvedValue({ id: 'exp-1' })
+    renderQuickAdd({ insertExpense })
+
+    expect(screen.queryByPlaceholderText('Nota (opcional)')).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: '+ Agregar nota' }))
+    await userEvent.type(screen.getByPlaceholderText('Nota (opcional)'), '  Uber ida y vuelta  ')
+    await userEvent.type(screen.getByLabelText('Monto'), '2000')
+    await userEvent.selectOptions(screen.getByLabelText('Categoría'), 'Transporte')
+    await userEvent.click(screen.getByRole('button', { name: 'Guardar gasto' }))
+
+    await waitFor(() => {
+      expect(insertExpense).toHaveBeenCalledWith(
+        expect.objectContaining({ note: 'Uber ida y vuelta' })
+      )
+    })
+  })
+
+  it('calls onAdded with the new expense on success', async () => {
+    const insertExpense = vi.fn().mockResolvedValue({ id: 'exp-1' })
+    const onAdded = vi.fn()
+    renderQuickAdd({ insertExpense, onAdded })
+
+    await userEvent.type(screen.getByLabelText('Monto'), '1500')
+    await userEvent.selectOptions(screen.getByLabelText('Categoría'), 'Merch')
+    await userEvent.click(screen.getByRole('button', { name: 'Guardar gasto' }))
+
+    await waitFor(() => {
+      expect(onAdded).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'exp-1', amount: 1500, category: 'Merch', event_id: 'ev-1', date: '2026-05-01' })
+      )
+    })
+  })
+
+  it('shows the error and does not call onAdded when the insert fails', async () => {
+    const insertExpense = vi.fn().mockResolvedValue({ error: 'El monto debe ser mayor a 0.' })
+    const onAdded = vi.fn()
+    renderQuickAdd({ insertExpense, onAdded })
+
+    await userEvent.type(screen.getByLabelText('Monto'), '1500')
+    await userEvent.selectOptions(screen.getByLabelText('Categoría'), 'Merch')
+    await userEvent.click(screen.getByRole('button', { name: 'Guardar gasto' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('El monto debe ser mayor a 0.')
+    })
+    expect(onAdded).not.toHaveBeenCalled()
+  })
+
+  // Una mutation que vuelve sin id ni error dejaría la fila fantasma en la
+  // lista local del panel, sin nada que borrar después.
+  it('refuses to report an add whose mutation came back without an id', async () => {
+    const insertExpense = vi.fn().mockResolvedValue({})
+    const onAdded = vi.fn()
+    renderQuickAdd({ insertExpense, onAdded })
+
+    await userEvent.type(screen.getByLabelText('Monto'), '1500')
+    await userEvent.selectOptions(screen.getByLabelText('Categoría'), 'Merch')
+    await userEvent.click(screen.getByRole('button', { name: 'Guardar gasto' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('No se pudo registrar el gasto.')
+    })
+    expect(onAdded).not.toHaveBeenCalled()
+  })
+
+  it('calls onCancel when "Cancelar" is clicked', async () => {
+    const onCancel = vi.fn()
+    renderQuickAdd({ onCancel })
+
+    await userEvent.click(screen.getByRole('button', { name: 'Cancelar' }))
+    expect(onCancel).toHaveBeenCalled()
+  })
+})

--- a/src/domains/expenses/service.test.ts
+++ b/src/domains/expenses/service.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
+const mockCreateClient = vi.fn()
+
 vi.mock('./data', () => ({
   getExpenses: vi.fn(),
   getExpenseById: vi.fn(),
@@ -12,8 +14,17 @@ vi.mock('@/src/domains/events/data', () => ({
   getEvents: vi.fn(),
 }))
 
+vi.mock('@/src/core/lib/supabase/server', () => ({
+  createClient: () => mockCreateClient(),
+}))
+
+vi.mock('@/src/core/auth/session', () => ({
+  getCurrentUserId: vi.fn(),
+}))
+
 import { getExpenses, getExpenseById, getExpensesForEvent, getExpensesSummary, getVenueArtistSpendEstimate } from './data'
 import { getEvents } from '@/src/domains/events/data'
+import { getCurrentUserId } from '@/src/core/auth/session'
 import {
   listExpenses,
   findExpenseById,
@@ -21,8 +32,28 @@ import {
   summarizeExpenses,
   listEventOptionsForExpensePicker,
   estimateSpendForEvent,
+  insertExpense,
+  modifyExpense,
+  removeExpense,
 } from './service'
 import type { EventWithRelations } from '@/src/core/types'
+
+const VALID_EXPENSE_ID = '11111111-1111-1111-1111-111111111111'
+const VALID_EVENT_ID = '22222222-2222-2222-2222-222222222222'
+
+function makeQueryBuilder(result: { data: unknown; error: unknown }) {
+  const builder: Record<string, unknown> = {}
+  const chain = () => builder
+  builder.insert = vi.fn(chain)
+  builder.update = vi.fn(chain)
+  builder.delete = vi.fn(chain)
+  builder.eq = vi.fn(chain)
+  builder.select = vi.fn(chain)
+  builder.single = vi.fn(() => Promise.resolve(result))
+  builder.then = (onFulfilled: (v: unknown) => unknown, onRejected?: (e: unknown) => unknown) =>
+    Promise.resolve(result).then(onFulfilled, onRejected)
+  return builder
+}
 
 /**
  * This service is the seam introduced for issue #25: Server Components and
@@ -108,5 +139,253 @@ describe('expenses service (use-case layer)', () => {
     await estimateSpendForEvent(event, 'u1')
 
     expect(getVenueArtistSpendEstimate).toHaveBeenCalledWith('u1', null, [], 'ev-1')
+  })
+})
+
+/**
+ * Write side. These use cases lived in actions.ts until the GraphQL
+ * migration (#44) folded them into this module: the Server Actions that
+ * wrapped them — createExpense/updateExpense/deleteExpense, which redirected
+ * — are gone, and the GraphQL mutations now call these directly. The
+ * validation, sanitization and user-scoping rules did not change, so they
+ * are asserted here at their new home.
+ *
+ * The redirect assertions those Server Actions used to carry now belong to
+ * the components that navigate instead — ExpenseForm.test.tsx for
+ * create/edit and DeleteExpenseAction.test.tsx for delete.
+ */
+describe('insertExpense', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getCurrentUserId).mockResolvedValue('user-1')
+  })
+
+  it('requires a logged-in user', async () => {
+    vi.mocked(getCurrentUserId).mockResolvedValue(null)
+
+    const result = await insertExpense({ amount: 100, category: 'Entrada', date: '2024-01-01' })
+
+    expect(result.error).toBeTruthy()
+    expect(mockCreateClient).not.toHaveBeenCalled()
+  })
+
+  it('rejects a zero or negative amount', async () => {
+    const zero = await insertExpense({ amount: 0, category: 'Entrada', date: '2024-01-01' })
+    expect(zero.error).toBeTruthy()
+
+    const negative = await insertExpense({ amount: -5, category: 'Entrada', date: '2024-01-01' })
+    expect(negative.error).toBeTruthy()
+
+    expect(mockCreateClient).not.toHaveBeenCalled()
+  })
+
+  it('rejects an amount over the sanity cap', async () => {
+    const result = await insertExpense({ amount: 20_000_000, category: 'Entrada', date: '2024-01-01' })
+
+    expect(result.error).toBeTruthy()
+    expect(mockCreateClient).not.toHaveBeenCalled()
+  })
+
+  it('rejects a missing category', async () => {
+    const result = await insertExpense({ amount: 100, category: '  ', date: '2024-01-01' })
+
+    expect(result.error).toBeTruthy()
+    expect(mockCreateClient).not.toHaveBeenCalled()
+  })
+
+  it('rejects a missing or unparseable date', async () => {
+    const missing = await insertExpense({ amount: 100, category: 'Entrada', date: '' })
+    expect(missing.error).toBeTruthy()
+
+    const bad = await insertExpense({ amount: 100, category: 'Entrada', date: 'not-a-date' })
+    expect(bad.error).toBeTruthy()
+
+    expect(mockCreateClient).not.toHaveBeenCalled()
+  })
+
+  it('rejects an invalid event_id when provided', async () => {
+    const result = await insertExpense({
+      amount: 100,
+      category: 'Entrada',
+      date: '2024-01-01',
+      event_id: 'not-a-uuid',
+    })
+
+    expect(result.error).toBeTruthy()
+    expect(mockCreateClient).not.toHaveBeenCalled()
+  })
+
+  it('inserts trimmed values scoped to the current user, and returns the new id', async () => {
+    const builder = makeQueryBuilder({ data: { id: 'expense-1' }, error: null })
+    mockCreateClient.mockReturnValue(Promise.resolve({ from: vi.fn(() => builder) }))
+
+    const result = await insertExpense({
+      amount: 150,
+      category: '  Entrada  ',
+      note: '  Con descuento  ',
+      date: '2024-01-01',
+      event_id: VALID_EVENT_ID,
+    })
+
+    expect(builder.insert).toHaveBeenCalledWith({
+      user_id: 'user-1',
+      amount: 150,
+      category: 'Entrada',
+      note: 'Con descuento',
+      event_id: VALID_EVENT_ID,
+      date: '2024-01-01',
+    })
+    expect(result).toEqual({ id: 'expense-1' })
+  })
+
+  it('stores a null event_id and note when the expense carries neither', async () => {
+    const builder = makeQueryBuilder({ data: { id: 'expense-1' }, error: null })
+    mockCreateClient.mockReturnValue(Promise.resolve({ from: vi.fn(() => builder) }))
+
+    await insertExpense({ amount: 150, category: 'Entrada', date: '2024-01-01' })
+
+    expect(builder.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ event_id: null, note: null })
+    )
+  })
+
+  it('returns a sanitized error when the insert fails, never the raw DB message', async () => {
+    const builder = makeQueryBuilder({ data: null, error: { message: 'boom' } })
+    mockCreateClient.mockReturnValue(Promise.resolve({ from: vi.fn(() => builder) }))
+
+    const result = await insertExpense({ amount: 100, category: 'Entrada', date: '2024-01-01' })
+
+    expect(result.error).toBeTruthy()
+    expect(result.error).not.toContain('boom')
+  })
+})
+
+describe('modifyExpense', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getCurrentUserId).mockResolvedValue('user-1')
+  })
+
+  it('requires a logged-in user', async () => {
+    vi.mocked(getCurrentUserId).mockResolvedValue(null)
+
+    const result = await modifyExpense(VALID_EXPENSE_ID, {})
+
+    expect(result.error).toBeTruthy()
+    expect(mockCreateClient).not.toHaveBeenCalled()
+  })
+
+  it('rejects an invalid expense id', async () => {
+    const result = await modifyExpense('not-a-uuid', {})
+
+    expect(result.error).toBeTruthy()
+    expect(mockCreateClient).not.toHaveBeenCalled()
+  })
+
+  it('rejects an invalid amount when provided', async () => {
+    const result = await modifyExpense(VALID_EXPENSE_ID, { amount: -1 })
+
+    expect(result.error).toBeTruthy()
+    expect(mockCreateClient).not.toHaveBeenCalled()
+  })
+
+  it('rejects an invalid event_id when provided', async () => {
+    const result = await modifyExpense(VALID_EXPENSE_ID, { event_id: 'not-a-uuid' })
+
+    expect(result.error).toBeTruthy()
+    expect(mockCreateClient).not.toHaveBeenCalled()
+  })
+
+  it('rejects an unparseable date when provided, without touching the client', async () => {
+    const result = await modifyExpense(VALID_EXPENSE_ID, { date: 'not-a-date' })
+
+    expect(result.error).toBeTruthy()
+    expect(mockCreateClient).not.toHaveBeenCalled()
+  })
+
+  it('reports noChanges when nothing was actually provided, without touching the client', async () => {
+    const result = await modifyExpense(VALID_EXPENSE_ID, {})
+
+    expect(result).toEqual({ noChanges: true })
+    expect(mockCreateClient).not.toHaveBeenCalled()
+  })
+
+  it(
+    'scopes the update to both the expense id and the owning user_id ' +
+      "(defense in depth against updating someone else's expense)",
+    async () => {
+      const builder = makeQueryBuilder({ data: null, error: null })
+      mockCreateClient.mockReturnValue(Promise.resolve({ from: vi.fn(() => builder) }))
+
+      const result = await modifyExpense(VALID_EXPENSE_ID, { category: 'Comida y bebida' })
+
+      expect(builder.update).toHaveBeenCalledWith({ category: 'Comida y bebida' })
+      expect(builder.eq).toHaveBeenCalledWith('id', VALID_EXPENSE_ID)
+      expect(builder.eq).toHaveBeenCalledWith('user_id', 'user-1')
+      expect(result).toEqual({})
+    }
+  )
+
+  it('only writes the fields that were actually provided', async () => {
+    const builder = makeQueryBuilder({ data: null, error: null })
+    mockCreateClient.mockReturnValue(Promise.resolve({ from: vi.fn(() => builder) }))
+
+    await modifyExpense(VALID_EXPENSE_ID, { amount: 2500 })
+
+    expect(builder.update).toHaveBeenCalledWith({ amount: 2500 })
+  })
+
+  it('returns a sanitized error when the update fails', async () => {
+    const builder = makeQueryBuilder({ data: null, error: { message: 'boom' } })
+    mockCreateClient.mockReturnValue(Promise.resolve({ from: vi.fn(() => builder) }))
+
+    const result = await modifyExpense(VALID_EXPENSE_ID, { category: 'Comida y bebida' })
+
+    expect(result.error).toBeTruthy()
+    expect(result.error).not.toContain('boom')
+  })
+})
+
+describe('removeExpense', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getCurrentUserId).mockResolvedValue('user-1')
+  })
+
+  it('requires a logged-in user', async () => {
+    vi.mocked(getCurrentUserId).mockResolvedValue(null)
+
+    const result = await removeExpense(VALID_EXPENSE_ID)
+
+    expect(result.error).toBeTruthy()
+    expect(mockCreateClient).not.toHaveBeenCalled()
+  })
+
+  it('rejects an invalid id', async () => {
+    const result = await removeExpense('not-a-uuid')
+
+    expect(result.error).toBeTruthy()
+    expect(mockCreateClient).not.toHaveBeenCalled()
+  })
+
+  it('scopes the delete to both the expense id and the owning user_id', async () => {
+    const builder = makeQueryBuilder({ data: null, error: null })
+    mockCreateClient.mockReturnValue(Promise.resolve({ from: vi.fn(() => builder) }))
+
+    const result = await removeExpense(VALID_EXPENSE_ID)
+
+    expect(builder.eq).toHaveBeenCalledWith('id', VALID_EXPENSE_ID)
+    expect(builder.eq).toHaveBeenCalledWith('user_id', 'user-1')
+    expect(result).toEqual({})
+  })
+
+  it('returns a sanitized error when the delete fails', async () => {
+    const builder = makeQueryBuilder({ data: null, error: { message: 'boom' } })
+    mockCreateClient.mockReturnValue(Promise.resolve({ from: vi.fn(() => builder) }))
+
+    const result = await removeExpense(VALID_EXPENSE_ID)
+
+    expect(result.error).toBeTruthy()
+    expect(result.error).not.toContain('boom')
   })
 })

--- a/src/graphql/expenses.test.ts
+++ b/src/graphql/expenses.test.ts
@@ -1,0 +1,292 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@/src/domains/expenses/service', () => ({
+  listExpenses: vi.fn(),
+  listExpensesForEvent: vi.fn(),
+  findExpenseById: vi.fn(),
+  summarizeExpenses: vi.fn(),
+  estimateSpendForEvent: vi.fn(),
+  insertExpense: vi.fn(),
+  modifyExpense: vi.fn(),
+  removeExpense: vi.fn(),
+}))
+
+vi.mock('@/src/domains/events/data', () => ({
+  getEvents: vi.fn(),
+  getEventsWithAttendance: vi.fn(),
+  getEventById: vi.fn(),
+}))
+
+vi.mock('@/src/core/lib/supabase/server', () => ({
+  createClient: vi.fn().mockResolvedValue({}),
+}))
+
+const mockGetCurrentUserId = vi.fn()
+vi.mock('@/src/core/auth/session', () => ({
+  getCurrentUserId: () => mockGetCurrentUserId(),
+}))
+
+import {
+  listExpenses,
+  listExpensesForEvent,
+  findExpenseById,
+  summarizeExpenses,
+  estimateSpendForEvent,
+  insertExpense,
+  modifyExpense,
+  removeExpense,
+} from '@/src/domains/expenses/service'
+import { getEventById } from '@/src/domains/events/data'
+import type { EventWithRelations } from '@/src/core/types'
+import { POST } from '@/app/api/graphql/route'
+
+async function query(source: string) {
+  const response = await POST(
+    new Request('http://localhost/api/graphql', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query: source }),
+    })
+  )
+  return response.json()
+}
+
+describe('expenses GraphQL schema', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetCurrentUserId.mockResolvedValue('user-1')
+  })
+
+  it('resolves expenses using the userId from the request context, not an argument', async () => {
+    vi.mocked(listExpenses).mockResolvedValue([
+      { id: 'ex1', user_id: 'user-1', amount: 5000, category: 'Entrada', date: '2026-03-01' },
+    ])
+
+    const body = await query('{ expenses { id amount category } }')
+
+    expect(body.errors).toBeUndefined()
+    expect(body.data).toEqual({ expenses: [{ id: 'ex1', amount: 5000, category: 'Entrada' }] })
+    expect(listExpenses).toHaveBeenCalledWith('user-1')
+  })
+
+  // Sin sesión el resolver no inventa un usuario: pasa null y deja que el
+  // data layer devuelva vacío, igual que hacía la Server Action anónima.
+  it('passes null when there is no session', async () => {
+    mockGetCurrentUserId.mockResolvedValue(null)
+    vi.mocked(listExpenses).mockResolvedValue([])
+
+    await query('{ expenses { id } }')
+
+    expect(listExpenses).toHaveBeenCalledWith(null)
+  })
+
+  // El filtro por recital entró con la migración: el panel del evento pide
+  // la misma query con eventId en vez de tener su propia.
+  it('narrows the expenses query to one event when given an eventId, still scoped to the session user', async () => {
+    vi.mocked(listExpensesForEvent).mockResolvedValue([
+      { id: 'ex1', user_id: 'user-1', amount: 5000, category: 'Entrada', event_id: 'ev-1', date: '2026-03-01' },
+    ])
+
+    const body = await query('{ expenses(eventId: "ev-1") { id eventId } }')
+
+    expect(body.errors).toBeUndefined()
+    expect(body.data).toEqual({ expenses: [{ id: 'ex1', eventId: 'ev-1' }] })
+    expect(listExpensesForEvent).toHaveBeenCalledWith('ev-1', 'user-1')
+    expect(listExpenses).not.toHaveBeenCalled()
+  })
+
+  it('resolves the aggregated summary, including the byCategory/byYear maps', async () => {
+    vi.mocked(summarizeExpenses).mockResolvedValue({
+      total: 15000,
+      count: 3,
+      byCategory: { Entrada: 10000, 'Comida y bebida': 5000 },
+      byYear: { '2026': 15000 },
+    })
+
+    const body = await query('{ expensesSummary { total count byCategory byYear } }')
+
+    expect(body.errors).toBeUndefined()
+    expect(body.data).toEqual({
+      expensesSummary: {
+        total: 15000,
+        count: 3,
+        byCategory: { Entrada: 10000, 'Comida y bebida': 5000 },
+        byYear: { '2026': 15000 },
+      },
+    })
+    expect(summarizeExpenses).toHaveBeenCalledWith('user-1')
+  })
+
+  it('resolves a single expense by id, null when it does not belong to the user', async () => {
+    vi.mocked(findExpenseById).mockResolvedValue(null)
+
+    const body = await query('{ expense(id: "missing") { id } }')
+
+    expect(body.errors).toBeUndefined()
+    expect(body.data).toEqual({ expense: null })
+    expect(findExpenseById).toHaveBeenCalledWith('missing', 'user-1')
+  })
+
+  it('exposes the snake_case row through camelCase fields', async () => {
+    vi.mocked(findExpenseById).mockResolvedValue({
+      id: 'ex1',
+      user_id: 'user-1',
+      amount: 5000,
+      category: 'Entrada',
+      note: 'Con descuento',
+      event_id: 'ev-1',
+      date: '2026-03-01',
+      created_at: '2026-03-01T10:00:00Z',
+    })
+
+    const body = await query('{ expense(id: "ex1") { id userId amount category note eventId date createdAt } }')
+
+    expect(body.errors).toBeUndefined()
+    expect(body.data.expense).toEqual({
+      id: 'ex1',
+      userId: 'user-1',
+      amount: 5000,
+      category: 'Entrada',
+      note: 'Con descuento',
+      eventId: 'ev-1',
+      date: '2026-03-01',
+      createdAt: '2026-03-01T10:00:00Z',
+    })
+  })
+
+  // La sugerencia blanda del panel de gastos (issue #7) también se sirve por
+  // GraphQL: primero busca el recital y recién ahí estima, scopeado al usuario.
+  it('estimates spend for an event through the service, scoped to the session user', async () => {
+    const event = { id: 'ev-1', venue_id: 'v-1', lineups: [] } as unknown as EventWithRelations
+    vi.mocked(getEventById).mockResolvedValue(event)
+    vi.mocked(estimateSpendForEvent).mockResolvedValue({ averageTotal: 12000, eventsConsidered: 3 })
+
+    const body = await query('{ estimateSpendForEvent(eventId: "ev-1") { averageTotal eventsConsidered } }')
+
+    expect(body.errors).toBeUndefined()
+    expect(body.data).toEqual({ estimateSpendForEvent: { averageTotal: 12000, eventsConsidered: 3 } })
+    expect(estimateSpendForEvent).toHaveBeenCalledWith(event, 'user-1')
+  })
+
+  it('returns null instead of estimating when the event does not exist', async () => {
+    vi.mocked(getEventById).mockResolvedValue(null)
+
+    const body = await query('{ estimateSpendForEvent(eventId: "missing") { averageTotal } }')
+
+    expect(body.errors).toBeUndefined()
+    expect(body.data).toEqual({ estimateSpendForEvent: null })
+    expect(estimateSpendForEvent).not.toHaveBeenCalled()
+  })
+})
+
+describe('expenses GraphQL mutations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetCurrentUserId.mockResolvedValue('user-1')
+  })
+
+  it('creates an expense, mapping camelCase input to the domain snake_case shape', async () => {
+    vi.mocked(insertExpense).mockResolvedValue({ id: 'ex-new' })
+
+    const body = await query(`mutation {
+      createExpense(input: { amount: 5000, category: "Entrada", date: "2026-03-01", eventId: "e1" }) { id error }
+    }`)
+
+    expect(body.errors).toBeUndefined()
+    expect(body.data).toEqual({ createExpense: { id: 'ex-new', error: null } })
+    expect(insertExpense).toHaveBeenCalledWith({
+      amount: 5000,
+      category: 'Entrada',
+      note: undefined,
+      event_id: 'e1',
+      date: '2026-03-01',
+    })
+  })
+
+  it('leaves event_id undefined when the expense is not linked to a show', async () => {
+    vi.mocked(insertExpense).mockResolvedValue({ id: 'ex-new' })
+
+    await query(`mutation {
+      createExpense(input: { amount: 5000, category: "Entrada", date: "2026-03-01" }) { id }
+    }`)
+
+    expect(insertExpense).toHaveBeenCalledWith(expect.objectContaining({ event_id: undefined }))
+  })
+
+  it('surfaces a rejected create through the error field, not a thrown GraphQL error', async () => {
+    vi.mocked(insertExpense).mockResolvedValue({ error: 'El monto debe ser mayor a 0.' })
+
+    const body = await query(`mutation {
+      createExpense(input: { amount: 0, category: "Entrada", date: "2026-03-01" }) { id error }
+    }`)
+
+    expect(body.errors).toBeUndefined()
+    expect(body.data).toEqual({ createExpense: { id: null, error: 'El monto debe ser mayor a 0.' } })
+  })
+
+  it('updates an expense, translating ActionResult into {success, error}', async () => {
+    vi.mocked(modifyExpense).mockResolvedValue({})
+
+    const body = await query(`mutation {
+      updateExpense(id: "ex1", input: { category: "Comida y bebida" }) { success error }
+    }`)
+
+    expect(body.errors).toBeUndefined()
+    expect(body.data).toEqual({ updateExpense: { success: true, error: null } })
+    expect(modifyExpense).toHaveBeenCalledWith('ex1', {
+      amount: undefined,
+      category: 'Comida y bebida',
+      note: undefined,
+      event_id: undefined,
+      date: undefined,
+    })
+  })
+
+  it('reports a no-op update as success, same as the service does', async () => {
+    vi.mocked(modifyExpense).mockResolvedValue({ noChanges: true })
+
+    const body = await query('mutation { updateExpense(id: "ex1", input: {}) { success error } }')
+
+    expect(body.data).toEqual({ updateExpense: { success: true, error: null } })
+  })
+
+  it('reports a rejected update through success:false', async () => {
+    vi.mocked(modifyExpense).mockResolvedValue({ error: 'Gasto inválido.' })
+
+    const body = await query('mutation { updateExpense(id: "nope", input: { amount: 1 }) { success error } }')
+
+    expect(body.errors).toBeUndefined()
+    expect(body.data).toEqual({ updateExpense: { success: false, error: 'Gasto inválido.' } })
+  })
+
+  it('deletes an expense', async () => {
+    vi.mocked(removeExpense).mockResolvedValue({})
+
+    const body = await query('mutation { deleteExpense(id: "ex1") { success error } }')
+
+    expect(body.errors).toBeUndefined()
+    expect(body.data).toEqual({ deleteExpense: { success: true, error: null } })
+    expect(removeExpense).toHaveBeenCalledWith('ex1')
+  })
+
+  it('reports failure through success:false, not a thrown GraphQL error', async () => {
+    vi.mocked(removeExpense).mockResolvedValue({ error: 'boom' })
+
+    const body = await query('mutation { deleteExpense(id: "ex1") { success error } }')
+
+    expect(body.errors).toBeUndefined()
+    expect(body.data).toEqual({ deleteExpense: { success: false, error: 'boom' } })
+  })
+
+  // Las mutations no aceptan un userId por argumento: el dueño sale siempre
+  // de la sesión dentro del service, así que un cliente no puede escribir
+  // sobre el gasto de otro pidiéndolo por parámetro.
+  it('exposes no userId argument on any expense mutation', async () => {
+    const body = await query(`mutation {
+      createExpense(input: { amount: 1, category: "Entrada", date: "2026-03-01", userId: "someone-else" }) { id }
+    }`)
+
+    expect(body.errors).toBeDefined()
+    expect(insertExpense).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Qué pasó

El PR #44 migró `expenses` de Server Actions a GraphQL y, en el camino, borró **837 líneas de tests en 5 archivos sin reemplazarlas por nada**:

| Archivo | Líneas borradas |
|---|---|
| `src/domains/expenses/actions.test.ts` | 266 |
| `src/domains/expenses/components/EventExpensesPanel.test.tsx` | 169 |
| `src/domains/expenses/components/ExpenseForm.test.tsx` | 97 |
| `src/domains/expenses/components/ExpenseQuickAdd.test.tsx` | 138 |
| `src/graphql/expenses.test.ts` | 167 |

Pasó la review porque CI quedó en verde: los tests que sobrevivieron seguían pasando y nada mira que el *conteo* de tests no baje. El comportamiento que esos tests cubrían sigue vivo en la app — simplemente dejó de estar testeado.

El PR #46 (misma migración para `venues` / `artists` / `festivals`) no repitió el error: reescribió los tests de componente contra un `useMutation` de urql doblado y movió los `actions.test.ts` a `service.test.ts`. Este PR aplica ese mismo patrón a `expenses`.

## Qué hace este PR

Restaura la cobertura contra la implementación actual. Los tests viejos no se pueden revivir tal cual: `actions.ts` no existe, su núcleo sin redirect vive ahora en `service.ts`, y los componentes escriben por urql en vez de recibir Server Actions por prop.

- **`src/domains/expenses/service.test.ts`** — se le suma el lado de escritura (`insertExpense` / `modifyExpense` / `removeExpense`), que es donde aterrizó lo que testeaba `actions.test.ts`: validaciones de monto (cero, negativo, tope de sanidad), categoría, fecha, `event_id`, el `noChanges` del update vacío, los errores saneados, y el scoping por `user_id` que impide tocar el gasto de otra persona.
- **`src/graphql/expenses.test.ts`** — resolvers contra el schema real vía `POST /api/graphql`, con el service doblado: `userId` sale siempre del contexto y nunca de un argumento, el mapeo camelCase → snake_case de los inputs, `ActionResult` → `{success, error}`, y los fallos que viajan como `success: false` en vez de como error de GraphQL.
- **`ExpenseForm.test.tsx`**, **`ExpenseQuickAdd.test.tsx`**, **`EventExpensesPanel.test.tsx`** — reescritos con el doble enganchado en `useMutation` y ruteado por nombre de operación, igual que `EventForm.test.tsx` en #46.
- **`DeleteExpenseAction.test.tsx`** — nuevo. #44 agregó este componente sin ningún test.

### Sustituciones por comportamiento que cambió de forma

Tres asserts viejos eran sobre `redirect()` de Server Actions, que ya no existen. En vez de saltearlos, se cubre el equivalente nuevo — el `router.push()` del cliente — en el componente que ahora navega:

| Assert viejo | Dónde vive ahora |
|---|---|
| `createExpense` redirige a `/expenses` | `ExpenseForm.test.tsx` — navega a la lista al crear |
| `updateExpense` redirige a `/expenses/:id` | `ExpenseForm.test.tsx` — navega al detalle al editar |
| `deleteExpense` redirige a `/expenses` | `DeleteExpenseAction.test.tsx` — vuelve a la lista al borrar |

También se cubren cosas que #44 introdujo y nunca tuvieron test: la query `expenses(eventId:)`, el resolver `estimateSpendForEvent`, y que el form preseleccione el recital tanto con la fila snake_case de Supabase como con la camelCase de GraphQL.

## Conteo

| | Antes | Después |
|---|---|---|
| Archivos de test | 100 | 105 |
| Tests | 819 | 894 |

`npm run lint` (0 errores), `npx tsc --noEmit` y `npm test` en verde. **Cero cambios en código de producción**: ningún assert restaurado tuvo que aflojarse para pasar.

## Nota aparte — un hueco que estos tests no cubren

Restaurando esto quedó a la vista un camino que ningún test toca, ni antes ni ahora, y que conviene mirar en su propio PR (no se toca acá porque este es de restauración de tests):

Cuando una mutation falla a nivel transporte (red caída, 500, error de validación de GraphQL), urql devuelve `data: undefined` y el error en `result.error`. Varios handlers leen sólo `data?.x?.error`, así que un fallo así se lee como éxito:

- `EventExpensesPanel.handleDelete` — saca la fila de la lista aunque el servidor nunca la borró.
- `EventExpensesPanel.handleModify` — muestra el monto editado aunque no se persistió.
- `ExpenseForm` y `DeleteExpenseAction` — navegan como si hubiera salido bien.

Con las Server Actions esto no podía pasar: un fallo siempre volvía como `{ error: string }`. `WishlistButton` y `FestivalAttendanceButton` (de #46) ya usan la forma segura — `if (!result || result.error)` — así que el arreglo es alinear el resto con ese patrón. `ExpenseQuickAdd` ya está a salvo porque chequea `!result.id`.

Cierra el hueco de cobertura que dejó #44.
