### PR TITLE
fix(graphql): tratar las fallas de transporte de urql como error, no como éxito

### DIFF
--- a/app/festivals/nuevo/page.test.tsx
+++ b/app/festivals/nuevo/page.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+const push = vi.fn()
+vi.mock('next/navigation', () => ({
+    useRouter: () => ({ push }),
+}))
+
+const createFestivalMock = vi.fn()
+vi.mock('urql', async () => {
+    const actual = await vi.importActual<typeof import('urql')>('urql')
+    return { ...actual, useMutation: () => [{ fetching: false }, createFestivalMock] }
+})
+
+import NuevoFestivalPage from '@/app/festivals/nuevo/page'
+import { TRANSPORT_ERROR_MESSAGE } from '@/src/graphql/mutation-result'
+import { transportError } from '@/src/graphql/transport-failure.testing'
+
+async function fillAndSubmit() {
+    await userEvent.type(screen.getByLabelText(/Nombre del festival/), 'Lollapalooza')
+    await userEvent.type(screen.getByLabelText(/Fecha de inicio/), '2026-03-20')
+    await userEvent.click(screen.getByRole('button', { name: 'Crear festival' }))
+}
+
+describe('NuevoFestivalPage', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        createFestivalMock.mockResolvedValue({ data: { createFestival: { id: 'f-new' } } })
+    })
+
+    it('navigates to the new festival once creation succeeds', async () => {
+        render(<NuevoFestivalPage />)
+        await fillAndSubmit()
+
+        await waitFor(() => expect(push).toHaveBeenCalledWith('/festivals/f-new'))
+    })
+
+    it('shows the resolver error and stays on the page when creation is rejected', async () => {
+        createFestivalMock.mockResolvedValue({
+            data: { createFestival: { error: 'Ya existe un registro con esos datos.' } },
+        })
+        render(<NuevoFestivalPage />)
+        await fillAndSubmit()
+
+        await waitFor(() => {
+            expect(screen.getByText('Ya existe un registro con esos datos.')).toBeInTheDocument()
+        })
+        expect(push).not.toHaveBeenCalled()
+    })
+
+    it('stays on the page and surfaces an error when the request never reaches the resolver', async () => {
+        createFestivalMock.mockResolvedValue({ data: undefined, error: transportError() })
+        render(<NuevoFestivalPage />)
+        await fillAndSubmit()
+
+        await waitFor(() => {
+            expect(screen.getByText(TRANSPORT_ERROR_MESSAGE)).toBeInTheDocument()
+        })
+        expect(push).not.toHaveBeenCalled()
+    })
+})

--- a/app/festivals/nuevo/page.tsx
+++ b/app/festivals/nuevo/page.tsx
@@ -4,6 +4,7 @@ import { useState, useTransition } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useMutation, gql } from 'urql'
+import { unwrapMutation } from '@/src/graphql/mutation-result'
 import { FormField } from '@/src/core/components/ui'
 import { PageShell } from '@/src/core/components/layout'
 import { routes } from '@/src/core/lib/routes'
@@ -26,21 +27,24 @@ export default function NuevoFestivalPage() {
         const formData = new FormData(e.currentTarget)
 
         startTransition(async () => {
-            const { data } = await createFestival({
-                input: {
-                    name: formData.get('name') as string,
-                    edition: formData.get('edition') as string,
-                    startDate: formData.get('start_date') as string,
-                    endDate: (formData.get('end_date') as string) || undefined,
-                    city: formData.get('city') as string,
-                    country: formData.get('country') as string,
-                    website: formData.get('website') as string,
-                    notes: formData.get('notes') as string,
-                },
-            })
-            const result = data?.createFestival
-            if (!result || result.error || !result.id) {
-                setError(result?.error ?? 'No se pudo crear el festival.')
+            const result = unwrapMutation<{ id?: string; error?: string }>(
+                await createFestival({
+                    input: {
+                        name: formData.get('name') as string,
+                        edition: formData.get('edition') as string,
+                        startDate: formData.get('start_date') as string,
+                        endDate: (formData.get('end_date') as string) || undefined,
+                        city: formData.get('city') as string,
+                        country: formData.get('country') as string,
+                        website: formData.get('website') as string,
+                        notes: formData.get('notes') as string,
+                    },
+                }),
+                'createFestival',
+                'No se pudo crear el festival.'
+            )
+            if (result.error || !result.id) {
+                setError(result.error ?? 'No se pudo crear el festival.')
                 return
             }
             router.push(routes.festivals.detail(result.id))

--- a/src/domains/artists/components/ArtistForm.test.tsx
+++ b/src/domains/artists/components/ArtistForm.test.tsx
@@ -16,6 +16,8 @@ vi.mock('next/navigation', () => ({
 }))
 
 import { ArtistForm } from '@/src/domains/artists/components/ArtistForm'
+import { TRANSPORT_ERROR_MESSAGE } from '@/src/graphql/mutation-result'
+import { transportError } from '@/src/graphql/transport-failure.testing'
 
 describe('ArtistForm', () => {
   beforeEach(() => {
@@ -73,5 +75,19 @@ describe('ArtistForm', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Crear artista' }))
 
     await waitFor(() => expect(push).toHaveBeenCalledWith('/artists'))
+  })
+
+  it('stays on the form and surfaces an error when the request never reaches the resolver', async () => {
+    executeMutation.mockResolvedValue({ data: undefined, error: transportError() })
+    render(<ArtistForm />)
+
+    await userEvent.type(screen.getByLabelText(/Nombre del artista/), 'Bandalos Chinos')
+    await userEvent.click(screen.getByRole('button', { name: 'Crear artista' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(TRANSPORT_ERROR_MESSAGE)
+    })
+    expect(push).not.toHaveBeenCalled()
+    expect(screen.getByRole('button', { name: 'Crear artista' })).toBeEnabled()
   })
 })

--- a/src/domains/artists/components/ArtistForm.tsx
+++ b/src/domains/artists/components/ArtistForm.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useMutation, gql } from 'urql'
+import { unwrapMutation } from '@/src/graphql/mutation-result'
 import { Button, FormField, inputClass } from '@/src/core/components/ui'
 import { routes } from '@/src/core/lib/routes'
 
@@ -26,14 +27,17 @@ export function ArtistForm() {
     setExistingId(null)
     setIsSubmitting(true)
     const form = e.currentTarget
-    const { data } = await createArtist({
-      input: {
-        name: (form.elements.namedItem('name') as HTMLInputElement).value,
-        genre: (form.elements.namedItem('genre') as HTMLInputElement).value || undefined,
-      },
-    })
-    const result = data?.createArtist
-    if (result?.error) {
+    const result = unwrapMutation<{ id?: string; existingId?: string; error?: string }>(
+      await createArtist({
+        input: {
+          name: (form.elements.namedItem('name') as HTMLInputElement).value,
+          genre: (form.elements.namedItem('genre') as HTMLInputElement).value || undefined,
+        },
+      }),
+      'createArtist',
+      'No se pudo crear el artista.'
+    )
+    if (result.error) {
       setError(result.error)
       setExistingId(result.existingId ?? null)
       setIsSubmitting(false)

--- a/src/domains/artists/components/WishlistButton.test.tsx
+++ b/src/domains/artists/components/WishlistButton.test.tsx
@@ -11,6 +11,8 @@ vi.mock('urql', async () => {
 })
 
 import { WishlistButton } from '@/src/domains/artists/components/WishlistButton'
+import { TRANSPORT_ERROR_MESSAGE } from '@/src/graphql/mutation-result'
+import { transportError } from '@/src/graphql/transport-failure.testing'
 
 describe('WishlistButton', () => {
   beforeEach(() => {
@@ -65,5 +67,17 @@ describe('WishlistButton', () => {
     await waitFor(() => {
       expect(screen.getByRole('alert')).toHaveTextContent('No autenticado')
     })
+  })
+
+  it('rolls back the optimistic star and shows an error when the request never reaches the resolver', async () => {
+    mockToggleWishlist.mockResolvedValue({ data: undefined, error: transportError() })
+    render(<WishlistButton artistId="a1" initialInWishlist={false} />)
+
+    await userEvent.click(screen.getByRole('button'))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(TRANSPORT_ERROR_MESSAGE)
+    })
+    expect(screen.getByRole('button', { name: 'Seguir este artista' })).toBeInTheDocument()
   })
 })

--- a/src/domains/artists/components/WishlistButton.tsx
+++ b/src/domains/artists/components/WishlistButton.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useTransition } from 'react'
 import { useMutation, gql } from 'urql'
+import { unwrapMutation } from '@/src/graphql/mutation-result'
 
 const ToggleWishlistMutation = gql`
   mutation ToggleWishlist($artistId: ID!) {
@@ -25,11 +26,14 @@ export function WishlistButton({ artistId, initialInWishlist }: WishlistButtonPr
         setInWishlist((prev) => !prev)
         setError(null)
         startTransition(async () => {
-            const { data } = await toggleWishlist({ artistId })
-            const result = data?.toggleWishlist
-            if (!result || result.error) {
+            const result = unwrapMutation<{ inWishlist?: boolean; error?: string }>(
+                await toggleWishlist({ artistId }),
+                'toggleWishlist',
+                'No se pudo actualizar la wishlist.'
+            )
+            if (result.error || result.inWishlist == null) {
                 setInWishlist((prev) => !prev)
-                setError(result?.error ?? 'No se pudo actualizar la wishlist.')
+                setError(result.error ?? 'No se pudo actualizar la wishlist.')
             } else {
                 setInWishlist(result.inWishlist)
             }

--- a/src/domains/events/components/EventForm.test.tsx
+++ b/src/domains/events/components/EventForm.test.tsx
@@ -4,6 +4,8 @@ import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { EventForm } from '@/src/domains/events/components/EventForm'
 import type { Venue, Artist, EventWithRelations } from '@/src/core/types'
+import { TRANSPORT_ERROR_MESSAGE } from '@/src/graphql/mutation-result'
+import { transportError } from '@/src/graphql/transport-failure.testing'
 
 const push = vi.fn()
 vi.mock('next/navigation', () => ({
@@ -415,5 +417,50 @@ describe('EventForm — edit mode', () => {
       />
     )
     expect(screen.getByRole('link', { name: 'Cancelar' })).toHaveAttribute('href', '/events/e1')
+  })
+})
+
+/**
+ * Las altas inline de sede/artista fallaban en silencio cuando la mutation no
+ * llegaba al resolver: urql resuelve con `data: undefined`, así que cualquier
+ * chequeo que solo mire `data.<campo>.error` lee la falla como éxito.
+ */
+describe('EventForm — inline creation transport failures', () => {
+  beforeEach(() => {
+    push.mockClear()
+    findOrCreateVenueMock.mockReset()
+    findOrCreateArtistMock.mockReset()
+  })
+
+  it('does not add the venue and surfaces an error when the request never reaches the resolver', async () => {
+    findOrCreateVenueMock.mockResolvedValue({ data: undefined, error: transportError() })
+    const insertEvent = vi.fn()
+    render(<EventForm venues={[]} artists={artists} insertEvent={insertEvent} />)
+
+    await userEvent.type(screen.getByLabelText(/Nombre del recital/), 'Show')
+    await userEvent.type(screen.getByLabelText(/Fecha/), '2024-05-01')
+    await userEvent.type(screen.getByLabelText(/Sede/), 'Movistar Arena')
+    await userEvent.click(await screen.findByRole('option', { name: /Crear "Movistar Arena"/ }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(TRANSPORT_ERROR_MESSAGE)
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: 'Guardar y generar el talón' }))
+    expect(insertEvent).not.toHaveBeenCalled()
+    expect(push).not.toHaveBeenCalled()
+  })
+
+  it('does not add the artist to the lineup and surfaces an error when the request never reaches the resolver', async () => {
+    findOrCreateArtistMock.mockResolvedValue({ data: undefined, error: transportError() })
+    render(<EventForm venues={venues} artists={artists} insertEvent={vi.fn()} />)
+
+    await userEvent.type(screen.getByLabelText(/Artistas en el lineup/), 'El Mató')
+    await userEvent.click(await screen.findByRole('option', { name: /Crear "El Mató"/ }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(TRANSPORT_ERROR_MESSAGE)
+    })
+    expect(screen.queryByRole('button', { name: /Quitar El Mató/ })).not.toBeInTheDocument()
   })
 })

--- a/src/domains/events/components/EventForm.tsx
+++ b/src/domains/events/components/EventForm.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { useMutation, gql } from 'urql'
+import { unwrapMutation } from '@/src/graphql/mutation-result'
 import { Button, FormField, inputClass, Combobox, StarRating, type ComboboxOption } from '@/src/core/components/ui'
 import { routes } from '@/src/core/lib/routes'
 import { combineDateAndTime, eventTimeOfDay } from '@/src/core/lib/dates'
@@ -100,18 +101,24 @@ export function EventForm({
   }
 
   async function handleCreateVenue(name: string) {
-    const { data } = await findOrCreateVenue({ name })
-    const result = data?.findOrCreateVenue
-    if (!result || result.error || !result.id) return { error: result?.error ?? 'No se pudo crear la sede.' }
+    const result = unwrapMutation<{ id?: string; error?: string }>(
+      await findOrCreateVenue({ name }),
+      'findOrCreateVenue',
+      'No se pudo crear la sede.'
+    )
+    if (result.error || !result.id) return { error: result.error ?? 'No se pudo crear la sede.' }
     const option: ComboboxOption = { id: result.id, label: name }
     setVenueOptions((prev) => (prev.some((v) => v.id === option.id) ? prev : [...prev, option]))
     return option
   }
 
   async function handleCreateArtist(name: string) {
-    const { data } = await findOrCreateArtist({ name })
-    const result = data?.findOrCreateArtist
-    if (!result || result.error || !result.id) return { error: result?.error ?? 'No se pudo crear el artista.' }
+    const result = unwrapMutation<{ id?: string; error?: string }>(
+      await findOrCreateArtist({ name }),
+      'findOrCreateArtist',
+      'No se pudo crear el artista.'
+    )
+    if (result.error || !result.id) return { error: result.error ?? 'No se pudo crear el artista.' }
     const option: ComboboxOption = { id: result.id, label: name }
     setArtistOptions((prev) => (prev.some((a) => a.id === option.id) ? prev : [...prev, option]))
     return option

--- a/src/domains/expenses/components/DeleteExpenseAction.test.tsx
+++ b/src/domains/expenses/components/DeleteExpenseAction.test.tsx
@@ -16,6 +16,8 @@ vi.mock('urql', async () => {
 })
 
 import { DeleteExpenseAction } from '@/src/domains/expenses/components/DeleteExpenseAction'
+import { TRANSPORT_ERROR_MESSAGE } from '@/src/graphql/mutation-result'
+import { transportError } from '@/src/graphql/transport-failure.testing'
 
 const expense = { id: 'x1', amount: 1500, category: 'Entrada' } as Expense
 
@@ -65,6 +67,19 @@ describe('DeleteExpenseAction', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Cancelar' }))
 
     expect(deleteExpenseMock).not.toHaveBeenCalled()
+    expect(push).not.toHaveBeenCalled()
+  })
+
+  it('stays on the page and surfaces an error when the request never reaches the resolver', async () => {
+    deleteExpenseMock.mockResolvedValue({ data: undefined, error: transportError() })
+    render(<DeleteExpenseAction expense={expense} />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Eliminar gasto' }))
+    await userEvent.click(screen.getByRole('button', { name: /Sí, eliminar/ }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(TRANSPORT_ERROR_MESSAGE)
+    })
     expect(push).not.toHaveBeenCalled()
   })
 })

--- a/src/domains/expenses/components/DeleteExpenseAction.tsx
+++ b/src/domains/expenses/components/DeleteExpenseAction.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useMutation, gql } from 'urql'
+import { unwrapMutation } from '@/src/graphql/mutation-result'
 import { useRouter } from 'next/navigation'
 import { routes } from '@/src/core/lib/routes'
 import { DeleteExpenseButton } from './DeleteExpenseButton'
@@ -17,9 +18,9 @@ export function DeleteExpenseAction({ expense }: { expense: Expense | GraphQLExp
   const [, deleteExpense] = useMutation(DeleteExpenseQuery)
 
   const handleDelete = async (id: string) => {
-    const { data } = await deleteExpense({ id })
-    if (data?.deleteExpense?.error) {
-      return { error: data.deleteExpense.error }
+    const result = unwrapMutation(await deleteExpense({ id }), 'deleteExpense')
+    if (result.error) {
+      return { error: result.error }
     }
     router.push(routes.expenses.list)
     return {}

--- a/src/domains/expenses/components/EventExpensesPanel.test.tsx
+++ b/src/domains/expenses/components/EventExpensesPanel.test.tsx
@@ -25,6 +25,8 @@ vi.mock('urql', async () => {
 })
 
 import { EventExpensesPanel } from '@/src/domains/expenses/components/EventExpensesPanel'
+import { TRANSPORT_ERROR_MESSAGE } from '@/src/graphql/mutation-result'
+import { transportError } from '@/src/graphql/transport-failure.testing'
 
 const baseExpenses: Expense[] = [
   { id: 'x1', user_id: 'u1', amount: 5000, category: 'Comida y bebida', note: null, event_id: 'ev-1', date: '2026-05-01' },
@@ -217,5 +219,63 @@ describe('EventExpensesPanel', () => {
       expect(screen.getByRole('alert')).toHaveTextContent('No se pudo eliminar.')
     })
     expect(screen.getByText('$23.000')).toBeInTheDocument()
+  })
+
+  /**
+   * Cuando la request no llega al resolver (red caída, 500, GraphQL inválido)
+   * urql resuelve con `data: undefined` y `error` seteado. Mirar solo
+   * `data.x.error` leía eso como éxito y aplicaba el cambio optimista sobre
+   * algo que el servidor nunca guardó.
+   */
+  describe('transport failures (data undefined, result.error set)', () => {
+    it('quick-add: does not add the expense and surfaces an error', async () => {
+      createExpenseMock.mockResolvedValue({ data: undefined, error: transportError() })
+      renderPanel()
+
+      await userEvent.click(screen.getByRole('button', { name: '+ Cargar gasto' }))
+      await userEvent.type(screen.getByLabelText('Monto'), '2000')
+      await userEvent.selectOptions(screen.getByLabelText('Categoría'), 'Merch')
+      await userEvent.click(screen.getByRole('button', { name: 'Guardar gasto' }))
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toHaveTextContent(TRANSPORT_ERROR_MESSAGE)
+      })
+      expect(screen.getByText('$23.000')).toBeInTheDocument()
+      expect(screen.getByText(/3 ítems/)).toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: /Merch:/ })).not.toBeInTheDocument()
+    })
+
+    it('inline edit: keeps the old amount and surfaces an error', async () => {
+      updateExpenseMock.mockResolvedValue({ data: undefined, error: transportError() })
+      renderPanel()
+
+      await userEvent.click(screen.getByRole('button', { name: /Entrada: \$15\.000/ }))
+      await userEvent.click(screen.getByRole('button', { name: 'Editar' }))
+      const amountInput = screen.getByLabelText('Monto')
+      await userEvent.clear(amountInput)
+      await userEvent.type(amountInput, '16000')
+      await userEvent.click(screen.getByRole('button', { name: 'Guardar' }))
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toHaveTextContent(TRANSPORT_ERROR_MESSAGE)
+      })
+      expect(screen.getByText('$23.000')).toBeInTheDocument()
+      expect(screen.queryByText('$24.000')).not.toBeInTheDocument()
+    })
+
+    it('inline delete: keeps the expense in the list and surfaces an error', async () => {
+      deleteExpenseMock.mockResolvedValue({ data: undefined, error: transportError() })
+      renderPanel()
+
+      await userEvent.click(screen.getByRole('button', { name: /Entrada: \$15\.000/ }))
+      await userEvent.click(screen.getByRole('button', { name: 'Eliminar gasto' }))
+      await userEvent.click(screen.getByRole('button', { name: 'Sí, eliminar' }))
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toHaveTextContent(TRANSPORT_ERROR_MESSAGE)
+      })
+      expect(screen.getByText('$23.000')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /Entrada: \$15\.000/ })).toBeInTheDocument()
+    })
   })
 })

--- a/src/domains/expenses/components/EventExpensesPanel.tsx
+++ b/src/domains/expenses/components/EventExpensesPanel.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import Link from 'next/link'
 import { useMutation, gql } from 'urql'
+import { unwrapMutation } from '@/src/graphql/mutation-result'
 import { getExpenseCategory } from '@/src/domains/expenses/categories'
 import { groupExpensesByCategory } from '@/src/domains/expenses/grouping'
 import { formatChoripanComparison } from '@/src/domains/expenses/comparisons'
@@ -72,14 +73,14 @@ export function EventExpensesPanel({
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async function handleInsert(expenseData: any) {
-    const { data } = await createExpenseM({ input: expenseData })
-    return { id: data?.createExpense?.id, error: data?.createExpense?.error }
+    const result = await createExpenseM({ input: expenseData })
+    return unwrapMutation<{ id?: string; error?: string }>(result, 'createExpense')
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async function handleModify(id: string, expenseData: any) {
-    const { data } = await updateExpenseM({ id, input: expenseData })
-    return { error: data?.updateExpense?.error }
+    const result = await updateExpenseM({ id, input: expenseData })
+    return unwrapMutation(result, 'updateExpense')
   }
 
   const total = expenses.reduce((sum, e) => sum + Number(e.amount), 0)
@@ -98,13 +99,11 @@ export function EventExpensesPanel({
   }
 
   async function handleDelete(id: string) {
-    const { data } = await deleteExpenseM({ id })
-    if (!data?.deleteExpense?.error) {
-      setExpenses((prev) => prev.filter((e) => e.id !== id))
-      if (editingId === id) setEditingId(null)
-      return {}
-    }
-    return { error: data.deleteExpense.error }
+    const result = unwrapMutation(await deleteExpenseM({ id }), 'deleteExpense')
+    if (result.error) return { error: result.error }
+    setExpenses((prev) => prev.filter((e) => e.id !== id))
+    if (editingId === id) setEditingId(null)
+    return {}
   }
 
   return (

--- a/src/domains/expenses/components/ExpenseForm.test.tsx
+++ b/src/domains/expenses/components/ExpenseForm.test.tsx
@@ -27,6 +27,8 @@ vi.mock('urql', async () => {
 })
 
 import { ExpenseForm } from '@/src/domains/expenses/components/ExpenseForm'
+import { TRANSPORT_ERROR_MESSAGE } from '@/src/graphql/mutation-result'
+import { transportError } from '@/src/graphql/transport-failure.testing'
 
 const events = [{ id: 'e1', name: 'Show en Niceto', date: '2024-05-01' }] as EventWithRelations[]
 
@@ -203,5 +205,39 @@ describe('ExpenseForm — edit mode', () => {
     render(<ExpenseForm events={events} expense={graphQLExpense} />)
 
     expect(screen.getByLabelText(/Recital asociado/)).toHaveValue('e1')
+  })
+
+  /**
+   * Con `data: undefined` el chequeo viejo (`data?.createExpense?.error`) daba
+   * `undefined`, el form navegaba y el usuario creía que el gasto se guardó.
+   */
+  describe('transport failures (data undefined, result.error set)', () => {
+    it('create: stays on the form and surfaces an error instead of navigating', async () => {
+      createExpenseMock.mockResolvedValue({ data: undefined, error: transportError() })
+      render(<ExpenseForm events={events} />)
+
+      await userEvent.type(screen.getByLabelText(/Monto/), '5000')
+      await userEvent.selectOptions(screen.getByLabelText(/Categoría/), 'Entrada')
+      await userEvent.click(screen.getByRole('button', { name: 'Agregar gasto' }))
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toHaveTextContent(TRANSPORT_ERROR_MESSAGE)
+      })
+      expect(push).not.toHaveBeenCalled()
+      expect(screen.getByRole('button', { name: 'Agregar gasto' })).toBeEnabled()
+    })
+
+    it('update: stays on the form and surfaces an error instead of navigating', async () => {
+      updateExpenseMock.mockResolvedValue({ data: undefined, error: transportError() })
+      render(<ExpenseForm events={events} expense={expense} />)
+
+      await userEvent.click(screen.getByRole('button', { name: 'Guardar cambios' }))
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toHaveTextContent(TRANSPORT_ERROR_MESSAGE)
+      })
+      expect(push).not.toHaveBeenCalled()
+      expect(screen.getByRole('button', { name: 'Guardar cambios' })).toBeEnabled()
+    })
   })
 })

--- a/src/domains/expenses/components/ExpenseForm.tsx
+++ b/src/domains/expenses/components/ExpenseForm.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useMutation, gql } from 'urql'
+import { unwrapMutation } from '@/src/graphql/mutation-result'
 import { Button, FormField, inputClass } from '@/src/core/components/ui'
 import { routes } from '@/src/core/lib/routes'
 import { formatDate } from '@/src/core/lib/utils'
@@ -57,17 +58,17 @@ export function ExpenseForm({ events, expense }: ExpenseFormProps) {
     }
     
     if (isEdit && expense) {
-      const { data } = await updateExpenseM({ id: expense.id, input: payload })
-      if (data?.updateExpense?.error) {
-        setError(data.updateExpense.error)
+      const result = unwrapMutation(await updateExpenseM({ id: expense.id, input: payload }), 'updateExpense')
+      if (result.error) {
+        setError(result.error)
         setIsSubmitting(false)
       } else {
         router.push(routes.expenses.detail(expense.id))
       }
     } else {
-      const { data } = await createExpenseM({ input: payload })
-      if (data?.createExpense?.error) {
-        setError(data.createExpense.error)
+      const result = unwrapMutation(await createExpenseM({ input: payload }), 'createExpense')
+      if (result.error) {
+        setError(result.error)
         setIsSubmitting(false)
       } else {
         router.push(routes.expenses.list)

--- a/src/domains/festivals/components/FestivalAttendanceButton.test.tsx
+++ b/src/domains/festivals/components/FestivalAttendanceButton.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 const mockSaveFestivalAttendance = vi.fn()
@@ -11,6 +11,8 @@ vi.mock('urql', async () => {
 })
 
 import { FestivalAttendanceButton } from '@/src/domains/festivals/components/FestivalAttendanceButton'
+import { TRANSPORT_ERROR_MESSAGE } from '@/src/graphql/mutation-result'
+import { transportError } from '@/src/graphql/transport-failure.testing'
 
 describe('FestivalAttendanceButton', () => {
   beforeEach(() => {
@@ -60,5 +62,18 @@ describe('FestivalAttendanceButton', () => {
     await userEvent.keyboard('{Escape}')
 
     expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+  })
+
+  it('rolls back the optimistic status and shows an error when the request never reaches the resolver', async () => {
+    mockSaveFestivalAttendance.mockResolvedValue({ data: undefined, error: transportError() })
+    render(<FestivalAttendanceButton festivalId="f1" initialStatus="interested" />)
+
+    await userEvent.click(screen.getByRole('button'))
+    await userEvent.click(screen.getByRole('menuitemradio', { name: /Voy/ }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(TRANSPORT_ERROR_MESSAGE)
+    })
+    expect(screen.getByRole('button', { name: /Me interesa/ })).toBeInTheDocument()
   })
 })

--- a/src/domains/festivals/components/FestivalAttendanceButton.tsx
+++ b/src/domains/festivals/components/FestivalAttendanceButton.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useTransition, useEffect } from 'react'
 import { useMutation, gql } from 'urql'
+import { unwrapMutation } from '@/src/graphql/mutation-result'
 
 const SaveFestivalAttendanceMutation = gql`
   mutation SaveFestivalAttendance($festivalId: ID!, $status: AttendanceStatus!) {
@@ -33,11 +34,14 @@ export function FestivalAttendanceButton({ festivalId, initialStatus }: Festival
         setOpen(false)
         setError(null)
         startTransition(async () => {
-            const { data } = await saveFestivalAttendance({ festivalId, status: value })
-            const result = data?.saveFestivalAttendance
-            if (!result || result.error) {
+            const result = unwrapMutation<{ success?: boolean; error?: string }>(
+                await saveFestivalAttendance({ festivalId, status: value }),
+                'saveFestivalAttendance',
+                'No se pudo guardar la asistencia.'
+            )
+            if (result.error || !result.success) {
                 setStatus(previous)
-                setError(result?.error ?? 'No se pudo guardar la asistencia.')
+                setError(result.error ?? 'No se pudo guardar la asistencia.')
             }
         })
     }

--- a/src/domains/venues/components/VenueForm.test.tsx
+++ b/src/domains/venues/components/VenueForm.test.tsx
@@ -16,6 +16,8 @@ vi.mock('next/navigation', () => ({
 }))
 
 import { VenueForm } from '@/src/domains/venues/components/VenueForm'
+import { TRANSPORT_ERROR_MESSAGE } from '@/src/graphql/mutation-result'
+import { transportError } from '@/src/graphql/transport-failure.testing'
 
 describe('VenueForm', () => {
   beforeEach(() => {
@@ -89,5 +91,19 @@ describe('VenueForm', () => {
   it('links "Cancelar" to the venues list', () => {
     render(<VenueForm />)
     expect(screen.getByRole('link', { name: 'Cancelar' })).toHaveAttribute('href', '/venues')
+  })
+
+  it('stays on the form and surfaces an error when the request never reaches the resolver', async () => {
+    executeMutation.mockResolvedValue({ data: undefined, error: transportError() })
+    render(<VenueForm />)
+
+    await userEvent.type(screen.getByLabelText(/Nombre de la sede/), 'Niceto Club')
+    await userEvent.click(screen.getByRole('button', { name: 'Crear sede' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(TRANSPORT_ERROR_MESSAGE)
+    })
+    expect(push).not.toHaveBeenCalled()
+    expect(screen.getByRole('button', { name: 'Crear sede' })).toBeEnabled()
   })
 })

--- a/src/domains/venues/components/VenueForm.tsx
+++ b/src/domains/venues/components/VenueForm.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useMutation, gql } from 'urql'
+import { unwrapMutation } from '@/src/graphql/mutation-result'
 import { Button, FormField, inputClass } from '@/src/core/components/ui'
 import { routes } from '@/src/core/lib/routes'
 
@@ -26,16 +27,19 @@ export function VenueForm() {
     setExistingId(null)
     setIsSubmitting(true)
     const form = e.currentTarget
-    const { data } = await createVenue({
-      input: {
-        name: (form.elements.namedItem('name') as HTMLInputElement).value,
-        city: (form.elements.namedItem('city') as HTMLInputElement).value || undefined,
-        address: (form.elements.namedItem('address') as HTMLInputElement).value || undefined,
-        country: (form.elements.namedItem('country') as HTMLInputElement).value || undefined,
-      },
-    })
-    const result = data?.createVenue
-    if (result?.error) {
+    const result = unwrapMutation<{ id?: string; existingId?: string; error?: string }>(
+      await createVenue({
+        input: {
+          name: (form.elements.namedItem('name') as HTMLInputElement).value,
+          city: (form.elements.namedItem('city') as HTMLInputElement).value || undefined,
+          address: (form.elements.namedItem('address') as HTMLInputElement).value || undefined,
+          country: (form.elements.namedItem('country') as HTMLInputElement).value || undefined,
+        },
+      }),
+      'createVenue',
+      'No se pudo crear la sede.'
+    )
+    if (result.error) {
       setError(result.error)
       setExistingId(result.existingId ?? null)
       setIsSubmitting(false)

--- a/src/graphql/mutation-result.test.ts
+++ b/src/graphql/mutation-result.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest'
+import { CombinedError } from 'urql'
+import {
+    unwrapMutation,
+    TRANSPORT_ERROR_MESSAGE,
+    MALFORMED_RESPONSE_MESSAGE,
+} from '@/src/graphql/mutation-result'
+
+const networkFailure = () =>
+    new CombinedError({ networkError: new Error('Failed to fetch: connection refused at 10.0.0.1') })
+
+describe('unwrapMutation', () => {
+    it('returns the payload with error undefined when the mutation succeeds', () => {
+        const result = unwrapMutation<{ id?: string; error?: string }>(
+            { data: { createExpense: { id: 'x1' } } },
+            'createExpense'
+        )
+        expect(result).toEqual({ id: 'x1', error: undefined })
+    })
+
+    it('passes a business error from the resolver through unchanged', () => {
+        const result = unwrapMutation(
+            { data: { updateExpense: { error: 'El monto debe ser mayor a 0.' } } },
+            'updateExpense'
+        )
+        expect(result.error).toBe('El monto debe ser mayor a 0.')
+    })
+
+    it('keeps the rest of the payload alongside a business error', () => {
+        const result = unwrapMutation<{ existingId?: string; error?: string }>(
+            { data: { createVenue: { error: 'Ya existe una sede con ese nombre.', existingId: 'v-1' } } },
+            'createVenue'
+        )
+        expect(result.existingId).toBe('v-1')
+        expect(result.error).toBe('Ya existe una sede con ese nombre.')
+    })
+
+    it('reports a transport failure as an error even though data is undefined', () => {
+        const result = unwrapMutation({ data: undefined, error: networkFailure() }, 'deleteExpense')
+        expect(result.error).toBe(TRANSPORT_ERROR_MESSAGE)
+    })
+
+    it('never leaks the raw network/GraphQL error text to the caller', () => {
+        const result = unwrapMutation({ data: undefined, error: networkFailure() }, 'deleteExpense')
+        expect(result.error).not.toMatch(/fetch|10\.0\.0\.1|refused/i)
+    })
+
+    it('reports a transport failure even when data somehow came back too', () => {
+        const result = unwrapMutation(
+            { data: { deleteExpense: {} }, error: networkFailure() },
+            'deleteExpense'
+        )
+        expect(result.error).toBe(TRANSPORT_ERROR_MESSAGE)
+    })
+
+    it('reports an error when the response has no payload for the field', () => {
+        expect(unwrapMutation({ data: {} }, 'deleteExpense').error).toBe(MALFORMED_RESPONSE_MESSAGE)
+        expect(unwrapMutation({ data: { deleteExpense: null } }, 'deleteExpense').error).toBe(
+            MALFORMED_RESPONSE_MESSAGE
+        )
+        expect(unwrapMutation(undefined, 'deleteExpense').error).toBe(TRANSPORT_ERROR_MESSAGE)
+    })
+
+    it('uses the caller-supplied fallback message for a missing payload', () => {
+        const result = unwrapMutation({ data: {} }, 'findOrCreateVenue', 'No se pudo crear la sede.')
+        expect(result.error).toBe('No se pudo crear la sede.')
+    })
+
+    it('treats a null resolver error as success', () => {
+        const result = unwrapMutation<{ inWishlist?: boolean; error?: string }>(
+            { data: { toggleWishlist: { inWishlist: true, error: null } } },
+            'toggleWishlist'
+        )
+        expect(result.error).toBeUndefined()
+        expect(result.inWishlist).toBe(true)
+    })
+})

--- a/src/graphql/mutation-result.ts
+++ b/src/graphql/mutation-result.ts
@@ -1,0 +1,75 @@
+/**
+ * Normalización de resultados de mutations de urql para los client components.
+ *
+ * Una mutation de urql puede fallar por dos canales independientes:
+ *
+ * 1. `result.data.<campo>.error` — el resolver corrió y devolvió un error de
+ *    negocio ("Ya existe una sede con ese nombre.").
+ * 2. `result.error` — la request nunca llegó al resolver: red caída, HTTP 500,
+ *    error de validación de GraphQL. En ese caso `result.data` es `undefined`.
+ *
+ * Mirar solo el primero hace que el segundo se lea como éxito: `data?.x?.error`
+ * es `undefined`, el `if (!error)` da verdadero y la UI aplica el cambio
+ * optimista (borra la fila, navega, muestra el monto nuevo) sobre algo que el
+ * servidor nunca guardó. `unwrapMutation` colapsa los dos canales en la forma
+ * `{ error?: string }` que ya esperan los callers, sin descartar el resto del
+ * payload (`id`, `existingId`, `inWishlist`, …) que algunos necesitan.
+ *
+ * Nunca expone el texto crudo del error de red/GraphQL — mismo criterio que
+ * `sanitizeError` en las Server Actions: mensajes en castellano, sin detalles
+ * internos.
+ */
+
+/** La request no llegó al resolver (red, 500, GraphQL inválido). */
+export const TRANSPORT_ERROR_MESSAGE =
+    'No pudimos conectar con el servidor. Revisá tu conexión e intentá de nuevo.'
+
+/** El resolver respondió, pero sin el payload esperado. */
+export const MALFORMED_RESPONSE_MESSAGE = 'Ocurrió un error inesperado. Intentá de nuevo.'
+
+/** Todo payload de mutation del esquema expone `error` como campo opcional. */
+export interface MutationPayload {
+    error?: string | null
+}
+
+/**
+ * Forma estructural mínima de un `OperationResult` de urql. No importamos el
+ * tipo de urql para que el helper siga siendo testeable con objetos planos.
+ */
+export interface UrqlMutationResult {
+    data?: Record<string, unknown> | null
+    error?: { message?: string } | null
+}
+
+export type UnwrappedMutation<TPayload extends MutationPayload> = Omit<Partial<TPayload>, 'error'> & {
+    error?: string
+}
+
+/**
+ * Devuelve el payload de la mutation con `error` normalizado: string cuando
+ * falló por cualquiera de los dos canales, `undefined` cuando salió bien.
+ *
+ * @param result Lo que resolvió `executeMutation` de urql.
+ * @param field Nombre del campo del payload dentro de `data` (ej. `deleteExpense`).
+ * @param fallbackMessage Mensaje para cuando el resolver responde sin payload.
+ */
+export function unwrapMutation<TPayload extends MutationPayload = MutationPayload>(
+    result: UrqlMutationResult | null | undefined,
+    field: string,
+    fallbackMessage: string = MALFORMED_RESPONSE_MESSAGE
+): UnwrappedMutation<TPayload> {
+    if (!result || result.error) {
+        if (process.env.NODE_ENV === 'development' && result?.error?.message) {
+            console.error(`[graphql] ${field} falló en transporte:`, result.error.message)
+        }
+        return { error: TRANSPORT_ERROR_MESSAGE } as UnwrappedMutation<TPayload>
+    }
+
+    const payload = result.data?.[field] as TPayload | null | undefined
+    if (!payload) {
+        return { error: fallbackMessage } as UnwrappedMutation<TPayload>
+    }
+
+    const { error, ...rest } = payload
+    return { ...rest, error: error ?? undefined } as UnwrappedMutation<TPayload>
+}

--- a/src/graphql/transport-failure.testing.ts
+++ b/src/graphql/transport-failure.testing.ts
@@ -1,0 +1,14 @@
+import { CombinedError } from 'urql'
+
+/**
+ * El `CombinedError` que devuelve urql cuando la mutation nunca llegó al
+ * resolver — red caída, HTTP 500, GraphQL inválido. En ese caso urql resuelve
+ * con `{ data: undefined, error: transportError() }`: `data` no existe, así
+ * que cualquier chequeo que solo mire `data.<campo>.error` lee la falla como
+ * éxito.
+ *
+ * Solo lo usan los tests; ningún módulo de producción lo importa.
+ */
+export function transportError(): CombinedError {
+    return new CombinedError({ networkError: new Error('Failed to fetch') })
+}


### PR DESCRIPTION
## El bug

La migración a GraphQL (#23, PRs #44/#46) dejó un patrón repetido en toda la app: **una mutation que falla se lee como éxito.**

El resultado de una mutation de urql tiene dos canales de falla independientes:

- `result.data.<campo>.error` — error de negocio que devolvió el resolver.
- `result.error` — falla de **transporte**: red caída, HTTP 500, GraphQL inválido. En ese caso **`result.data` es `undefined`**.

Todos los call sites migrados miraban solo el primero:

```ts
const { data } = await deleteExpenseM({ id })
if (!data?.deleteExpense?.error) {        // undefined en falla de transporte → !undefined === true
  setExpenses((prev) => prev.filter((e) => e.id !== id))  // la fila desaparece de la UI
  return {}                                // se reporta como ÉXITO
}
```

Con un corte de red el usuario ve su gasto borrado, no recibe ningún error, y la fila reaparece al recargar porque el servidor nunca lo borró. Lo mismo con las ediciones (muestra el monto nuevo, no persistió nada) y con los submits de formulario (navega como si hubiera guardado).

## La solución

Un helper compartido en `src/graphql/mutation-result.ts` en vez de 13 `if` copiados a mano — así el próximo dominio que se migre no reintroduce el mismo bug:

```ts
unwrapMutation<TPayload>(result, field, fallbackMessage?): Partial<TPayload> & { error?: string }
```

- **Falla de transporte** (`result.error` seteado, `data` undefined) → mensaje en castellano, orientado al usuario. Nunca expone el texto crudo del error de red/GraphQL, mismo criterio que `sanitizeError` en las Server Actions.
- **Error de negocio** (`data.<campo>.error`) → pasa el mensaje tal cual.
- **Éxito** → devuelve el payload con `error: undefined`, **sin descartar el resto de los campos**: `ExpenseQuickAdd` chequea `!result.id`, `findOrCreateVenue`/`findOrCreateArtist` necesitan el registro, y `ArtistForm`/`VenueForm` necesitan `existingId` **junto con** el error de negocio.
- **Payload ausente** (`data` sin el campo, o `null`) → mensaje genérico, o el `fallbackMessage` del caller.

## Call sites enrutados por el helper (13)

Fallaban en silencio — este es el bug real:

| Archivo | Mutations |
| --- | --- |
| `src/domains/expenses/components/EventExpensesPanel.tsx` | create, update, delete |
| `src/domains/expenses/components/ExpenseForm.tsx` | create, update |
| `src/domains/expenses/components/DeleteExpenseAction.tsx` | delete |
| `src/domains/artists/components/ArtistForm.tsx` | create |
| `src/domains/venues/components/VenueForm.tsx` | create |

Ya eran defensivos con `!result` (no tenían el bug de éxito silencioso), pasados al helper para tener un solo mensaje compartido y un solo lugar donde acertar:

| Archivo | Mutations |
| --- | --- |
| `src/domains/events/components/EventForm.tsx` | findOrCreateVenue, findOrCreateArtist |
| `src/domains/artists/components/WishlistButton.tsx` | toggleWishlist |
| `src/domains/festivals/components/FestivalAttendanceButton.tsx` | saveFestivalAttendance |
| `app/festivals/nuevo/page.tsx` | createFestival |

Los `getClient().query()` de los Server Components quedan fuera de este PR a propósito: tienen otro modo de falla, mucho más visible.

## Tests

Cada uno de los 13 call sites tiene un test que resuelve la mutation como lo hace urql en una falla de transporte — `{ data: undefined, error: new CombinedError(...) }` — y verifica que el cambio optimista **no** se aplica y que **sí** aparece un error. Mismo patrón de mock de urql que dejó el PR #47.

Prueba de que los tests miden algo: revertir los 13 call sites y dejar los tests hace fallar exactamente 12 de ellos (el 13.º, `app/festivals/nuevo`, ya era defensivo y tiene test nuevo igual).

Más 9 tests unitarios de `unwrapMutation`, incluido uno que verifica que el texto crudo del error de red nunca llega al caller.

**894 → 918 tests** (105 → 107 archivos), todo en verde: `npm run lint`, `npx tsc --noEmit`, `npm test`.

## Fuera de la lista original

- **`app/festivals/nuevo/page.tsx`** — 13.º call site que faltaba en el inventario. Ya chequeaba `!result`, así que no tenía el bug de éxito silencioso, pero no tenía ningún test; ahora tiene tres.
- **`FestivalAttendanceButton` ignoraba `success: false`** — el mismo bug de éxito silencioso un campo más allá: el resolver podía responder `{ success: false }` sin `error` y la UI dejaba el estado optimista puesto. Ahora chequea `result.error || !result.success`.
- **El error de `app/festivals/nuevo` no tiene `role="alert"`**, a diferencia de todos los otros formularios de la app. No lo toqué para no mezclar accesibilidad con este fix, pero queda anotado.
