### PR TITLE
docs: audit and update docs for the GraphQL migration and new domains

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,10 +13,10 @@
     *   Seguí el estilo de código existente (TypeScript estricto, Tailwind CSS).
     *   Usá Server Components por defecto, `use client` solo cuando sea necesario (interactividad).
     *   Los comentarios tienen que valerse por sí solos — explicá el POR QUÉ cuando no sea obvio, nunca dejes referencias a discusiones o sesiones internas que alguien de afuera no puede ver.
-5.  **Probá antes de abrir el PR**:
+5.  **Probá antes de abrir el PR** (mismos comandos que corre la CI en `.github/workflows/ci.yml`):
+    *   `npm run lint` (ESLint, flat config)
     *   `npx tsc --noEmit` (tipos)
-    *   `npx vitest run` (tests)
-    *   `npx eslint app src --ext .ts,.tsx` (lint)
+    *   `npm test` (Vitest — `npm run test:coverage` si querés ver cobertura)
 6.  **Pull Request**:
     *   Describí qué cambios hiciste y por qué.
     *   Adjuntá capturas de pantalla si cambiaste algo visual.
@@ -24,14 +24,17 @@
 ## 🏗 Estructura y Convenciones
 
 ### Estructura de Directorios
-Adoptamos una estructura basada en **Dominios** dentro de `src/domains`. Cada dominio (ej: `artists`, `events`) debe contener:
+Adoptamos una estructura basada en **Dominios** dentro de `src/domains`. Cada dominio (ej: `artists`, `events`) suele contener:
 - `components/`: Componentes UI específicos.
-- `actions.ts`: Server Actions (ver nota de migración abajo).
-- `data.ts`: Fetching de datos.
+- `data.ts`: Fetching de datos (lecturas).
+- `service.ts`: Casos de uso de escritura — el seam del que cuelgan tanto los resolvers de GraphQL (`src/graphql/<dominio>.ts`) como, si todavía existen, las Server Actions del dominio.
+- `actions.ts`: Server Actions. **Ya no es universal** — `artists`, `expenses`, `festivals` y `venues` no tienen `actions.ts`, migraron por completo a GraphQL. Solo sigue existiendo donde GraphQL no puede resolver el caso (ver abajo) o donde todavía no se migró.
 - `types.ts`: Tipos específicos (si no están en `core/types`).
 
 ### ⚠️ Migración en curso: Server Actions → GraphQL
-El backend está migrando de Server Actions a una API GraphQL real (ver [issue de la migración](https://github.com/Lantieridev/Ritual/issues/23)) — es normal encontrar ambos patrones conviviendo en el código por ahora. **Si tu contribución necesita un endpoint de backend nuevo, agregalo en `src/graphql/`, no como una Server Action nueva** — evita sumar más deuda a lo que después hay que migrar.
+El backend está migrando de Server Actions a una API GraphQL real (ver [issue #23](https://github.com/Lantieridev/Ritual/issues/23) y [ADR 0004](./docs/adr/0004-graphql-migration-strangler-fig.md)) — es normal encontrar ambos patrones conviviendo en el código por ahora. **Si tu contribución necesita un endpoint de backend nuevo, agregalo en `src/graphql/`, no como una Server Action nueva** — evita sumar más deuda a lo que después hay que migrar.
+
+Estado real al momento de escribir esto: `artists`, `expenses`, `festivals` y `venues` ya son 100% GraphQL. `events` y `auth` son híbridos (alta/edición/borrado de evento y edición de perfil ya son GraphQL; asistencia, fotos, avatar, login/signup/signout y reset de contraseña siguen como Server Action). `showmode` (modo recital activo) todavía no migró. Una Server Action nueva solo se justifica si el caso no puede pasar por un resolver — por ejemplo, subir un archivo (`FormData`) sin un scalar `Upload` configurado en Yoga, como pasa hoy con el avatar (`src/domains/auth/avatar-actions.ts`).
 
 ### Stack
 - **Next.js 16**: Usamos App Router.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ Porque la música es cultura compartida. Queremos que RITUAL sea construido por 
 - **Frontend**: [Next.js 16](https://nextjs.org/) (App Router) + TypeScript.
 - **Estilos**: [Tailwind CSS 4](https://tailwindcss.com/) + CSS Variables.
 - **Backend**: [Supabase](https://supabase.com/) (PostgreSQL, Auth, Storage).
-- **APIs Externas**: Last.fm, Spotify, Setlist.fm, Ticketmaster.
+- **API**: GraphQL ([GraphQL Yoga](https://the-guild.dev/graphql/yoga-server) + [Pothos](https://pothos-graphql.dev/), code-first) consumido con [urql](https://commerce.nearform.com/open-source/urql/) — reemplazando Server Actions dominio por dominio (migración en curso, ver [issue #23](https://github.com/Lantieridev/Ritual/issues/23) y [ADR 0004](./docs/adr/0004-graphql-migration-strangler-fig.md)).
+- **APIs Externas**: Last.fm, Spotify, Setlist.fm, Ticketmaster, Open-Meteo.
 
 ## 🚀 Instalación Local
 
@@ -92,28 +93,34 @@ flowchart TB
     subgraph NextApp["Next.js App Router"]
         Middleware["proxy.ts\n(auth guard + cookie refresh)"]
         Routes["app/\n(rutas y páginas)"]
-        Domains["src/domains/\nartists · events · expenses\nfestivals · venues · auth · stats"]
+        GraphQL["src/graphql/\nYoga + Pothos schema\n(artists · auth · events · expenses\nfestivals · stats · venues)"]
+        Domains["src/domains/\nartists · auth · events · expenses\nfestivals · showmode · stats · venues · weather"]
         Core["src/core/\nUI base · auth · tipos · lib"]
     end
 
     Supabase[("Supabase\nPostgreSQL + Auth + Storage")]
-    External["APIs externas\nLast.fm · Spotify\nSetlist.fm · Ticketmaster"]
+    External["APIs externas\nLast.fm · Spotify\nSetlist.fm · Ticketmaster · Open-Meteo"]
 
     Browser -->|request| Middleware
     Middleware -->|user autenticado?| Routes
-    Routes --> Domains
+    Routes -->|reads/writes ya migrados: urql + yoga.fetch in-process| GraphQL
+    Routes -->|resto: Server Actions| Domains
+    GraphQL --> Domains
     Domains --> Core
-    Core -->|server.ts / client.ts| Supabase
+    Core -->|server.ts| Supabase
     Domains -.->|opcional, degrada sin key| External
 ```
 
-Decisiones de arquitectura documentadas en [`docs/adr/`](./docs/adr/README.md) — por qué `core/` vs `domains/`, por qué el cliente de Supabase está partido en tres, y por qué las API keys externas son opcionales.
+Cuatro de seis dominios con escritura (`artists`, `expenses`, `festivals`, `venues`) ya migraron por completo a GraphQL. `events` y `auth` son híbridos: alta/edición/borrado de eventos y edición de perfil pasan por GraphQL, pero asistencia, fotos, avatar, login/signup/signout y reset de contraseña siguen siendo Server Actions. `showmode` (modo recital activo) es 100% Server Actions por ahora — no migró en esta tanda.
+
+Decisiones de arquitectura documentadas en [`docs/adr/`](./docs/adr/README.md) — por qué `core/` vs `domains/`, por qué el cliente de Supabase está partido por contexto de ejecución, por qué las API keys externas son opcionales, y por qué el backend está migrando de Server Actions a GraphQL.
 
 ## 📂 Estructura del Proyecto
 
-- `app/`: Rutas y páginas (Next.js App Router).
+- `app/`: Rutas y páginas (Next.js App Router), incluye `app/api/graphql/` (endpoint único de GraphQL).
 - `src/core/`: Componentes base (UI), librerías (Supabase, API clients) y tipos globales.
-- `src/domains/`: Lógica de negocio dividida por dominio (Artists, Events, Auth, Venues).
+- `src/domains/`: Lógica de negocio dividida por dominio (Artists, Auth, Events, Expenses, Festivals, Show Mode, Stats, Venues, Weather).
+- `src/graphql/`: Schema GraphQL (Pothos) y servidor (Yoga) — un archivo por dominio migrado, ver [`docs/estructura-del-proyecto.md`](./docs/estructura-del-proyecto.md).
 - `supabase/`: Migraciones y configuración de base de datos.
 - `docs/`: Documentación del proyecto (incluye [`adr/`](./docs/adr/README.md), decisiones de arquitectura).
 

--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -14,6 +14,8 @@ Ritual tiene dos roles reales hoy: **visitante sin sesión** y **usuario autenti
 | Gastos personales | ❌ No tiene sentido sin cuenta | ✅ Propios únicamente |
 | Fotos de eventos | ✅ Ve todas | ✅ Ve todas, borra solo las propias |
 | Perfil de usuario | — | ✅ Propio únicamente |
+| Modo recital activo (preferencias, checklist pre-show) | ❌ No tiene sentido sin cuenta | ✅ Propio únicamente |
+| Clima exacto de un show | ✅ Ve todo (si la sede tiene lat/lng) | ✅ Ve todo (si la sede tiene lat/lng) |
 
 ## Por qué la nav se separó en dos grupos
 
@@ -23,6 +25,6 @@ El catálogo compartido (Artistas, Sedes, Festivales, Buscar, Stats) tiene senti
 
 ## Cómo se aplica en el backend
 
-Todo lo de la tabla de arriba está reforzado con Row Level Security en Postgres, no solo en la UI — un usuario no puede escribir datos de otro aunque manipule la request directamente. Cada Server Action de escritura además valida la sesión de entrada (`getCurrentUserId()`) antes de tocar la base, para fallar con un mensaje claro en vez de depender solo del rechazo silencioso de RLS.
+Todo lo de la tabla de arriba está reforzado con Row Level Security en Postgres, no solo en la UI — un usuario no puede escribir datos de otro aunque manipule la request directamente. Cada operación de escritura además valida la sesión de entrada (`getCurrentUserId()`) antes de tocar la base, para fallar con un mensaje claro en vez de depender solo del rechazo silencioso de RLS — da igual si esa escritura llega por una Server Action o por un resolver de mutación GraphQL (`src/graphql/`): ambos caminos llaman al mismo `service.ts` del dominio, que es donde vive esa validación (ver [ADR 0004](./adr/0004-graphql-migration-strangler-fig.md)).
 
 No existe hoy ningún concepto de "administrador" ni de contenido moderado por la app — cualquier fila del catálogo compartido (evento, artista, sede, festival) puede ser creada o editada por cualquier usuario autenticado, no solo por quien la creó originalmente. Si en el futuro se agrega un rol de administrador (por ejemplo, para publicar noticias o moderar el catálogo), este documento es el lugar para registrar esa distinción.

--- a/docs/adr/0001-domain-based-folder-structure.md
+++ b/docs/adr/0001-domain-based-folder-structure.md
@@ -10,7 +10,7 @@ RITUAL no es un CRUD simple: mezcla itinerarios, gastos, perfiles, festivales/gi
 Separar el código en dos capas:
 
 - **`src/core/`**: lo transversal — componentes de UI reutilizables, clientes de Supabase, autenticación, tipos globales, utilidades. No conoce ningún dominio específico.
-- **`src/domains/<dominio>/`**: la lógica de negocio agrupada por dominio (`artists`, `events`, `expenses`, `festivals`, `venues`, `auth`, `stats`). Cada dominio tiene sus propios `actions.ts`, `data.ts` y componentes.
+- **`src/domains/<dominio>/`**: la lógica de negocio agrupada por dominio (`artists`, `events`, `expenses`, `festivals`, `venues`, `auth`, `stats`, y luego `showmode` y `weather`). Cada dominio tiene sus propios `data.ts` y componentes; `actions.ts` era universal al momento de este ADR pero dejó de serlo con la migración a GraphQL — ver [ADR 0004](./0004-graphql-migration-strangler-fig.md).
 - **`app/`**: solo rutas y composición de página, importando de `core/` y `domains/`.
 
 ## Consecuencias

--- a/docs/adr/0002-supabase-client-split-by-execution-context.md
+++ b/docs/adr/0002-supabase-client-split-by-execution-context.md
@@ -7,7 +7,7 @@ Aceptada
 Next.js App Router ejecuta código en tres contextos distintos con reglas de cookies diferentes: Client Components (browser), Server Components/Server Actions (request-scoped, cookies read-only en algunos casos) y Middleware (puede escribir cookies en la respuesta). Un único cliente de Supabase genérico rompe en alguno de los tres apenas se usa fuera de su contexto original — es el error clásico de SSR con Supabase Auth (sesión que no persiste, o que se cae en producción y no en local).
 
 ## Decisión
-Tres módulos separados en `src/core/lib/supabase/`, cada uno con su propia estrategia de cookies:
+Módulos separados en `src/core/lib/supabase/`, cada uno con su propia estrategia de cookies:
 
 - **`client.ts`** — `createBrowserClient`, sin manejo de cookies (lo hace el browser).
 - **`server.ts`** — `createServerClient` usando `next/headers` `cookies()`; `setAll` está envuelto en try/catch porque Server Components no pueden escribir cookies (se asume que el middleware refresca la sesión).
@@ -17,3 +17,6 @@ Tres módulos separados en `src/core/lib/supabase/`, cada uno con su propia estr
 - Cada archivo se importa solo desde su contexto correspondiente — nunca `server.ts` desde un Client Component ni viceversa.
 - La protección de rutas está centralizada en el middleware, no repetida en cada página protegida.
 - Si se agrega una ruta protegida nueva, hay que sumarla a `protectedPaths` en `middleware.ts` — es manual, no hay convención de carpeta (ej. `(protected)/`) que lo haga automático todavía. Si la lista crece mucho vale la pena revisar ese approach.
+
+## Nota (2026-08-23)
+`client.ts` (el módulo browser de la lista de arriba) se eliminó el 2026-07-11 (`18b7a5e`, sin relación con la migración a GraphQL) — no quedó ningún Client Component que necesitara `createBrowserClient` directo. Los dos módulos que sí siguen vivos y activos son `server.ts` y `middleware.ts`; la decisión de fondo (un cliente por contexto de ejecución, nunca uno genérico) sigue vigente, solo que hoy son dos contextos con módulo propio en vez de tres. Si en algún momento un Client Component necesita leer Supabase directo otra vez, este es el lugar para recrear `client.ts` siguiendo el mismo patrón — no reintroducir un cliente genérico.

--- a/docs/adr/0004-graphql-migration-strangler-fig.md
+++ b/docs/adr/0004-graphql-migration-strangler-fig.md
@@ -1,0 +1,44 @@
+# 0004 — Migración de Server Actions a GraphQL (Yoga + Pothos + urql), patrón strangler fig
+
+## Estado
+Aceptada — en curso (issue [#23](https://github.com/Lantieridev/Ritual/issues/23))
+
+## Contexto
+El backend usaba Server Actions de Next.js para todas las escrituras. Server Actions solo funcionan dentro de esa misma app web: un cliente separado (por ejemplo una futura PWA o app nativa en Swift/Kotlin) no puede consumirlas. En vez de mantener para siempre una arquitectura mitad Server Actions / mitad API, se decidió reescribir el backend como una API GraphQL real.
+
+## Decisión
+
+### Stack elegido
+- **GraphQL Yoga** como servidor — liviano, se integra bien con route handlers de Next.js App Router (`app/api/graphql/route.ts` reexporta `yoga.handleRequest`).
+- **Pothos** para el schema, code-first — tipos TypeScript en vez de archivos `.graphql` separados y sin codegen; los tipos de respuesta se escriben a mano en `src/core/types/index.ts`.
+- **urql** como cliente — más liviano que Apollo Client para el tamaño de esta app.
+
+Se descartó **tRPC** (la alternativa típica en el ecosistema Next.js) porque depende de compartir tipos de TypeScript entre cliente y servidor — no sirve para un cliente nativo real en Swift/Kotlin, que es justo el caso que motiva dejar de depender de Server Actions.
+
+### Ejecución in-process (sin round-trip HTTP)
+Los Server Components leen con `getClient().query()` (`src/graphql/client.ts`), un cliente urql cuyo `fetch` apunta a `yoga.fetch` directamente en vez de hacer una request HTTP real contra la propia app (ver PR #44). Se comprobó empíricamente (probe query leyendo `cookies()` dentro de un resolver) que Next.js sigue propagando las cookies de sesión a esa ejecución in-process, así que la autenticación no se pierde. La URL de fetch (`http://localhost/api/graphql`) nunca se marca — solo tiene que matchear el `graphqlEndpoint` que Yoga espera, porque Yoga rutea sobre ese path y devuelve 404 a cualquier otro (bug real encontrado y corregido en PR #44).
+
+Los Client Components escriben con `useMutation` de urql, desenvolviendo el resultado con el helper `unwrapMutation` (`src/graphql/mutation-result.ts`).
+
+### Patrón de migración: strangler fig
+Migración incremental a propósito, no un reemplazo de todo junto:
+1. Se construyó primero el schema de GraphQL completo (queries y mutations) para los dominios con escritura.
+2. Se apuntó el frontend real (páginas y componentes) a GraphQL dominio por dominio, verificando que no rompiera nada.
+3. El `actions.ts` de cada dominio se borra una vez que nadie lo importa — no antes.
+
+Cualquier feature nueva que necesite un endpoint de backend se agrega directo en `src/graphql/`, no como una Server Action nueva (ver `CONTRIBUTING.md`).
+
+### Estado real (2026-08-23, tras PRs #44/#46/#49)
+- **Queries**: los 7 dominios con lectura relevante (`artists`, `auth`, `events`, `expenses`, `festivals`, `stats`, `venues`) tienen schema en `src/graphql/`.
+- **Mutations — 100% migrados** (sin `actions.ts` en el dominio): `artists`, `expenses`, `festivals`, `venues`.
+- **Mutations — híbridos**: `events` (alta/edición/borrado de evento y `addExternalEvent` ya son GraphQL; asistencia y fotos siguen como Server Action en `attendance-actions.ts`/`photo-actions.ts`) y `auth` (edición de perfil ya es GraphQL; login/signup/signout/reset de contraseña siguen en `src/core/auth/actions.ts`, y el avatar queda como Server Action a propósito — ver más abajo).
+- **Sin migrar**: `showmode` (modo recital activo, issue #9) — es 100% Server Actions, no le tocó turno todavía.
+
+### Excepción deliberada: subida de archivos
+El avatar de perfil (`src/domains/auth/avatar-actions.ts`) sigue siendo una Server Action a propósito y va a seguir siéndolo aunque el resto de `auth` termine de migrar: recibe un `File` por `FormData`, y GraphQL Yoga no tiene un scalar `Upload` configurado en este proyecto. La URL que devuelve entra después por `avatar_url` a la misma mutación `updateProfile`, para que la escritura a la tabla `profiles` tenga un solo camino.
+
+## Consecuencias
+- Mientras dura la migración, el código convive con dos patrones de backend a propósito — no es deuda accidental, es la forma elegida de migrar sin un big-bang. `CONTRIBUTING.md` documenta esto para quien contribuya código nuevo mientras tanto.
+- La validación de sesión (`getCurrentUserId()`) vive en `service.ts`, no en `actions.ts` ni en el resolver — así un mismo caso de uso sirve de caller tanto a una Server Action como a un resolver GraphQL sin duplicar la validación (ver `docs/access-control.md`).
+- Cualquier integración futura que necesite subir archivos binarios tiene el mismo problema que el avatar: hasta que no se configure un scalar `Upload` en Yoga, esa escritura puntual se queda en Server Action aunque el resto del dominio esté en GraphQL.
+- El cliente urql in-process ahorra un round-trip HTTP en cada lectura server-side, pero acopla la validez de esa optimización a que Next.js siga propagando cookies a `yoga.fetch` tal como lo hace hoy — si eso cambiara en una versión futura de Next.js, las lecturas server-side dejarían de autenticar silenciosamente. Vale la pena un test de regresión sobre ese comportamiento si no existe todavía.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -7,6 +7,7 @@ Registro de decisiones de arquitectura de RITUAL. Cada ADR documenta una decisi�
 | [0001](./0001-domain-based-folder-structure.md) | Estructura de carpetas por dominio (`core/` vs `domains/`) | Aceptada |
 | [0002](./0002-supabase-client-split-by-execution-context.md) | Cliente Supabase separado por contexto de ejecución (browser/server/middleware) | Aceptada |
 | [0003](./0003-optional-external-api-keys-graceful-degradation.md) | Las API keys externas opcionales degradan sin romper el build | Aceptada |
+| [0004](./0004-graphql-migration-strangler-fig.md) | Migración de Server Actions a GraphQL (Yoga + Pothos + urql), patrón strangler fig | Aceptada — en curso |
 
 ## Cuándo agregar un ADR nuevo
 

--- a/docs/api-eventos-futuro.md
+++ b/docs/api-eventos-futuro.md
@@ -5,7 +5,7 @@
 - **Objetivo**: Buscar recitales futuros por artista o por ciudad sin cargar la base de datos. Solo se persiste lo que el usuario agrega.
 - **Config**: `TICKETMASTER_API_KEY` en `.env.local` (opcional; sin ella la búsqueda de shows futuros no está disponible, pero el resto de la app funciona igual).
 - **Ruta**: `/buscar` (tab "Shows futuros"). También alimenta el badge de próximos shows en `/wishlist`.
-- **Código**: `src/core/lib/ticketmaster.ts` (cliente), `src/domains/events/actions.ts` → `addExternalEvent`, página `app/buscar/page.tsx`.
+- **Código**: `src/core/lib/ticketmaster.ts` (cliente), `src/domains/events/service.ts` → `addExternalEvent` (expuesta como mutación GraphQL en `src/graphql/events.ts`, ya no como Server Action — ver [ADR 0004](./adr/0004-graphql-migration-strangler-fig.md)), página `app/buscar/page.tsx`.
 - **Historial pasado**: usa Setlist.fm por separado (`src/core/lib/setlistfm.ts`), tab "Historial pasado" en la misma página.
 
 Cada resultado tiene "Agregar", que crea evento + sede + artista en nuestra DB si no existen (`findOrCreateByName` en `src/core/lib/find-or-create.ts`).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -40,6 +40,17 @@ No existe el concepto de "gira" (tour): se evaluó en el diseño original pero n
 * **`festival_attendance`**: Asistencia del usuario a un `festival` (independiente de la de sus `events` individuales, si los tiene vinculados). Mismo patrón plano que `attendance`.
     * `festival_id`, `user_id`, `status`, `rating`, `review`.
 
+### E. Modo Recital Activo (Show Mode)
+Cuatro tablas nuevas (migración `20260823100000_show_mode.sql`, issue #9), todas por usuario y con RLS de dueño — no hay lectura pública acá, a diferencia del catálogo:
+* **`user_preferences`**: una fila por usuario (PK = `id` = `auth.users.id`). Ventana configurable del modo recital: `show_mode_days_before` (default 7), `show_mode_days_after` (default 2). Genérica a propósito — no `show_mode_preferences` — porque es el primer lugar del proyecto donde vive una preferencia de usuario; las que vengan después entran acá como columnas nuevas.
+* **`checklist_template_items`**: la plantilla base del usuario (`label`, `position`), configurada una vez y reusada en todos los shows.
+* **`event_checklist_items`**: ítems ad-hoc de un show puntual (no vienen de la plantilla), con su propio `checked`.
+* **`event_checklist_checks`**: el tilde de un ítem de la *plantilla* para un show específico — PK compuesta `(user_id, event_id, template_item_id)`, `ON DELETE CASCADE` en las tres. No se copian los textos de la plantilla a cada show: si se copiaran, editar la plantilla no se reflejaría en shows futuros y borrar un ítem dejaría copias huérfanas. Guardando solo el tilde por `(evento, ítem)`, la plantilla sigue siendo la única fuente de verdad del texto.
+
+La ventana de tiempo en sí (qué shows "están en modo recital activo" ahora) es una función pura sobre `events.date` + `user_preferences`, no una columna ni una vista — ver `src/domains/showmode/window.ts`.
+
+El clima exacto del show (feature separada, mismo momento) no agrega tablas: `weather-service.ts` llama a Open-Meteo en cada request usando `venues.lat`/`venues.lng` + `events.date`, sin persistir nada.
+
 ## 3. Flujos de Usuario
 
 ### Caso 1: Asistir a un Festival (con días vinculados)

--- a/docs/estructura-del-proyecto.md
+++ b/docs/estructura-del-proyecto.md
@@ -14,8 +14,9 @@ src/
     lib/
       supabase/
         server.ts            # Cliente de Supabase para Server Components/Actions
-        client.ts            # Cliente de Supabase para Client Components
         middleware.ts        # Cliente de Supabase usado por proxy.ts (auth guard)
+                              # (no hay client.ts — se eliminó, ningún Client Component
+                              # necesita Supabase directo hoy; ver ADR 0002)
       routes.ts               # Rutas centralizadas (evita strings mágicos)
       dates.ts, validation.ts, env.ts, spotify.ts, lastfm.ts…
     types/
@@ -25,36 +26,67 @@ src/
       layout/                 # Navbar, Footer, PageShell
       home/                   # Piezas compuestas específicas del Home
 
-  domains/                    # Un folder por dominio (datos + acciones + vistas + componentes)
-    events/
+  domains/                    # Un folder por dominio (datos + acciones/servicio + vistas + componentes)
+    events/                    # Híbrido: alta/edición/borrado de evento ya es GraphQL,
+                                # asistencia y fotos siguen como Server Action.
       data.ts                 # getEvents, getEventById, getEventsWithAttendance
-      actions.ts               # createEvent, updateEvent, deleteEvent
-      attendance-data.ts / attendance-actions.ts
-      photo-actions.ts
+      service.ts               # insertEvent, modifyEvent, removeEvent, addExternalEvent
+                                # — casos de uso detrás de las mutations de src/graphql/events.ts
+                                # (actions.ts se borró cuando se migró, PR #49)
+      attendance-data.ts / attendance-actions.ts   # Server Actions, sin migrar
+      photo-actions.ts                              # Server Action, sin migrar
       home-view.ts             # Lógica pura para el hero del Home (testeada sin renderizar)
       components/
-    venues/
-    artists/
+    venues/                    # 100% GraphQL — sin actions.ts
+      service.ts
+    artists/                   # 100% GraphQL — sin actions.ts
       collection-view.ts       # Lógica pura para Colección (artistas+sedes+festivales)
       enrichment.ts             # Enriquecimiento con Spotify/Last.fm
-    festivals/
-    expenses/                  # Gastos personales, privados por usuario (RLS)
+      service.ts, wishlist-service.ts
+    festivals/                 # 100% GraphQL — sin actions.ts
+      service.ts, write-service.ts
+    expenses/                  # 100% GraphQL — sin actions.ts. Gastos personales, privados por usuario (RLS)
+      service.ts, categories.ts, comparisons.ts, grouping.ts
     stats/
       wrapped-view.ts           # Lógica del resumen anual "Wrapped"
-    auth/                       # Perfil, login/signup, acciones de sesión
+    auth/                       # Híbrido: edición de perfil ya es GraphQL (service.ts →
+                                 # updateProfile), login/signup/signout/reset de contraseña
+                                 # siguen en src/core/auth/actions.ts (Server Actions).
+      service.ts, data.ts
+      avatar-actions.ts         # Server Action a propósito: recibe un File por FormData,
+                                 # y Yoga no tiene un scalar Upload configurado.
+    showmode/                   # "Modo recital activo" (issue #9) — checklist pre-show,
+                                 # ventana configurable, tarjeta-recuerdo. 100% Server Actions,
+                                 # no migró en esta tanda.
+      actions.ts, service.ts, data.ts, checklist.ts, pending.ts, preferences.ts, window.ts, memory-card.ts
+    weather/                    # Clima exacto del show vía Open-Meteo (issue #8). Servicio de
+                                 # servidor puro: sin actions.ts ni resolver GraphQL, se llama
+                                 # directo desde Server Components.
+      open-meteo.ts, weather-service.ts, icons.ts
 
-  graphql/                     # Capa GraphQL (Pothos + Yoga), en migración progresiva
-                                # desde Server Actions — ver issue #23. Un archivo por
-                                # dominio (events.ts, artists.ts…), mismo split que domains/.
-    builder.ts, schema.ts, context.ts
+  graphql/                     # Capa GraphQL (Pothos + Yoga), migración progresiva desde
+                                # Server Actions — ver issue #23 y ADR 0004. Un archivo de
+                                # schema por dominio migrado: artists.ts, auth.ts, events.ts,
+                                # expenses.ts, festivals.ts, stats.ts, venues.ts.
+    builder.ts                 # Instancia de Pothos SchemaBuilder
+    schema.ts                  # Ensambla el schema final a partir de los archivos por dominio
+    context.ts                 # createGraphQLContext — cliente Supabase + userId por request
+    client.ts                  # Cliente urql (Server Components) — apunta a yoga.fetch
+                                # in-process, nunca hace un round-trip HTTP real
+    yoga.ts                    # Instancia de GraphQL Yoga, montada en app/api/graphql/route.ts
+    shared.ts, mutation-result.ts  # MutationResultRef + unwrapMutation: el shape común de
+                                    # resultado de mutation que consumen los Client Components
+    provider.tsx                # Provider de urql para Client Components
+    health.ts                   # Query de healthcheck
 
 app/                           # Solo rutas y páginas (importan de src/core, src/domains, src/graphql)
-  api/graphql/                 # Endpoint único de GraphQL (Yoga)
+  api/graphql/                 # Endpoint único de GraphQL (Yoga) — route.ts reexporta
+                                # yoga.handleRequest en GET/POST/OPTIONS
   page.tsx                     # Home
   layout.tsx
   coleccion/                   # Artistas + Sedes + Festivales unificados
   events/, venues/, artists/, festivals/, expenses/, stats/, wishlist/, wrapped/
-  login/, signup/, profile/
+  login/, signup/, profile/, modo-recital/
   buscar/ (activa) — search/ (alias legado, ver R2-009)
 
 proxy.ts                       # Auth guard + refresh de cookies (antes middleware.ts, ver docs/adr)
@@ -76,9 +108,10 @@ proxy.ts                       # Auth guard + refresh de cookies (antes middlewa
 
 ### Imports
 
-- Páginas en `app/`: importan de `@/src/core/*`, `@/src/domains/*` y (progresivamente) `@/src/graphql/*`.
-- Dentro de un dominio: `data.ts` y `actions.ts` importan de `@/src/core/lib/supabase/server` y `@/src/core/types`.
-- Componentes de dominio: importan de `@/src/core/components/ui` y `@/src/core/lib/routes`.
+- Páginas en `app/`: importan de `@/src/core/*`, `@/src/domains/*` y `@/src/graphql/*` — este último ya es el camino principal de escritura para `artists`, `expenses`, `festivals` y `venues`, y de lectura server-side vía `getClient().query()` donde se migró (ver `docs/adr/0004-graphql-migration-strangler-fig.md`).
+- Dentro de un dominio: `data.ts`, `service.ts` y (donde sigue existiendo) `actions.ts` importan de `@/src/core/lib/supabase/server` y `@/src/core/types`.
+- Resolvers en `src/graphql/<dominio>.ts`: importan las funciones de `service.ts`/`data.ts` del dominio correspondiente — nunca acceden a Supabase directamente.
+- Componentes de dominio: importan de `@/src/core/components/ui`, `@/src/core/lib/routes` y, para mutaciones ya migradas, `useMutation` de `urql` + `unwrapMutation` de `@/src/graphql/mutation-result`.
 
 ---
 
@@ -89,6 +122,7 @@ proxy.ts                       # Auth guard + refresh de cookies (antes middlewa
 - **Campos**: user_id, amount, category, note, event_id (opcional, para asociar a un recital), date.
 - **Rutas**: `/expenses` (listado), `/expenses/nuevo` (formulario), `/expenses/[id]/editar`.
 - Sin sesión, `requireUserId()` devuelve un error de "iniciá sesión" — no hay bypass de desarrollo (el `RITUAL_DEV_USER_ID` de versiones tempranas del proyecto ya no existe; usá un usuario real de Supabase Auth).
+- **Capa de datos**: `src/domains/expenses/service.ts` (casos de uso) + `data.ts`, `categories.ts`, `comparisons.ts`, `grouping.ts`. Expuesto íntegramente por GraphQL (`src/graphql/expenses.ts`) — no queda `actions.ts` en este dominio.
 
 ---
 

--- a/docs/usuarios-y-perfiles.md
+++ b/docs/usuarios-y-perfiles.md
@@ -1,21 +1,26 @@
-# Usuarios y perfiles (futuro)
+# Usuarios y perfiles
 
-Cada usuario tendrá su propio historial de recitales (a los que fue, a los que va, etc.) y una especie de perfil. Este doc resume cómo está preparada la base y qué tocar cuando sumemos auth.
+> Este doc describía originalmente un estado "futuro" (auth sin implementar todavía, tabla `memories` separada). Ambas cosas ya pasaron y cambiaron de forma: auth está implementado desde hace tiempo, y `memories` se eliminó en la migración `20260722010000_fold_memories_into_attendance.sql` — sus columnas (`rating`, `review`, `notes`) viven ahora directo en `attendance` (ver `docs/architecture.md`, nota histórica). Lo que sigue es el estado real.
 
-## Ya existe en la DB
+## Auth: implementado
 
-- **`profiles`**: id (FK a auth.users), username, avatar_url, bio. Se crea con el trigger al registrarse.
-- **`attendance`**: user_id (FK a profiles), event_id, status (`interested` | `going` | `went`). Es la tabla “mis recitales” por usuario.
-- **`memories`**: vinculado a attendance (rating, review, media_urls) para después.
+- **Supabase Auth** vía `@supabase/ssr`. Sesión resuelta server-side con `getCurrentUserId()` (`src/core/auth/session.ts`) — fuente única de verdad, no se repite por página.
+- **Rutas**: `/login`, `/signup`, `/forgot-password`, `/reset-password`, `/profile`, `/profile/edit`.
+- **Mutaciones de sesión** (`login`, `signup`, `signout`, `requestPasswordReset`, `updatePassword`): Server Actions en `src/core/auth/actions.ts`. No migraron a GraphQL — no hay una razón técnica que lo impida, simplemente no les tocó turno todavía en la migración del issue #23.
+- **Edición de perfil** (`modifyProfile`/`updateProfile`): sí migró a GraphQL (`src/graphql/auth.ts`, mutación `updateProfile`), consumida desde `ProfileForm` con `useMutation` de urql.
+- **Avatar**: sigue siendo Server Action a propósito (`src/domains/auth/avatar-actions.ts`) — recibe un `File` por `FormData`, y GraphQL Yoga no tiene un scalar `Upload` configurado. La URL resultante se guarda con el mismo `modifyProfile` de arriba, para que la escritura a `profiles` tenga un solo camino.
+- **Protección de rutas**: `proxy.ts` (middleware de Next.js) redirige a `/login` en `/profile`, `/wishlist`, `/stats`, `/expenses` si no hay sesión — ver `src/core/lib/supabase/middleware.ts` y [ADR 0002](./adr/0002-supabase-client-split-by-execution-context.md).
 
-## Cuando agreguemos auth
+## Modelo de datos real
 
-1. **Supabase Auth**: ya está el cliente; faltará usar `getUser()` en layout o middleware y pasar usuario a componentes que lo necesiten.
-2. **Rutas pensadas**: `/perfil` o `/me` (ver/editar perfil), listado “Mis recitales” filtrando por `attendance.user_id = auth.uid()`.
-3. **RLS**: attendance y memories ya están restringidas por user_id; profiles permite ver todos y editar solo el propio.
-4. **Eventos**: hoy son globales. Decidir si “Agregar recital” crea eventos públicos para todos o si cada usuario tiene “sus” eventos; en el segundo caso haría falta un `created_by` en events y políticas acordes.
+- **`profiles`**: `id` (FK a `auth.users`), `username`, `avatar_url`, `bio`, `full_name`, `website`, `location`. Se crea con un trigger al registrarse. RLS: cualquiera puede leer, solo el dueño edita.
+- **`attendance`**: `user_id`, `event_id`, `status` (`interested` | `going` | `went`), más `rating`, `review`, `notes` (fusionados desde `memories`, ver nota arriba). Es la tabla "mis recitales" por usuario.
+- Detalle completo del resto del esquema (eventos, festivales, gastos, modo recital activo) en [`docs/architecture.md`](./architecture.md).
 
-## No cambiar ahora
+## Modo público (sin login)
 
-- La app sigue funcionando sin login (modo público / single player).
-- Al sumar auth, las pantallas “Mis recitales” y “Mi perfil” consumirán attendance y profiles sin tocar la estructura actual de eventos/sedes/artistas.
+La app sigue funcionando sin sesión: catálogo de eventos/artistas/sedes/festivales y búsqueda de shows futuros/pasados son visibles para cualquiera. Lo que requiere cuenta (asistencia, wishlist, gastos, perfil, modo recital activo) está detallado en [`docs/access-control.md`](./access-control.md), que es la fuente de verdad actual para permisos por rol — este doc se queda solo con el modelo de datos de usuarios/perfiles.
+
+## Nota sobre "eventos son globales"
+
+El catálogo compartido (eventos, artistas, sedes, festivales) no tiene `created_by`: cualquier usuario autenticado puede crear o editar cualquier fila, no solo la que él mismo cargó. Es una decisión deliberada, no un placeholder — ver `docs/access-control.md` para el razonamiento y qué pasaría si en el futuro se agrega un rol de administrador o moderación.


### PR DESCRIPTION
## Por qué

Anoche el repo tuvo cambios grandes: migración a GraphQL (issue #23, PRs #44/#46/#49 — 4 de 6 dominios con escritura ya están 100% fuera de Server Actions, `urql`/`@urql/next`/`graphql-yoga`/`@pothos/core` ahora son dependencias core, patrón `unwrapMutation`, ejecución in-process vía `yoga.fetch`), "modo recital activo" (dominio `showmode` nuevo, 4 tablas nuevas), clima exacto del show (`src/domains/weather/`, Open-Meteo), gastos inline con service layer, y service layer para festivals. Toda la documentación que describía "cómo funciona el backend" quedó desactualizada.

Este PR es solo documentación — no toca código de aplicación. Cada corrección fue verificada contra el código real (no son suposiciones): rutas de archivos, qué dominios migraron y cuáles no, qué sigue siendo Server Action y por qué, y el contenido de la migración `show_mode`.

## Qué cambió

| Archivo | Cambio |
|---|---|
| `README.md` | Diagrama de arquitectura y stack ahora muestran la capa GraphQL; lista completa de dominios (agrega `showmode`, `weather`) |
| `CONTRIBUTING.md` | `actions.ts` ya no es universal por dominio; comandos de test alineados con los scripts reales de `package.json`/CI; documenta el estado real de la migración por dominio |
| `docs/architecture.md` | Agrega el schema de `show_mode` (4 tablas nuevas) |
| `docs/access-control.md` | Agrega filas para modo recital activo y clima; ajusta la frase que asumía que toda escritura es una Server Action |
| `docs/api-eventos-futuro.md` | Corrige una referencia a un archivo borrado (`src/domains/events/actions.ts`, eliminado en el PR #49) |
| `docs/estructura-del-proyecto.md` | Reescribe el árbol de `domains/`/`graphql/` para reflejar la realidad, agrega `showmode`/`weather`, corrige una entrada `core/lib/supabase/client.ts` que ya no existe |
| `docs/usuarios-y-perfiles.md` | Describía auth como "futuro" (sin implementar) y referenciaba la tabla `memories`, eliminada hace tiempo — reescrito para reflejar el estado actual |
| `docs/adr/0004-graphql-migration-strangler-fig.md` | **ADR nuevo**: documenta la decisión de migrar a GraphQL (Yoga + Pothos + urql, por qué no tRPC, ejecución in-process vía `yoga.fetch`, patrón strangler-fig), con fuente en el issue #23 y los hallazgos del PR #44 |
| `docs/adr/0002-...md` | Nota de corrección: `client.ts` (cliente Supabase de browser) ya no existe, sin relación con la migración a GraphQL |
| `docs/adr/0001-...md` | Nota apuntando al ADR 0004, ya que `actions.ts` dejó de ser universal |
| `docs/adr/README.md` | Agrega el ADR 0004 al índice |

## Sugerencias de alcance (no implementadas, para que decidas)

Estas son decisiones de contenido, no correcciones de precisión — las dejo para que las evalúes:

- ¿Vale una página de docs dedicada para `showmode` (modo recital activo)? Hoy solo tiene una sección corta en `architecture.md` (schema) y una fila en `access-control.md` (permisos), nada que explique el flujo de usuario completo (ventana configurable, plantilla vs. checklist por show).
- Lo mismo para `weather` (clima exacto del show): documentado como servicio en `estructura-del-proyecto.md`, pero sin una página propia que explique las reglas de negocio (historical vs. forecast API, límite de 16 días, degradación sin lat/lng).
- `expenses` ya tiene una sección corta en `estructura-del-proyecto.md`; podría ameritar más detalle sobre el service layer nuevo (categories/comparisons/grouping) si crece.

## Hallazgo aparte (no es de documentación, lo menciono de paso)

`/modo-recital` no está en `protectedPaths` de `src/core/lib/supabase/middleware.ts` (a diferencia de `/profile`, `/wishlist`, `/stats`, `/expenses`). La página hace su propio `redirect` si no hay sesión, así que no es un agujero de seguridad, pero es la única ruta privada sin el resguardo del middleware como defensa en profundidad — lo dejo como observación, no lo toqué por ser código de aplicación.

## Test plan

- [x] Cada afirmación de código (rutas de archivo, qué dominios migraron, qué tablas existen) verificada leyendo el código real, no asumida
- [x] Todos los links internos entre docs (incluyendo al ADR nuevo) apuntan a rutas relativas correctas
- [x] No se tocó código de aplicación, solo `README.md`, `CONTRIBUTING.md` y `docs/`