### PR TITLE
fix(auth): protect /modo-recital route in middleware

### DIFF
--- a/src/core/lib/supabase/middleware.test.ts
+++ b/src/core/lib/supabase/middleware.test.ts
@@ -46,6 +46,15 @@ describe('updateSession', () => {
     expect(response.status).toBe(200)
   })
 
+  it('redirects an anonymous visitor away from /modo-recital', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: new AuthSessionMissingError() })
+
+    const response = await updateSession(makeRequest('/modo-recital'))
+
+    expect(response.status).toBe(307)
+    expect(response.headers.get('location')).toContain('/login')
+  })
+
   it('does not log an error for the expected anonymous-visitor case (no session)', async () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
     mockGetUser.mockResolvedValue({ data: { user: null }, error: new AuthSessionMissingError() })

--- a/src/core/lib/supabase/middleware.ts
+++ b/src/core/lib/supabase/middleware.ts
@@ -37,7 +37,7 @@ export async function updateSession(request: NextRequest) {
 
     // ─── Route Protection ────────────────────────────────────────────────────────
     const url = request.nextUrl.clone()
-    const protectedPaths = ['/profile', '/wishlist', '/stats', '/expenses']
+    const protectedPaths = ['/profile', '/wishlist', '/stats', '/expenses', '/modo-recital']
     const isProtected = protectedPaths.some((path) => url.pathname.startsWith(path))
 
     if (isProtected && !user) {


### PR DESCRIPTION
## Summary
- `/modo-recital` was missing from `protectedPaths` in `src/core/lib/supabase/middleware.ts`, unlike every other private route (`/profile`, `/wishlist`, `/stats`, `/expenses`).
- The page itself already redirects unauthenticated visitors client-side, so this wasn't an actual data leak — but it was the one private route without the middleware's defense-in-depth layer, which every other route in the app has.
- Found during a documentation audit of Ritual (verifying `docs/access-control.md`'s claims against the real middleware code) and fixed directly since it was small and clear-cut.

## Test plan
- [x] Added a regression test in `middleware.test.ts` asserting an anonymous visitor to `/modo-recital` gets redirected to `/login`, same pattern as the existing `/profile` test.
- [x] `npx vitest run src/core/lib/supabase/middleware.test.ts` — 6/6 passing.
- [x] `npx tsc --noEmit` — clean.
- [x] `npx eslint` on both changed files — clean.