### PR TITLE
feat: external event sources - Wave 4 (final: EntradaWeb, NorteTicket, PulsoTickets)

### DIFF
--- a/sdd/ritual-external-sources/03-tasks.md
+++ b/sdd/ritual-external-sources/03-tasks.md
@@ -14,22 +14,22 @@
 - [x] Write tests for Dedup logic
 
 ## Wave 2 (Fase 2 - "Cheap Scrapes" de alto valor)
-- [ ] Implement adapter: AllAccess
-- [ ] Implement adapter: Livepass
-- [ ] Implement adapter: Movistar Arena
-- [ ] Implement adapter: Entradaweb
-- [ ] Refine dedup logic with real world data
+- [x] Implement adapter: AllAccess
+- [x] Implement adapter: Livepass
+- [x] Implement adapter: Entradaweb
+- [x] Refine dedup logic with real world data
+- [ ] Implement adapter: Movistar Arena *(Explicitly deferred: confirmed to be a Blazor Server + SignalR WebSocket app, not scrapeable via plain HTTP fetch. Needs Playwright/headless infrastructure decision.)*
 
 ## Wave 3 (Fase 3 - "Cheap Scrapes" de nicho)
-- [ ] Implement adapter: Enigma
-- [ ] Implement adapter: Entraste
-- [ ] Implement adapter: Tuentrada
-- [ ] Implement adapter: Puntoticket
-- [ ] Implement adapter: Konex
-- [ ] Implement adapter: Pulsotickets
-- [ ] Implement adapter: Norteticket
+- [x] Implement adapter: Enigma
+- [x] Implement adapter: Entraste
+- [x] Implement adapter: Tuentrada
+- [x] Implement adapter: Puntoticket
+- [x] Implement adapter: Konex
+- [x] Implement adapter: Pulsotickets
+- [x] Implement adapter: Norteticket
 
 ## Wave 4 (Fase 4 - Las bloqueadas - Evaluación de riesgo)
-- [ ] Evaluate Passline headless strategy
-- [ ] Evaluate Mientrada headless strategy
-- [ ] Evaluate Edén Entradas SSL bypass strategy
+- [~] Evaluate Passline headless strategy *(Excluded entirely - established in earlier waves)*
+- [~] Evaluate Mientrada headless strategy *(Excluded entirely - established in earlier waves)*
+- [~] Evaluate Edén Entradas SSL bypass strategy *(Excluded entirely - established in earlier waves)*

--- a/src/core/lib/external-sources/adapters/__fixtures__/entradaweb.json
+++ b/src/core/lib/external-sources/adapters/__fixtures__/entradaweb.json
@@ -1,0 +1,26 @@
+{
+  "events": [
+    {
+      "order": 1,
+      "status": "1",
+      "visibleGroup": "false",
+      "groupId": "",
+      "groupOrder": "",
+      "publicPresentationPlace": "presencial",
+      "locationId": "DPPA-2e040eef",
+      "type": "imagen",
+      "itemType": "event",
+      "image": "https://imgs.entradaweb.com.ar/events/MDIA-17d84218.jpg",
+      "mobileImage": "https://imgs.entradaweb.com.ar/events/MDIA-17d84218.jpg",
+      "place": "Teatro Sarmiento | Sala Principal",
+      "location": "Capital | San Juan, Argentina",
+      "dates": "Jueves 10 de Septiembre, 2026",
+      "hours": "21:30hs.",
+      "contentType": "Teatro",
+      "contentTypeExtra": "Teatro",
+      "title": "MARTIN BOSSI, GUSTAVO BERMUDEZ y LAURITA FERNANDEZ <br/>presentan <br/>LA CENA DE LOS TONTOS | SAN JUAN",
+      "link": "https://www.entradaweb.com.ar/evento/40c261d5/step/1",
+      "eventHash": "40c261d5"
+    }
+  ]
+}

--- a/src/core/lib/external-sources/adapters/__fixtures__/norteticket.html
+++ b/src/core/lib/external-sources/adapters/__fixtures__/norteticket.html
@@ -1,0 +1,12 @@
+<div class="owl-carousel owl-theme">
+  <div class="item">     
+    <a href="https://norteticket.com/CONOCIENDO-RUSIA-EN-JUJUY/" target="_blank"> 
+      <img data-src="/media/banners/1001553644_1.png" class="owl-lazy" alt="Banner 1">
+    </a>        
+  </div>
+  <div class="item">     
+    <a href="https://norteticket.com/MARCELA-MORELO-EN-JUJUY-2026/" target="_blank"> 
+      <img data-src="/media/banners/morelo.jpg" class="owl-lazy" alt="Banner 2">
+    </a>        
+  </div>
+</div>

--- a/src/core/lib/external-sources/adapters/__fixtures__/norteticket_event.html
+++ b/src/core/lib/external-sources/adapters/__fixtures__/norteticket_event.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>CONOCIENDO RUSIA EN JUJUY</title>
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Event",
+      "name": "CONOCIENDO RUSIA EN JUJUY",
+      "startDate": "2026-09-22T22:00:00-03:00",
+      "location": {
+        "@type": "Place",
+        "name": "Centro Cultural Martin Fierro"
+      },
+      "image": "https://norteticket.com/media/imagenes_eventos/home/2026/05/conociendo_rusia.png"
+    }
+  </script>
+</head>
+<body></body>
+</html>

--- a/src/core/lib/external-sources/adapters/__fixtures__/pulsotickets.html
+++ b/src/core/lib/external-sources/adapters/__fixtures__/pulsotickets.html
@@ -1,0 +1,25 @@
+<div class="group bg-white rounded-3xl overflow-hidden shadow-lg border border-gray-100 transform transition duration-300 hover:-translate-y-2 hover:shadow-xl flex flex-col">
+    <div class="relative h-56 overflow-hidden">
+        <a href="https://pulsotickets.com/evento/popfest-1015"> 
+            <img class="w-full h-full object-cover transition-transform duration-700 group-hover:scale-110" src="https://pulsotickets.com/storage/posters/01M00TWYG3Y0BK3JK9TMP7CRF9.png" alt="Póster de PopFest 101.5">
+        </a>
+        <div class="absolute top-4 right-0">
+            <span class="bg-[#1e1b4b]/90 backdrop-blur-sm text-white text-[12px] font-bold px-3 py-1 uppercase tracking-wider rounded-l-md shadow-sm">
+                Música &amp; Recitales
+            </span>
+        </div>
+    </div>
+    <div class="p-5 flex flex-col flex-grow bg-white">
+        <h3 class="text-[#1e1b4b] font-extrabold text-2xl uppercase leading-tight mb-1 line-clamp-2 min-h-[3rem]">
+            PopFest 101.5
+        </h3>
+        <p class="text-slate-500 text-xl font-medium mb-4">
+            Diciembre 2026 - Parque Norte
+        </p>
+        <div class="mt-auto">
+            <a href="https://pulsotickets.com/evento/popfest-1015" class="block w-full text-center bg-gradient-to-r from-blue-700 to-blue-600 text-white font-bold py-2.5 rounded-lg shadow hover:shadow-blue-500/40 transition-all duration-300 text-sm tracking-wide uppercase">
+                Ver Entradas
+            </a>
+        </div>
+    </div>
+</div>

--- a/src/core/lib/external-sources/adapters/entradaweb.test.ts
+++ b/src/core/lib/external-sources/adapters/entradaweb.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs'
+import path from 'path'
+import { parseEntradaWebJSON } from './entradaweb'
+
+describe('EntradaWeb Adapter', () => {
+  it('should parse events from JSON fixture', () => {
+    const json = JSON.parse(fs.readFileSync(path.join(__dirname, '__fixtures__', 'entradaweb.json'), 'utf8'))
+    const events = parseEntradaWebJSON(json, {})
+    
+    expect(events.length).toBeGreaterThan(0)
+    
+    const firstEvent = events[0]
+    expect(firstEvent.title).toBe('MARTIN BOSSI, GUSTAVO BERMUDEZ y LAURITA FERNANDEZ presentan LA CENA DE LOS TONTOS | SAN JUAN')
+    expect(firstEvent.url).toContain('entradaweb.com.ar')
+    expect(firstEvent.datetime).toBe('Jueves 10 de Septiembre, 2026')
+    expect(firstEvent.id).toMatch(/^entradaweb-[a-f0-9]{8}$/)
+  })
+
+  it('should filter events by keyword', () => {
+    const json = JSON.parse(fs.readFileSync(path.join(__dirname, '__fixtures__', 'entradaweb.json'), 'utf8'))
+    const events = parseEntradaWebJSON(json, { keyword: 'BOSSI' })
+    
+    expect(events.length).toBe(1)
+    
+    const eventsEmpty = parseEntradaWebJSON(json, { keyword: 'Metallica' })
+    expect(eventsEmpty.length).toBe(0)
+  })
+
+  it('should return empty array for invalid data', () => {
+    const events = parseEntradaWebJSON({}, {})
+    expect(events).toEqual([])
+  })
+})

--- a/src/core/lib/external-sources/adapters/entradaweb.ts
+++ b/src/core/lib/external-sources/adapters/entradaweb.ts
@@ -1,0 +1,77 @@
+import { FutureEvent } from '@/src/core/types'
+import { ExternalSearchRequest, ExternalSearchResponse, ExternalSourceAdapter } from '../types'
+import { fetchWithRetry } from '@/src/core/lib/http'
+import crypto from 'crypto'
+
+export const entradawebAdapter: ExternalSourceAdapter = {
+  id: 'entradaweb',
+  name: 'EntradaWeb',
+  type: 'api',
+  isConfigured: () => true,
+  search: async (query: ExternalSearchRequest): Promise<ExternalSearchResponse> => {
+    try {
+      const res = await fetchWithRetry('https://bff.entradaweb.com.ar/v1/events', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({})
+      })
+
+      if (!res.ok) {
+        return { events: [], total: 0, error: `EntradaWeb responded with status: ${res.status}` }
+      }
+
+      const data = await res.json()
+      const events = parseEntradaWebJSON(data, query)
+
+      return {
+        events,
+        total: events.length
+      }
+    } catch (error) {
+      console.error('EntradaWeb adapter error:', error)
+      return { events: [], total: 0, error: 'Failed to fetch EntradaWeb' }
+    }
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function parseEntradaWebJSON(data: any, query: ExternalSearchRequest): FutureEvent[] {
+  if (!data || !Array.isArray(data.events)) {
+    return []
+  }
+
+  const events: FutureEvent[] = []
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  for (const ev of data.events as any[]) {
+    if (!ev.title) continue
+
+    const title = String(ev.title).replace(/<br\s*\/?>/gi, ' ').replace(/\s+/g, ' ').trim()
+
+    if (query.keyword && !title.toLowerCase().includes(query.keyword.toLowerCase())) {
+      continue
+    }
+
+    const url = ev.link || `https://www.entradaweb.com.ar/evento/${ev.eventHash}/step/1`
+    
+    // Hash URL for deterministic ID
+    const hash = crypto.createHash('md5').update(url).digest('hex').substring(0, 8)
+
+    events.push({
+      id: `entradaweb-${hash}`,
+      title,
+      datetime: ev.dates || '',
+      venue: {
+        name: ev.place || 'EntradaWeb',
+        city: ev.location || query.city || null
+      },
+      lineup: [],
+      url,
+      image: ev.image || ev.mobileImage
+    })
+  }
+
+  return events
+}

--- a/src/core/lib/external-sources/adapters/index.ts
+++ b/src/core/lib/external-sources/adapters/index.ts
@@ -9,6 +9,9 @@ import { entrasteAdapter } from './entraste'
 import { tuentradaAdapter } from './tuentrada'
 import { puntoticketAdapter } from './puntoticket'
 import { konexAdapter } from './konex'
+import { pulsoticketsAdapter } from './pulsotickets'
+import { norteticketAdapter } from './norteticket'
+import { entradawebAdapter } from './entradaweb'
 
 export const externalAdapters: ExternalSourceAdapter[] = [
   alpogoAdapter,
@@ -21,4 +24,7 @@ export const externalAdapters: ExternalSourceAdapter[] = [
   tuentradaAdapter,
   puntoticketAdapter,
   konexAdapter,
+  pulsoticketsAdapter,
+  norteticketAdapter,
+  entradawebAdapter,
 ]

--- a/src/core/lib/external-sources/adapters/norteticket.test.ts
+++ b/src/core/lib/external-sources/adapters/norteticket.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs'
+import path from 'path'
+import { extractNorteTicketUrls, parseNorteTicketEventHTML } from './norteticket'
+
+describe('NorteTicket Adapter', () => {
+  it('should extract urls from home HTML fixture', () => {
+    const html = fs.readFileSync(path.join(__dirname, '__fixtures__', 'norteticket.html'), 'utf8')
+    const urls = extractNorteTicketUrls(html)
+    
+    expect(urls.length).toBe(2)
+    expect(urls).toContain('https://norteticket.com/CONOCIENDO-RUSIA-EN-JUJUY/')
+    expect(urls).toContain('https://norteticket.com/MARCELA-MORELO-EN-JUJUY-2026/')
+  })
+
+  it('should parse event from event HTML fixture', () => {
+    const html = fs.readFileSync(path.join(__dirname, '__fixtures__', 'norteticket_event.html'), 'utf8')
+    const event = parseNorteTicketEventHTML(html, 'https://norteticket.com/CONOCIENDO-RUSIA-EN-JUJUY/', {})
+    
+    expect(event).toBeTruthy()
+    expect(event?.title).toBe('CONOCIENDO RUSIA EN JUJUY')
+    expect(event?.venue.name).toBe('Centro Cultural Martin Fierro')
+    expect(event?.datetime).toBe('2026-09-22T22:00:00-03:00')
+    expect(event?.id).toMatch(/^norteticket-[a-f0-9]{8}$/)
+  })
+
+  it('should filter events by keyword', () => {
+    const html = fs.readFileSync(path.join(__dirname, '__fixtures__', 'norteticket_event.html'), 'utf8')
+    const event = parseNorteTicketEventHTML(html, 'https://norteticket.com/CONOCIENDO-RUSIA-EN-JUJUY/', { keyword: 'RUSIA' })
+    expect(event).toBeTruthy()
+    
+    const eventEmpty = parseNorteTicketEventHTML(html, 'https://norteticket.com/CONOCIENDO-RUSIA-EN-JUJUY/', { keyword: 'METALLICA' })
+    expect(eventEmpty).toBeNull()
+  })
+
+  it('should return null for invalid HTML', () => {
+    const event = parseNorteTicketEventHTML('<html><body></body></html>', 'https://norteticket.com/CONOCIENDO-RUSIA-EN-JUJUY/', {})
+    expect(event).toBeNull()
+  })
+})

--- a/src/core/lib/external-sources/adapters/norteticket.ts
+++ b/src/core/lib/external-sources/adapters/norteticket.ts
@@ -1,0 +1,108 @@
+import { FutureEvent } from '@/src/core/types'
+import { ExternalSearchRequest, ExternalSearchResponse, ExternalSourceAdapter } from '../types'
+import { fetchWithRetry } from '@/src/core/lib/http'
+import crypto from 'crypto'
+import * as cheerio from 'cheerio'
+
+export const norteticketAdapter: ExternalSourceAdapter = {
+  id: 'norteticket',
+  name: 'NorteTicket',
+  type: 'scrape',
+  isConfigured: () => true,
+  search: async (query: ExternalSearchRequest): Promise<ExternalSearchResponse> => {
+    try {
+      const res = await fetchWithRetry('https://norteticket.com/', {
+        method: 'GET'
+      })
+
+      if (!res.ok) {
+        return { events: [], total: 0, error: `NorteTicket responded with status: ${res.status}` }
+      }
+
+      const html = await res.text()
+      const urls = extractNorteTicketUrls(html)
+
+      const events: FutureEvent[] = []
+      
+      // Fetch each event page sequentially with a small delay to be polite
+      for (const url of urls) {
+        try {
+          const evRes = await fetchWithRetry(url, { method: 'GET' })
+          if (evRes.ok) {
+            const evHtml = await evRes.text()
+            const event = parseNorteTicketEventHTML(evHtml, url, query)
+            if (event) {
+              events.push(event)
+            }
+          }
+          // Polite delay
+          await new Promise(r => setTimeout(r, 1000))
+        } catch (e) {
+          console.error(`Failed to scrape NorteTicket event at ${url}:`, e)
+        }
+      }
+
+      return {
+        events,
+        total: events.length
+      }
+    } catch (error) {
+      console.error('NorteTicket adapter error:', error)
+      return { events: [], total: 0, error: 'Failed to scrape NorteTicket' }
+    }
+  }
+}
+
+export function extractNorteTicketUrls(html: string): string[] {
+  const $ = cheerio.load(html)
+  const urls = new Set<string>()
+
+  $('.owl-carousel .item a').each((_, el) => {
+    const href = $(el).attr('href')
+    if (href && href.startsWith('https://norteticket.com/') && href !== 'https://norteticket.com/' && !href.includes('?buscar=')) {
+      urls.add(href)
+    }
+  })
+
+  return Array.from(urls)
+}
+
+export function parseNorteTicketEventHTML(html: string, url: string, query: ExternalSearchRequest): FutureEvent | null {
+  const $ = cheerio.load(html)
+  const jsonldScript = $('script[type="application/ld+json"]').html()
+  
+  if (!jsonldScript) return null
+
+  let data
+  try {
+    data = JSON.parse(jsonldScript)
+  } catch {
+    return null
+  }
+
+  // Handle both array of schemas and single schema
+  const eventData = Array.isArray(data) ? data.find(d => d['@type'] === 'Event') : (data['@type'] === 'Event' ? data : null)
+  
+  if (!eventData) return null
+
+  const title = eventData.name || ''
+  
+  if (query.keyword && !title.toLowerCase().includes(query.keyword.toLowerCase())) {
+    return null
+  }
+
+  const hash = crypto.createHash('md5').update(url).digest('hex').substring(0, 8)
+  
+  return {
+    id: `norteticket-${hash}`,
+    title,
+    datetime: eventData.startDate || '',
+    venue: {
+      name: eventData.location?.name || 'NorteTicket',
+      city: query.city || null
+    },
+    lineup: [],
+    url,
+    image: eventData.image || ''
+  }
+}

--- a/src/core/lib/external-sources/adapters/pulsotickets.test.ts
+++ b/src/core/lib/external-sources/adapters/pulsotickets.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs'
+import path from 'path'
+import { parsePulsoTicketsHTML } from './pulsotickets'
+
+describe('PulsoTickets Adapter', () => {
+  it('should parse events from HTML fixture', () => {
+    const html = fs.readFileSync(path.join(__dirname, '__fixtures__', 'pulsotickets.html'), 'utf8')
+    const events = parsePulsoTicketsHTML(html, {})
+    
+    expect(events.length).toBeGreaterThan(0)
+    
+    const firstEvent = events[0]
+    expect(firstEvent.title).toBe('PopFest 101.5')
+    expect(firstEvent.url).toContain('pulsotickets.com')
+    expect(firstEvent.datetime).toBe('Diciembre 2026')
+    expect(firstEvent.venue.name).toBe('Parque Norte')
+    expect(firstEvent.id).toMatch(/^pulsotickets-[a-f0-9]{8}$/)
+  })
+
+  it('should filter events by keyword', () => {
+    const html = fs.readFileSync(path.join(__dirname, '__fixtures__', 'pulsotickets.html'), 'utf8')
+    const events = parsePulsoTicketsHTML(html, { keyword: 'POPFEST' })
+    expect(events.length).toBe(1)
+    
+    const eventsEmpty = parsePulsoTicketsHTML(html, { keyword: 'Metallica' })
+    expect(eventsEmpty.length).toBe(0)
+  })
+
+  it('should return empty array for invalid HTML', () => {
+    const events = parsePulsoTicketsHTML('<html><body></body></html>', {})
+    expect(events).toEqual([])
+  })
+})

--- a/src/core/lib/external-sources/adapters/pulsotickets.ts
+++ b/src/core/lib/external-sources/adapters/pulsotickets.ts
@@ -1,0 +1,83 @@
+import { FutureEvent } from '@/src/core/types'
+import { ExternalSearchRequest, ExternalSearchResponse, ExternalSourceAdapter } from '../types'
+import { fetchWithRetry } from '@/src/core/lib/http'
+import crypto from 'crypto'
+import * as cheerio from 'cheerio'
+
+export const pulsoticketsAdapter: ExternalSourceAdapter = {
+  id: 'pulsotickets',
+  name: 'PulsoTickets',
+  type: 'scrape',
+  isConfigured: () => true,
+  search: async (query: ExternalSearchRequest): Promise<ExternalSearchResponse> => {
+    try {
+      const res = await fetchWithRetry('https://pulsotickets.com/', {
+        method: 'GET'
+      })
+
+      if (!res.ok) {
+        return { events: [], total: 0, error: `PulsoTickets responded with status: ${res.status}` }
+      }
+
+      const html = await res.text()
+      const events = parsePulsoTicketsHTML(html, query)
+
+      return {
+        events,
+        total: events.length
+      }
+    } catch (error) {
+      console.error('PulsoTickets adapter error:', error)
+      return { events: [], total: 0, error: 'Failed to scrape PulsoTickets' }
+    }
+  }
+}
+
+export function parsePulsoTicketsHTML(html: string, query: ExternalSearchRequest): FutureEvent[] {
+  const $ = cheerio.load(html)
+  const events: FutureEvent[] = []
+  const seenUrls = new Set<string>()
+
+  // Usually cards are within div.group
+  $('div.group').each((_, el) => {
+    const linkEl = $(el).find('a[href*="/evento/"]').first()
+    const url = linkEl.attr('href') || ''
+    
+    if (!url || seenUrls.has(url)) return
+    seenUrls.add(url)
+
+    const titleEl = $(el).find('h3')
+    const title = titleEl.text().trim()
+    
+    if (!title) return
+
+    if (query.keyword && !title.toLowerCase().includes(query.keyword.toLowerCase())) {
+      return
+    }
+
+    const dateVenueStr = $(el).find('p.text-slate-500').text().trim()
+    const parts = dateVenueStr.split(' - ')
+    const datetime = parts[0] ? parts[0].trim() : ''
+    const venueName = parts.length > 1 ? parts[1].trim() : 'PulsoTickets'
+
+    const imageEl = $(el).find('img')
+    const image = imageEl.attr('src') || ''
+
+    const hash = crypto.createHash('md5').update(url).digest('hex').substring(0, 8)
+
+    events.push({
+      id: `pulsotickets-${hash}`,
+      title,
+      datetime,
+      venue: {
+        name: venueName,
+        city: query.city || null
+      },
+      lineup: [],
+      url,
+      image
+    })
+  })
+
+  return events
+}


### PR DESCRIPTION
## Summary
Wave 4, the final wave of the 14-source external events expansion: EntradaWeb (v1 JSON API), NorteTicket (cheerio + LD-JSON scraping), PulsoTickets (cheerio scraping).

This completes the approved scope: 13 of 14 sources now implemented across all 4 waves (Alpogo, Venti, Quehacemos, AllAccess, Livepass, Enigma, Entraste, TuEntrada, PuntoTicket, Konex, EntradaWeb, NorteTicket, PulsoTickets). The 14th, Movistar Arena, is explicitly deferred (Blazor Server + SignalR WebSocket, needs Playwright - a separate infra decision, tracked in `03-tasks.md`). Passline, Mientrada, Edén Entradas remain excluded per the original scope decision (active bot-blocking / SSL issues).

Note: the apply agent's own run hit a client-side timeout after committing its work (agy's process died before it could print a final report), so I independently re-verified everything below myself rather than trusting a self-report.

## Test plan
- [x] Independently re-ran the full suite myself: 980/980 tests passing (970 baseline + 10 new, no drop).
- [x] `tsc --noEmit` clean.
- [x] `eslint` clean on the 3 new adapter files.
- [x] Fixtures are trimmed (12-26 lines), not full-page dumps.
- [x] `sdd/ritual-external-sources/03-tasks.md` updated to reflect final wave status.