### PR TITLE
fix: auditoría del proyecto — migraciones aplicables, agujeros de seguridad y fuentes externas funcionando

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,13 @@ next-env.d.ts
 
 # local editor/agent tooling
 .claude/
+
+# MCP server: dependencias y build. El patrón /node_modules de arriba está
+# anclado a la raíz, así que no cubre mcp/node_modules — sin esto un
+# `git add .` mete más de 4300 archivos al repo.
+mcp/node_modules/
+mcp/dist/
+
+# Scripts de refactor de un solo uso y scratch de exploración.
+/refactor.js
+/refactor-waterfall.js

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,0 +1,76 @@
+import Link from 'next/link'
+import { routes } from '@/src/core/lib/routes'
+import { ReactNode } from 'react'
+
+export default function AdminLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="min-h-screen bg-ritual-bg flex flex-col md:flex-row">
+      {/* Sidebar */}
+      <aside className="w-full md:w-64 shrink-0 bg-ritual-panel border-r border-ritual-border-subtle flex flex-col h-auto md:min-h-screen">
+        <div className="p-6 border-b border-ritual-border-subtle">
+          <p className="font-label text-[10px] tracking-[0.32em] text-ritual-red-hover uppercase">Control</p>
+          <h2 className="font-display text-3xl uppercase text-ritual-bone mt-2">
+            Sala de Máquinas
+          </h2>
+        </div>
+
+        <nav className="flex-1 p-6 space-y-8">
+          <div>
+            <p className="font-label text-[10px] tracking-[0.14em] text-ritual-gray-text uppercase mb-4">
+              Moderación
+            </p>
+            <ul className="space-y-3">
+              <li>
+                <Link
+                  href={routes.admin.moderation.artists}
+                  className="font-dense text-ritual-bone hover:text-ritual-red-hover uppercase transition-colors"
+                >
+                  Artistas
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href={routes.admin.moderation.venues}
+                  className="font-dense text-ritual-bone hover:text-ritual-red-hover uppercase transition-colors"
+                >
+                  Sedes
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href={routes.admin.moderation.events}
+                  className="font-dense text-ritual-bone hover:text-ritual-red-hover uppercase transition-colors"
+                >
+                  Eventos
+                </Link>
+              </li>
+            </ul>
+          </div>
+          
+          {/* Futuros enlaces de admin */}
+          <div>
+            <p className="font-label text-[10px] tracking-[0.14em] text-ritual-gray-text uppercase mb-4">
+              Sistema
+            </p>
+            <ul className="space-y-3">
+              <li>
+                <Link
+                  href="/admin/usuarios"
+                  className="font-dense text-ritual-gray-light-2 hover:text-ritual-red-hover uppercase transition-colors cursor-not-allowed opacity-50"
+                  title="Próximamente"
+                >
+                  Usuarios
+                </Link>
+              </li>
+            </ul>
+          </div>
+        </nav>
+      </aside>
+
+      {/* Main Content */}
+      <main className="flex-1 overflow-x-hidden">
+        {children}
+      </main>
+    </div>
+  )
+}

--- a/app/admin/moderacion/artistas/ModerationActions.tsx
+++ b/app/admin/moderacion/artistas/ModerationActions.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import { useState } from 'react'
+import { useMutation } from 'urql'
+import { useRouter } from 'next/navigation'
+
+const APPROVE_ARTIST = `
+  mutation ApproveArtist($id: ID!) {
+    approveArtist(id: $id) { success }
+  }
+`
+
+const MERGE_ARTISTS = `
+  mutation MergeArtists($sourceId: ID!, $targetId: ID!) {
+    mergeArtists(sourceId: $sourceId, targetId: $targetId) { success }
+  }
+`
+
+export function ArtistModerationActions({ artistId, artistName }: { artistId: string, artistName: string }) {
+  const router = useRouter()
+  const [, approve] = useMutation(APPROVE_ARTIST)
+  const [, merge] = useMutation(MERGE_ARTISTS)
+  const [isMerging, setIsMerging] = useState(false)
+  const [targetId, setTargetId] = useState('')
+
+  const handleApprove = async () => {
+    if (!confirm(`¿Aprobar a ${artistName}?`)) return
+    await approve({ id: artistId })
+    router.refresh()
+  }
+
+  const handleMerge = async () => {
+    if (!targetId) return
+    if (!confirm(`¿Estás seguro de que querés fusionar ${artistName} hacia el ID ${targetId}? Esta acción destruirá el registro original.`)) return
+    await merge({ sourceId: artistId, targetId })
+    setIsMerging(false)
+    router.refresh()
+  }
+
+  if (isMerging) {
+    return (
+      <div className="flex items-center gap-2 justify-end">
+        <input 
+          type="text" 
+          placeholder="ID canónico destino..." 
+          className="bg-ritual-bg border border-ritual-border-subtle text-ritual-bone px-3 py-1 text-xs w-48 focus:outline-none focus:border-ritual-red-hover"
+          value={targetId}
+          onChange={e => setTargetId(e.target.value)}
+        />
+        <button onClick={handleMerge} className="font-label text-[10px] tracking-[0.16em] text-green-500 hover:text-green-400 uppercase transition-colors">
+          Confirmar
+        </button>
+        <button onClick={() => setIsMerging(false)} className="font-label text-[10px] tracking-[0.16em] text-ritual-gray-text hover:text-ritual-bone uppercase transition-colors">
+          Cancelar
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-x-4">
+      <button onClick={handleApprove} className="font-label text-[10px] tracking-[0.16em] text-ritual-bone hover:text-green-500 uppercase transition-colors">
+        ✓ Aprobar
+      </button>
+      <button onClick={() => setIsMerging(true)} className="font-label text-[10px] tracking-[0.16em] text-ritual-bone hover:text-ritual-red-hover uppercase transition-colors">
+        Fusionar...
+      </button>
+    </div>
+  )
+}

--- a/app/admin/moderacion/artistas/page.tsx
+++ b/app/admin/moderacion/artistas/page.tsx
@@ -1,0 +1,79 @@
+import { getClient } from '@/src/graphql/client'
+import { cache } from 'react'
+import { ArtistModerationActions } from './ModerationActions'
+
+interface UnverifiedArtist {
+  id: string
+  name: string
+  genre: string | null
+  status: string | null
+}
+
+const GET_UNVERIFIED_ARTISTS = `
+  query getUnverifiedArtists {
+    unverifiedArtists {
+      id
+      name
+      genre
+      status
+    }
+  }
+`
+
+const loadArtists = cache(async () => {
+  const result = await getClient().query(GET_UNVERIFIED_ARTISTS, {}).toPromise()
+  if (result.error) throw new Error(result.error.message)
+  return result.data?.unverifiedArtists ?? []
+})
+
+export default async function ModerationArtistsPage() {
+  const artists = await loadArtists()
+
+  return (
+    <div className="p-6 md:p-10 max-w-5xl">
+      <div className="mb-10">
+        <p className="font-label text-[10px] tracking-[0.32em] text-ritual-red-hover uppercase">Pendientes</p>
+        <h1 className="font-display text-5xl uppercase text-ritual-bone mt-2">
+          Artistas
+        </h1>
+        <p className="font-body italic text-ritual-gray-text mt-2">
+          Cargados por la comunidad. Revisar o fusionar con los originales.
+        </p>
+      </div>
+
+      {artists.length === 0 ? (
+        <div className="border border-dashed border-ritual-border-subtle p-12 text-center">
+          <p className="font-dense text-ritual-gray-light-2 uppercase">Todo limpio por acá.</p>
+        </div>
+      ) : (
+        <div className="bg-ritual-surface border border-ritual-border overflow-hidden">
+          <table className="w-full text-left">
+            <thead className="bg-ritual-panel border-b border-ritual-border-subtle">
+              <tr>
+                <th className="px-6 py-4 font-label text-[10px] tracking-[0.14em] text-ritual-gray-text uppercase w-1/3">Nombre</th>
+                <th className="px-6 py-4 font-label text-[10px] tracking-[0.14em] text-ritual-gray-text uppercase w-1/4">Género</th>
+                <th className="px-6 py-4 font-label text-[10px] tracking-[0.14em] text-ritual-gray-text uppercase text-right w-5/12">Acciones</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-ritual-border-subtle">
+              {artists.map((artist: UnverifiedArtist) => (
+                <tr key={artist.id} className="group hover:bg-ritual-bg transition-colors">
+                  <td className="px-6 py-4">
+                    <p className="font-dense font-extrabold text-ritual-bone uppercase">{artist.name}</p>
+                    <p className="font-label text-[10px] text-ritual-gray-light-2">{artist.id}</p>
+                  </td>
+                  <td className="px-6 py-4">
+                    <p className="font-body text-sm text-ritual-gray-text">{artist.genre || '—'}</p>
+                  </td>
+                  <td className="px-6 py-4 text-right">
+                    <ArtistModerationActions artistId={artist.id} artistName={artist.name} />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/admin/moderacion/eventos/page.tsx
+++ b/app/admin/moderacion/eventos/page.tsx
@@ -1,0 +1,100 @@
+import { getClient } from '@/src/graphql/client'
+import { cache } from 'react'
+
+interface UnverifiedEvent {
+  id: string
+  name: string | null
+  date: string
+  status: string | null
+  venue: { name: string } | null
+  lineups: Array<{ artist: { name: string } | null }> | null
+}
+import { formatDate } from '@/src/core/lib/utils'
+
+const GET_UNVERIFIED_EVENTS = `
+  query getUnverifiedEvents {
+    unverifiedEvents {
+      id
+      name
+      date
+      status
+      venue {
+        name
+      }
+      lineups {
+        artist {
+          name
+        }
+      }
+    }
+  }
+`
+
+const loadEvents = cache(async () => {
+  const result = await getClient().query(GET_UNVERIFIED_EVENTS, {}).toPromise()
+  if (result.error) throw new Error(result.error.message)
+  return result.data?.unverifiedEvents ?? []
+})
+
+export default async function ModerationEventsPage() {
+  const events = await loadEvents()
+
+  return (
+    <div className="p-6 md:p-10 max-w-5xl">
+      <div className="mb-10">
+        <p className="font-label text-[10px] tracking-[0.32em] text-ritual-red-hover uppercase">Pendientes</p>
+        <h1 className="font-display text-5xl uppercase text-ritual-bone mt-2">
+          Eventos
+        </h1>
+        <p className="font-body italic text-ritual-gray-text mt-2">
+          Recitales creados a mano que no vinieron por APIs externas.
+        </p>
+      </div>
+
+      {events.length === 0 ? (
+        <div className="border border-dashed border-ritual-border-subtle p-12 text-center">
+          <p className="font-dense text-ritual-gray-light-2 uppercase">Todo limpio por acá.</p>
+        </div>
+      ) : (
+        <div className="bg-ritual-surface border border-ritual-border overflow-hidden">
+          <table className="w-full text-left">
+            <thead className="bg-ritual-panel border-b border-ritual-border-subtle">
+              <tr>
+                <th className="px-6 py-4 font-label text-[10px] tracking-[0.14em] text-ritual-gray-text uppercase">Evento / Headliner</th>
+                <th className="px-6 py-4 font-label text-[10px] tracking-[0.14em] text-ritual-gray-text uppercase">Sede & Fecha</th>
+                <th className="px-6 py-4 font-label text-[10px] tracking-[0.14em] text-ritual-gray-text uppercase text-right">Acciones</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-ritual-border-subtle">
+              {events.map((ev: UnverifiedEvent) => {
+                const title = ev.name || ev.lineups?.[0]?.artist?.name || 'Evento sin nombre'
+                return (
+                  <tr key={ev.id} className="group hover:bg-ritual-bg transition-colors">
+                    <td className="px-6 py-4">
+                      <p className="font-dense font-extrabold text-ritual-bone uppercase">{title}</p>
+                      <p className="font-label text-[10px] text-ritual-gray-light-2">{ev.id}</p>
+                    </td>
+                    <td className="px-6 py-4">
+                      <p className="font-body text-sm text-ritual-gray-text uppercase">{ev.venue?.name || 'Sin Sede'}</p>
+                      <p className="font-label text-[10px] text-ritual-gray-light-2 mt-1">
+                        {formatDate(ev.date, { day: 'numeric', month: 'long', year: 'numeric' })}
+                      </p>
+                    </td>
+                    <td className="px-6 py-4 text-right space-x-4">
+                      <button className="font-label text-[10px] tracking-[0.16em] text-ritual-bone hover:text-green-500 uppercase transition-colors">
+                        ✓ Aprobar
+                      </button>
+                      <button className="font-label text-[10px] tracking-[0.16em] text-ritual-bone hover:text-ritual-red-hover uppercase transition-colors">
+                        Fusionar...
+                      </button>
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/admin/moderacion/sedes/page.tsx
+++ b/app/admin/moderacion/sedes/page.tsx
@@ -1,0 +1,89 @@
+import { getClient } from '@/src/graphql/client'
+import { cache } from 'react'
+
+interface UnverifiedVenue {
+  id: string
+  name: string
+  city: string | null
+  address: string | null
+  status: string | null
+}
+
+const GET_UNVERIFIED_VENUES = `
+  query getUnverifiedVenues {
+    unverifiedVenues {
+      id
+      name
+      city
+      address
+      status
+    }
+  }
+`
+
+const loadVenues = cache(async () => {
+  const result = await getClient().query(GET_UNVERIFIED_VENUES, {}).toPromise()
+  if (result.error) throw new Error(result.error.message)
+  return result.data?.unverifiedVenues ?? []
+})
+
+export default async function ModerationVenuesPage() {
+  const venues = await loadVenues()
+
+  return (
+    <div className="p-6 md:p-10 max-w-5xl">
+      <div className="mb-10">
+        <p className="font-label text-[10px] tracking-[0.32em] text-ritual-red-hover uppercase">Pendientes</p>
+        <h1 className="font-display text-5xl uppercase text-ritual-bone mt-2">
+          Sedes
+        </h1>
+        <p className="font-body italic text-ritual-gray-text mt-2">
+          Lugares y estadios cargados a mano por la comunidad.
+        </p>
+      </div>
+
+      {venues.length === 0 ? (
+        <div className="border border-dashed border-ritual-border-subtle p-12 text-center">
+          <p className="font-dense text-ritual-gray-light-2 uppercase">Todo limpio por acá.</p>
+        </div>
+      ) : (
+        <div className="bg-ritual-surface border border-ritual-border overflow-hidden">
+          <table className="w-full text-left">
+            <thead className="bg-ritual-panel border-b border-ritual-border-subtle">
+              <tr>
+                <th className="px-6 py-4 font-label text-[10px] tracking-[0.14em] text-ritual-gray-text uppercase">Nombre</th>
+                <th className="px-6 py-4 font-label text-[10px] tracking-[0.14em] text-ritual-gray-text uppercase">Ubicación</th>
+                <th className="px-6 py-4 font-label text-[10px] tracking-[0.14em] text-ritual-gray-text uppercase text-right">Acciones</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-ritual-border-subtle">
+              {venues.map((venue: UnverifiedVenue) => (
+                <tr key={venue.id} className="group hover:bg-ritual-bg transition-colors">
+                  <td className="px-6 py-4">
+                    <p className="font-dense font-extrabold text-ritual-bone uppercase">{venue.name}</p>
+                    <p className="font-label text-[10px] text-ritual-gray-light-2">{venue.id}</p>
+                  </td>
+                  <td className="px-6 py-4">
+                    <p className="font-body text-sm text-ritual-gray-text">
+                      {venue.city ? `${venue.city}` : ''}
+                      {venue.address ? ` — ${venue.address}` : ''}
+                      {!venue.city && !venue.address && '—'}
+                    </p>
+                  </td>
+                  <td className="px-6 py-4 text-right space-x-4">
+                    <button className="font-label text-[10px] tracking-[0.16em] text-ritual-bone hover:text-green-500 uppercase transition-colors">
+                      ✓ Aprobar
+                    </button>
+                    <button className="font-label text-[10px] tracking-[0.16em] text-ritual-bone hover:text-ritual-red-hover uppercase transition-colors">
+                      Fusionar...
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,0 +1,6 @@
+import { redirect } from 'next/navigation'
+import { routes } from '@/src/core/lib/routes'
+
+export default function AdminIndex() {
+  redirect(routes.admin.moderation.artists)
+}

--- a/app/api/cron/sync-external-sources/route.ts
+++ b/app/api/cron/sync-external-sources/route.ts
@@ -10,6 +10,16 @@ function slugify(text: string) {
 export const maxDuration = 300 // 5 minutes max duration for vercel cron
 
 /**
+ * El schedule vive en `vercel.json` (`0 7 * * *`, diario). Se documenta acá
+ * porque el esquema de Vercel rechaza claves extra dentro de `crons` y JSON no
+ * admite comentarios.
+ *
+ * Diario y no más seguido por dos razones: el plan Hobby dispara los crons una
+ * vez por día, y el TTL del cache es de 7 días, así que una corrida diaria lo
+ * mantiene fresco con margen. En Pro se puede pasar a cada seis horas.
+ */
+
+/**
  * Comparación en tiempo constante para no filtrar el secreto carácter por
  * carácter vía el tiempo de respuesta. `timingSafeEqual` exige buffers del
  * mismo largo, así que la diferencia de longitud se chequea aparte.

--- a/app/api/cron/sync-external-sources/route.ts
+++ b/app/api/cron/sync-external-sources/route.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from 'node:crypto'
 import { NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
 import { externalAdapters } from '@/src/core/lib/external-sources/adapters'
@@ -8,15 +9,39 @@ function slugify(text: string) {
 
 export const maxDuration = 300 // 5 minutes max duration for vercel cron
 
+/**
+ * Comparación en tiempo constante para no filtrar el secreto carácter por
+ * carácter vía el tiempo de respuesta. `timingSafeEqual` exige buffers del
+ * mismo largo, así que la diferencia de longitud se chequea aparte.
+ */
+function secretMatches(provided: string, expected: string): boolean {
+  const a = Buffer.from(provided)
+  const b = Buffer.from(expected)
+  return a.length === b.length && timingSafeEqual(a, b)
+}
+
 export async function GET(request: Request) {
-  const authHeader = request.headers.get('authorization')
-  // Basic security for cron (Vercel cron uses CRON_SECRET)
-  if (process.env.CRON_SECRET && authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+  // Falla cerrado: sin CRON_SECRET configurado el endpoint queda inaccesible en
+  // vez de abierto. Antes la guarda era `if (CRON_SECRET && ...)`, así que un
+  // olvido de la variable en el entorno saltaba el chequeo entero y dejaba la
+  // ruta pública corriendo con la service role key, que bypassa RLS.
+  const cronSecret = process.env.CRON_SECRET
+  if (!cronSecret) {
+    console.error('CRON_SECRET no está configurado: se rechaza la corrida del cron.')
+    return NextResponse.json({ error: 'Cron not configured' }, { status: 503 })
+  }
+
+  const authHeader = request.headers.get('authorization') ?? ''
+  if (!authHeader.startsWith('Bearer ') || !secretMatches(authHeader.slice(7), cronSecret)) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
-  const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!supabaseUrl || !supabaseServiceKey) {
+    console.error('Faltan NEXT_PUBLIC_SUPABASE_URL o SUPABASE_SERVICE_ROLE_KEY para el cron.')
+    return NextResponse.json({ error: 'Cron not configured' }, { status: 503 })
+  }
   const supabase = createClient(supabaseUrl, supabaseServiceKey)
 
   const results = await Promise.allSettled(

--- a/app/artists/[id]/page.tsx
+++ b/app/artists/[id]/page.tsx
@@ -69,7 +69,7 @@ async function fetchArtistDetail(id: string) {
     const { data } = await getClient().query<{
         artist: GraphQLArtistWithEvents | null
         wishlistArtistIds: string[]
-    }>(ArtistDetailQuery, { id })
+    }>(ArtistDetailQuery, { id }).toPromise()
     return {
         artist: data?.artist ? toDomainArtist(data.artist) : null,
         wishlistIds: data?.wishlistArtistIds ?? [],

--- a/app/buscar/loading.tsx
+++ b/app/buscar/loading.tsx
@@ -3,7 +3,7 @@ export default function BuscarLoading() {
     <main className="min-h-screen bg-neutral-950 text-white p-6 md:p-8 font-sans animate-pulse">
       <div className="h-6 w-24 bg-white/10 rounded mb-8" />
       <div className="h-8 w-56 bg-white/10 rounded mb-2" />
-      <div className="h-4 w-96 bg-white/10 rounded mb-8" />
+      <div className="h-4 w-full max-w-sm bg-white/10 rounded mb-8" />
       <div className="h-10 w-64 bg-white/10 rounded mb-4" />
       <div className="h-10 w-32 bg-white/10 rounded" />
     </main>

--- a/app/buscar/page.tsx
+++ b/app/buscar/page.tsx
@@ -10,7 +10,7 @@ import { FutureEventsResults } from '@/src/domains/events/components/FutureEvent
 import { isTicketmasterConfigured, searchTicketmasterEvents } from '@/src/core/lib/ticketmaster'
 import { searchCachedExternalEvents } from '@/src/core/lib/external-sources/cache'
 import { isSetlistFmConfigured, getSetlistsByArtist } from '@/src/core/lib/setlistfm'
-import { createClient } from '@/src/core/lib/supabase/server'
+import { searchCatalog } from '@/src/domains/search/service'
 import { formatDate } from '@/src/core/lib/utils'
 import { EmptyState } from '@/src/core/components/ui/EmptyState'
 
@@ -23,21 +23,6 @@ type SearchParams = { artist?: string; location?: string; source?: 'future' | 'p
 
 interface PageProps {
   searchParams: Promise<SearchParams>
-}
-
-async function globalSearch(query: string) {
-  const q = `%${query}%`
-  const supabase = await createClient()
-  const [eventsRes, artistsRes, venuesRes] = await Promise.all([
-    supabase.from('events').select('id, name, date').ilike('name', q).order('date', { ascending: false }).limit(8),
-    supabase.from('artists').select('id, name, genre').ilike('name', q).limit(8),
-    supabase.from('venues').select('id, name, city, country').ilike('name', q).limit(8),
-  ])
-  return {
-    events: eventsRes.data ?? [],
-    artists: artistsRes.data ?? [],
-    venues: venuesRes.data ?? [],
-  }
 }
 
 function tabHref(tab: 'cartelera' | 'archivo', params: SearchParams) {
@@ -92,7 +77,7 @@ export default async function BuscarPage({ searchParams }: PageProps) {
   }
 
   const query = params.q?.trim() ?? ''
-  const archiveResults = tab === 'archivo' && query.length >= 2 ? await globalSearch(query) : null
+  const archiveResults = tab === 'archivo' && query.length >= 2 ? await searchCatalog(query) : null
   const archiveTotal = archiveResults
     ? archiveResults.events.length + archiveResults.artists.length + archiveResults.venues.length
     : 0

--- a/app/coleccion/page.tsx
+++ b/app/coleccion/page.tsx
@@ -84,7 +84,7 @@ async function ArtistsShelvesView() {
         getClient().query<{ artists: GraphQLArtist[]; wishlistArtistIds: string[] }>(
             ArtistsTabQuery,
             {}
-        ),
+        ).toPromise(),
         getEventsWithAttendance().then((events) => events.filter((e) => e.attendance?.[0]?.status === 'went')),
     ])
     const artists = (data?.artists ?? []).map(toDomainArtist)
@@ -199,7 +199,7 @@ const VenuesTabQuery = gql`
 `
 
 async function VenuesTab() {
-    const { data } = await getClient().query<{ venues: GraphQLVenue[] }>(VenuesTabQuery, {})
+    const { data } = await getClient().query<{ venues: GraphQLVenue[] }>(VenuesTabQuery, {}).toPromise()
     const venues = data?.venues ?? []
 
     if (venues.length === 0) {
@@ -266,7 +266,7 @@ async function FestivalsTab() {
     const { data } = await getClient().query<{ festivals: CollectionFestival[] }>(
         FestivalsTabQuery,
         {}
-    )
+    ).toPromise()
     const festivals = data?.festivals ?? []
     const upcoming = festivals.filter((f) => !isPastEvent(f.startDate))
     const past = festivals.filter((f) => isPastEvent(f.startDate))

--- a/app/events/[id]/editar/page.tsx
+++ b/app/events/[id]/editar/page.tsx
@@ -18,7 +18,7 @@ async function fetchPickers() {
   const { data } = await getClient().query<{
     venues: GraphQLVenue[]
     artists: GraphQLArtist[]
-  }>(EventFormPickersQuery, {})
+  }>(EventFormPickersQuery, {}).toPromise()
   const venues: Venue[] = data?.venues ?? []
   const artists: Artist[] = (data?.artists ?? []).map((a) => ({
     id: a.id,

--- a/app/events/[id]/gastos/page.tsx
+++ b/app/events/[id]/gastos/page.tsx
@@ -54,7 +54,7 @@ export default async function EventExpensesPage({ params }: EventExpensesPagePro
   const event = await getEventById(id)
   if (!event) notFound()
 
-  const { data } = await getClient().query<{ expenses: import('@/src/core/types').GraphQLExpense[], estimateSpendForEvent: { averageTotal: number, eventsConsidered: number } | null }>(EventExpensesPageQuery, { eventId: id })
+  const { data } = await getClient().query<{ expenses: import('@/src/core/types').GraphQLExpense[], estimateSpendForEvent: { averageTotal: number, eventsConsidered: number } | null }>(EventExpensesPageQuery, { eventId: id }).toPromise()
   const expenses = data?.expenses ?? []
   const spendEstimate = data?.estimateSpendForEvent ?? null
 

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -63,6 +63,12 @@ export async function generateMetadata({ params }: EventDetailPageProps): Promis
     : 'Sede por confirmar'
   const description = `${title} — ${formatDate(event.date)} · ${venueLabel}`
 
+  let heroImage: string | undefined = undefined
+  if (mainArtist && isSpotifyConfigured()) {
+    const { artist: spotifyArtist } = await searchSpotifyArtist(mainArtist)
+    heroImage = spotifyArtist ? (getBestSpotifyImage(spotifyArtist.images) ?? undefined) : undefined
+  }
+
   return {
     title: `${title} | RITUAL`,
     description,
@@ -70,6 +76,7 @@ export async function generateMetadata({ params }: EventDetailPageProps): Promis
       title: `${title} | RITUAL`,
       description,
       type: 'website',
+      ...(heroImage ? { images: [{ url: heroImage }] } : {}),
     },
   }
 }

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -85,7 +85,7 @@ export default async function EventDetailPage({ params }: EventDetailPageProps) 
 
   if (!event) notFound()
 
-  const { data } = await getClient().query(EventDetailPageQuery, { eventId: id })
+  const { data } = await getClient().query(EventDetailPageQuery, { eventId: id }).toPromise()
   const expenses = data?.expenses ?? []
   const spendEstimate = data?.estimateSpendForEvent ?? null
 

--- a/app/events/nuevo/page.tsx
+++ b/app/events/nuevo/page.tsx
@@ -28,7 +28,7 @@ async function fetchPickers() {
   const { data } = await getClient().query<{
     venues: GraphQLVenue[]
     artists: GraphQLArtist[]
-  }>(EventFormPickersQuery, {})
+  }>(EventFormPickersQuery, {}).toPromise()
   const venues: Venue[] = data?.venues ?? []
   const artists: Artist[] = (data?.artists ?? []).map((a) => ({
     id: a.id,

--- a/app/expenses/[id]/page.tsx
+++ b/app/expenses/[id]/page.tsx
@@ -28,7 +28,7 @@ interface ExpenseDetailPageProps {
 
 export async function generateMetadata({ params }: ExpenseDetailPageProps): Promise<Metadata> {
   const { id } = await params
-  const { data } = await getClient().query<{ expense: GraphQLExpense }>(ExpenseDetailQuery, { id })
+  const { data } = await getClient().query<{ expense: GraphQLExpense }>(ExpenseDetailQuery, { id }).toPromise()
   const expense = data?.expense
   if (!expense) return { title: 'Gasto no encontrado | RITUAL' }
   return {
@@ -39,7 +39,7 @@ export async function generateMetadata({ params }: ExpenseDetailPageProps): Prom
 
 export default async function ExpenseDetailPage({ params }: ExpenseDetailPageProps) {
   const { id } = await params
-  const { data } = await getClient().query<{ expense: GraphQLExpense }>(ExpenseDetailQuery, { id })
+  const { data } = await getClient().query<{ expense: GraphQLExpense }>(ExpenseDetailQuery, { id }).toPromise()
   const expense = data?.expense
 
   if (!expense) notFound()

--- a/app/expenses/page.tsx
+++ b/app/expenses/page.tsx
@@ -30,7 +30,7 @@ const ExpensesPageQuery = gql`
 
 export default async function ExpensesPage() {
   const userId = await getCurrentUserId()
-  const { data } = await getClient().query<{ expenses: GraphQLExpense[], expensesSummary: GraphQLExpenseSummary }>(ExpensesPageQuery, {})
+  const { data } = await getClient().query<{ expenses: GraphQLExpense[], expensesSummary: GraphQLExpenseSummary }>(ExpensesPageQuery, {}).toPromise()
   const expenses = data?.expenses ?? []
   const summary = data?.expensesSummary ?? { total: 0, count: 0, byCategory: {}, byYear: {} }
 

--- a/app/festivals/[id]/page.tsx
+++ b/app/festivals/[id]/page.tsx
@@ -41,7 +41,7 @@ async function fetchFestival(id: string): Promise<GraphQLFestival | null> {
     const { data } = await getClient().query<{ festival: GraphQLFestival | null }>(
         FestivalDetailQuery,
         { id }
-    )
+    ).toPromise()
     return data?.festival ?? null
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -30,6 +30,7 @@ const fontVariables = [
 ].join(" ");
 
 export const metadata: Metadata = {
+  metadataBase: new URL(process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000"),
   title: "RITUAL — Tu agenda de recitales",
   description: "Plataforma de gestión de recitales: itinerarios, giras y memoria en vivo.",
 };

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -5,7 +5,7 @@ export default function Loading() {
     <div className="max-w-7xl mx-auto px-6 md:px-8 pt-24 pb-16 space-y-8 animate-in fade-in duration-500">
       <div className="space-y-4">
         <Skeleton className="h-12 w-48 bg-white/10" />
-        <Skeleton className="h-4 w-96 bg-white/5" />
+        <Skeleton className="h-4 w-full max-w-sm bg-white/5" />
       </div>
 
       {/* Grid layout similar to events/festivals */}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -119,7 +119,7 @@ export default async function HomePage() {
       wishlistArtistIds: string[]
       artists: Array<Pick<GraphQLArtist, 'id' | 'name'>>
       festivals: HomeFestival[]
-    }>(HomePageQuery, {}),
+    }>(HomePageQuery, {}).toPromise(),
   ])
   const festivals = (data?.festivals ?? []).map(toHeroFestival)
   const now = new Date()

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import type { Metadata } from 'next'
 import Link from 'next/link'
-import { getEventsWithAttendance } from '@/src/domains/events/data'
+import { getMyEvents } from '@/src/domains/events/data'
 import { buildHomeFeed, buildHomeHeroState } from '@/src/domains/events/home-view'
 import { HomeHero } from '@/src/domains/events/components/HomeHero'
 import { gql } from 'urql'
@@ -35,8 +35,7 @@ interface NearbyCard {
 
 const HomePageQuery = gql`
   query HomePage {
-    wishlistArtistIds
-    artists { id name }
+    wishlistArtists { id name }
     festivals {
       id
       name
@@ -81,14 +80,15 @@ function toHeroFestival(festival: HomeFestival) {
  * mucho esto conviene moverlo a un fetch client-side diferido.
  */
 async function getNearbyShows(
-  wishlistArtistIds: string[],
-  catalog: Array<Pick<GraphQLArtist, 'id' | 'name'>>
+  wishlistArtists: Array<Pick<GraphQLArtist, 'id' | 'name'>>
 ): Promise<NearbyCard[]> {
   if (!isTicketmasterConfigured()) return []
-  if (wishlistArtistIds.length === 0) return []
+  if (wishlistArtists.length === 0) return []
 
-  const wishlisted = new Set(wishlistArtistIds.slice(0, 6))
-  const artists = catalog.filter((a) => wishlisted.has(a.id))
+  // La query ya devuelve los artistas de la wishlist con su nombre. Antes se
+  // pedían los ids por un lado y el catálogo COMPLETO de artistas por otro,
+  // sólo para cruzarlos en memoria y quedarse con seis.
+  const artists = wishlistArtists.slice(0, 6)
 
   const results = await Promise.allSettled(
     artists.map(async (artist) => {
@@ -113,8 +113,8 @@ async function getNearbyShows(
   return withImages
 }
 
-async function NearbyShowsWrapper({ wishlistArtistIds, catalog }: { wishlistArtistIds: string[], catalog: Array<Pick<GraphQLArtist, 'id' | 'name'>> }) {
-  const nearbyShows = await getNearbyShows(wishlistArtistIds, catalog)
+async function NearbyShowsWrapper({ wishlistArtists }: { wishlistArtists: Array<Pick<GraphQLArtist, 'id' | 'name'>> }) {
+  const nearbyShows = await getNearbyShows(wishlistArtists)
   if (nearbyShows.length === 0) return null
 
   return (
@@ -164,10 +164,9 @@ async function NearbyShowsWrapper({ wishlistArtistIds, catalog }: { wishlistArti
 
 export default async function HomePage() {
   const [allEvents, { data }] = await Promise.all([
-    getEventsWithAttendance(),
+    getMyEvents(),
     getClient().query<{
-      wishlistArtistIds: string[]
-      artists: Array<Pick<GraphQLArtist, 'id' | 'name'>>
+      wishlistArtists: Array<Pick<GraphQLArtist, 'id' | 'name'>>
       festivals: HomeFestival[]
     }>(HomePageQuery, {}).toPromise(),
   ])
@@ -198,7 +197,7 @@ export default async function HomePage() {
       </React.Suspense>
 
       <React.Suspense fallback={<div className="min-h-screen bg-ritual-bg animate-pulse flex items-center justify-center"><p className="text-ritual-gray-text font-label uppercase">Buscando shows cerca tuyo...</p></div>}>
-        <NearbyShowsWrapper wishlistArtistIds={data?.wishlistArtistIds ?? []} catalog={data?.artists ?? []} />
+        <NearbyShowsWrapper wishlistArtists={data?.wishlistArtists ?? []} />
       </React.Suspense>
 
       {upcomingFestivals.length > 0 && (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { getEventsWithAttendance } from '@/src/domains/events/data'
@@ -112,45 +113,11 @@ async function getNearbyShows(
   return withImages
 }
 
-export default async function HomePage() {
-  const [allEvents, { data }] = await Promise.all([
-    getEventsWithAttendance(),
-    getClient().query<{
-      wishlistArtistIds: string[]
-      artists: Array<Pick<GraphQLArtist, 'id' | 'name'>>
-      festivals: HomeFestival[]
-    }>(HomePageQuery, {}).toPromise(),
-  ])
-  const festivals = (data?.festivals ?? []).map(toHeroFestival)
-  const now = new Date()
-
-  const { nextShow, byYear, years } = buildHomeFeed(allEvents, 'went', now)
-  const heroState = buildHomeHeroState(nextShow, festivals, now)
-
-  const heroEvent = heroState.kind === 'show-today' ? heroState.event : heroState.kind === 'normal' ? heroState.nextShow : undefined
-  const heroHeadliner = heroEvent?.lineups?.[0]?.artists.name ?? heroEvent?.name ?? null
-  const heroImage =
-    heroHeadliner && isSpotifyConfigured()
-      ? await searchSpotifyArtist(heroHeadliner).then(({ artist }) => (artist ? getBestSpotifyImage(artist.images) : null))
-      : null
-
-  const [nearbyShows, upcomingFestivals] = await Promise.all([
-    getNearbyShows(data?.wishlistArtistIds ?? [], data?.artists ?? []),
-    Promise.resolve(
-      festivals
-        .filter((f) => !isPastEvent(f.end_date ?? f.start_date, now))
-        .filter((f) => !(heroState.kind === 'festival' && f.id === heroState.festival.id))
-        .slice(0, 4)
-    ),
-  ])
-
-  const hasArchive = byYear && years.length > 0
+async function NearbyShowsWrapper({ wishlistArtistIds, catalog }: { wishlistArtistIds: string[], catalog: Array<Pick<GraphQLArtist, 'id' | 'name'>> }) {
+  const nearbyShows = await getNearbyShows(wishlistArtistIds, catalog)
+  if (nearbyShows.length === 0) return null
 
   return (
-    <>
-      <HomeHero state={heroState} backgroundImage={heroImage} />
-
-      {nearbyShows.length > 0 && (
         <section className="min-h-screen flex flex-col justify-center px-6 md:px-10 py-20 bg-ritual-bg">
           <div className="flex flex-wrap items-end justify-between gap-4 mb-10">
             <div>
@@ -192,7 +159,47 @@ export default async function HomePage() {
             ))}
           </div>
         </section>
-      )}
+  )
+}
+
+export default async function HomePage() {
+  const [allEvents, { data }] = await Promise.all([
+    getEventsWithAttendance(),
+    getClient().query<{
+      wishlistArtistIds: string[]
+      artists: Array<Pick<GraphQLArtist, 'id' | 'name'>>
+      festivals: HomeFestival[]
+    }>(HomePageQuery, {}).toPromise(),
+  ])
+  const festivals = (data?.festivals ?? []).map(toHeroFestival)
+  const now = new Date()
+
+  const { nextShow, byYear, years } = buildHomeFeed(allEvents, 'went', now)
+  const heroState = buildHomeHeroState(nextShow, festivals, now)
+
+  const heroEvent = heroState.kind === 'show-today' ? heroState.event : heroState.kind === 'normal' ? heroState.nextShow : undefined
+  const heroHeadliner = heroEvent?.lineups?.[0]?.artists.name ?? heroEvent?.name ?? null
+  const heroImagePromise =
+    heroHeadliner && isSpotifyConfigured()
+      ? searchSpotifyArtist(heroHeadliner).then(({ artist }) => (artist ? getBestSpotifyImage(artist.images) : null))
+      : Promise.resolve(null)
+
+  const upcomingFestivals = festivals
+    .filter((f) => !isPastEvent(f.end_date ?? f.start_date, now))
+    .filter((f) => !(heroState.kind === 'festival' && f.id === heroState.festival.id))
+    .slice(0, 4)
+
+  const hasArchive = byYear && years.length > 0
+
+  return (
+    <>
+      <React.Suspense fallback={<HomeHero state={heroState} backgroundImage={null} />}>
+        <HomeHero state={heroState} backgroundImage={heroImagePromise} />
+      </React.Suspense>
+
+      <React.Suspense fallback={<div className="min-h-screen bg-ritual-bg animate-pulse flex items-center justify-center"><p className="text-ritual-gray-text font-label uppercase">Buscando shows cerca tuyo...</p></div>}>
+        <NearbyShowsWrapper wishlistArtistIds={data?.wishlistArtistIds ?? []} catalog={data?.artists ?? []} />
+      </React.Suspense>
 
       {upcomingFestivals.length > 0 && (
         <section className="min-h-screen flex flex-col justify-center px-6 md:px-10 py-20 bg-ritual-panel">

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,24 @@
+import { MetadataRoute } from 'next'
+import { getEvents } from '@/src/domains/events/data'
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://ritual.vercel.app'
+  const events = await getEvents()
+
+  const eventsUrls = events.map((event) => ({
+    url: `${baseUrl}/events/${event.id}`,
+    lastModified: new Date(),
+    changeFrequency: 'weekly' as const,
+    priority: 0.8,
+  }))
+
+  return [
+    {
+      url: baseUrl,
+      lastModified: new Date(),
+      changeFrequency: 'daily' as const,
+      priority: 1,
+    },
+    ...eventsUrls,
+  ]
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,13 +1,13 @@
 import { MetadataRoute } from 'next'
-import { getEvents } from '@/src/domains/events/data'
+import { getEventIdsForSitemap } from '@/src/domains/events/data'
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://ritual.vercel.app'
-  const events = await getEvents()
+  const events = await getEventIdsForSitemap()
 
   const eventsUrls = events.map((event) => ({
     url: `${baseUrl}/events/${event.id}`,
-    lastModified: new Date(),
+    lastModified: new Date(event.date),
     changeFrequency: 'weekly' as const,
     priority: 0.8,
   }))

--- a/app/venues/[id]/page.tsx
+++ b/app/venues/[id]/page.tsx
@@ -31,7 +31,7 @@ async function fetchVenue(id: string): Promise<GraphQLVenueWithEvents | null> {
     const { data } = await getClient().query<{ venue: GraphQLVenueWithEvents | null }>(
         VenueDetailQuery,
         { id }
-    )
+    ).toPromise()
     return data?.venue ?? null
 }
 

--- a/app/wishlist/page.tsx
+++ b/app/wishlist/page.tsx
@@ -37,7 +37,7 @@ export default async function WishlistPage() {
     const { data } = await getClient().query<{
         wishlistArtistIds: string[]
         artists: GraphQLArtist[]
-    }>(WishlistPageQuery, {})
+    }>(WishlistPageQuery, {}).toPromise()
     const artistIds = data?.wishlistArtistIds ?? []
 
     if (artistIds.length === 0) {

--- a/app/wrapped/page.tsx
+++ b/app/wrapped/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import { getPersonalStats } from '@/src/domains/stats/data'
 import { buildWrappedSummary } from '@/src/domains/stats/wrapped-view'
-import { getEventsWithAttendance } from '@/src/domains/events/data'
+import { getMyEvents } from '@/src/domains/events/data'
 import { summarizeExpenses } from '@/src/domains/expenses/service'
 import { getProfile } from '@/src/domains/auth/data'
 import { getCurrentUserId } from '@/src/core/auth/session'
@@ -32,7 +32,7 @@ export default async function WrappedPage({ searchParams }: PageProps) {
     const userId = await getCurrentUserId()
     const [stats, allEvents, expensesSummary, profile] = await Promise.all([
         getPersonalStats(),
-        getEventsWithAttendance(),
+        getMyEvents(),
         summarizeExpenses(userId),
         getProfile(userId ?? undefined),
     ])
@@ -181,7 +181,7 @@ function buildSlides(data: {
     selectedYear: number
     showCount: number
     topArtist: readonly [string, number] | null
-    bestNight: Awaited<ReturnType<typeof getEventsWithAttendance>>[number] | null
+    bestNight: Awaited<ReturnType<typeof getMyEvents>>[number] | null
     uniqueVenues: number
     spentThisYear: number
 }): WrappedSlide[] {

--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -1,6 +1,6 @@
 # Acceso por rol
 
-Ritual tiene dos roles reales hoy: **visitante sin sesión** y **usuario autenticado**. No hay roles de administrador ni de moderación todavía. Este documento existe para que quede claro, en un solo lugar, qué puede ver y hacer cada uno — la fuente de la verdad real es la política RLS de cada tabla en `supabase/migrations/`; esta tabla es un resumen legible, no un reemplazo.
+Ritual tiene cuatro niveles de acceso: **visitante sin sesión**, **usuario autenticado**, **moderador** y **admin**. Los dos últimos sólo gatean la cola de moderación y el borrado del catálogo; el detalle está en la sección "Roles" más abajo. Este documento existe para que quede claro, en un solo lugar, qué puede ver y hacer cada uno — la fuente de la verdad real es la política RLS de cada tabla en `supabase/migrations/`; esta tabla es un resumen legible, no un reemplazo.
 
 ## Resumen por área
 
@@ -25,4 +25,15 @@ El catálogo compartido (Artistas, Sedes, Festivales, Buscar, Stats) tiene senti
 
 Todo lo de la tabla de arriba está reforzado con Row Level Security en Postgres, no solo en la UI — un usuario no puede escribir datos de otro aunque manipule la request directamente. Cada Server Action de escritura además valida la sesión de entrada (`getCurrentUserId()`) antes de tocar la base, para fallar con un mensaje claro en vez de depender solo del rechazo silencioso de RLS.
 
-**Fase 1 de roles (`sdd/ritual-roles-moderation-phase-1/`):** existe una columna `role` (`usuario` / `moderador` / `admin`, default `usuario`) en `profiles`, pero todavía **no gatea nada del catálogo** — cualquier fila compartida (evento, artista, sede, festival) sigue siendo editable por cualquier usuario autenticado, no solo por admin/moderador. Lo único que el rol controla hoy es la mutación `assignRole` (solo un admin puede cambiar el rol de otro usuario), a través de una función `assign_user_role` en Postgres que además revalida el permiso ella misma. El campo `role` en `Profile` solo es visible para el dueño del perfil o para un admin — no es público. La cola de moderación del catálogo, el panel `/admin` y el log de auditoría son fases futuras, todavía sin implementar; cuando se implementen, esta tabla debe actualizarse.
+### Roles
+
+Existe una columna `role` en `profiles` (`usuario` / `moderador` / `admin`, default `usuario`). Lo que gatea hoy:
+
+- **`assignRole`**: sólo un admin cambia el rol de otro usuario, vía la función `assign_user_role`, que revalida el permiso por su cuenta. El campo `role` de `Profile` sólo lo ve el dueño del perfil o un admin.
+- **Cola de moderación** (`/admin/moderacion/*`): las queries `unverified*`, las mutations `approve*` y `merge*`, y la query `mergeTargets` exigen `admin` o `moderador` en el resolver. Del lado de la base, `approve_entity` y los tres `merge_*` son `SECURITY DEFINER` y revalidan el rol adentro, así que pegarle directo a PostgREST no lo saltea.
+- **Cambio de `status`** (verificado / sin verificar): un trigger `BEFORE UPDATE` en `artists`, `venues` y `events` rechaza la transición si quien la hace no es admin ni moderador. Va por trigger y no por policy porque en una policy de UPDATE no se pueden correlacionar la fila vieja y la nueva.
+- **Borrado del catálogo**: eliminar un evento o un festival está restringido a admin y moderador, en RLS y en el service. La **edición** sigue abierta a cualquier autenticado a propósito: el catálogo es colaborativo y el borrado es lo único sin vuelta atrás.
+
+**Pendiente:** la creación de festivales sigue abierta a cualquier autenticado, aunque el spec de la fase 2 (§4) los reserva a Admin. El log de auditoría tampoco existe todavía.
+
+El modelo es de **post-moderación**: lo que carga un usuario se publica al instante con `status = 'unverified'` y queda visible en la app pública. La cola sirve para revisarlo después, no para retenerlo. Falta una marca visual de "sin verificar" en las vistas públicas.

--- a/docs/auditoria-2026-08-25.md
+++ b/docs/auditoria-2026-08-25.md
@@ -1,0 +1,483 @@
+# Auditoría — 2026-08-25
+
+Cuatro revisiones en paralelo (seguridad, carga de base, scrapers, estructura y
+flujo) sobre la rama `main` con el working tree sin commitear, más verificación
+directa contra la base desplegada `ritual-db`.
+
+Cada hallazgo indica cómo se estableció:
+
+- **[verificado]** — comprobado contra el código o contra la base, en esta sesión.
+- **[reportado]** — hallazgo de un agente, no re-verificado de forma independiente.
+- **[requiere medición]** — depende de datos o de red que no había disponibles.
+
+## Estado de corrección
+
+Arreglado y verificado contra un `supabase db reset` limpio, con `npm test`
+(1021), `tsc --noEmit` y `npm run lint` los tres en verde:
+
+- P1.1 — los merge apuntaban a `event_artists`/`user_wishlist`, que no existen.
+  Renombrado a `lineups`/`wishlist`.
+- P1.2 — colisión de `events.status`. La columna vieja (`text default
+  'scheduled'`, sin lectores en el código) se dropea antes de crear el enum.
+- P2.1 — el cron fallaba abierto. Ahora falla cerrado y compara en tiempo
+  constante.
+- P2.2 — borrado del catálogo restringido a moderadores, en RLS y en el
+  service. `removeEvent` además verifica que el DELETE haya afectado una fila.
+- P2.3 — `search_catalog` del MCP escapa comodines de LIKE.
+- P3.1 — cron agendado en `vercel.json`.
+- P3.2 — CI en verde: lint y `tsc` pasan.
+- P3.3 — fechas de fuentes externas parseadas con `parseExternalDateTime`.
+- P4.1 — el `approve_entity` del MCP pasa por el RPC y deja de mentir.
+- Orden de `pg_trgm`: el índice trigram de `external_events_cache` se creaba
+  antes de habilitar la extensión y cortaba toda la cadena de migraciones desde
+  cero. **El CLI de Supabase devolvía exit 0 igual**, así que ni el CI lo veía.
+- GRANTs de tabla, que ninguna migración otorgaba
+  (`20260826000000_table_grants.sql`).
+
+Sigue pendiente todo lo listado en P5 (carga sobre la base) y P6 (estructura),
+más los ítems de UI pausados a propósito.
+
+---
+
+## P0 — El entorno local no arranca contra ninguna base
+
+**[verificado]** leyendo `.env.local` mediante un script que reporta sólo forma
+y longitud, sin exponer valores.
+
+- `NEXT_PUBLIC_SUPABASE_URL` = `http://localhost:54321` — el stack de Supabase
+  **local**, no el proyecto remoto. Existe una config `supabase-local` en
+  `.claude/launch.json` que lo respalda.
+- `NEXT_PUBLIC_SUPABASE_ANON_KEY` mide 153 caracteres, de los cuales 145 son
+  no-Latin1: 8 caracteres reales seguidos de 145 `•` (U+2022, desde el índice 8).
+  Es la key copiada del dashboard con el enmascarado puesto.
+
+Consecuencia: `fetch` no puede construir el header y tira
+`TypeError: Cannot convert argument to a ByteString`. Toda lectura falla, la
+degradación las convierte en listas vacías, y la home muestra su estado vacío
+("Todavía no hay ningún talón") como si simplemente no hubiera datos.
+
+`validateEnv()` no lo detecta porque sólo verifica que las variables estén
+presentes, no que sean válidas.
+
+### Corrección
+
+Reponer la anon key real. Si el desarrollo va contra Supabase local, es el JWT
+fijo que imprime `supabase start`.
+
+---
+
+## P0.1 — El proyecto remoto está muy por detrás del repo
+
+**[verificado]** contra el proyecto Supabase del entorno remoto, consultando su
+esquema en vivo. El identificador del proyecto se omite a propósito: este repo
+es público.
+
+Salvedad importante: `.env.local` apunta a Supabase local, así que **este
+proyecto remoto no es el que usa el entorno de desarrollo**. No hay
+configuración de despliegue en el repo que confirme si es el de producción o un
+remoto abandonado. Determinarlo es el primer paso; el resto de esta sección
+describe su estado tal cual está hoy.
+
+### Qué falta
+
+| Objeto ausente | Migración que lo crea |
+|---|---|
+| `profiles.role`, tipo `user_role`, `get_user_role()`, `assign_user_role()` | `20260823202400_user_roles` |
+| `artists.status`, `venues.status`, `created_by`, tipo `verification_status` | `20260824202000_moderation_queue` |
+| `merge_artists()`, `merge_venues()`, `merge_events()`, `check_creation_rate_limit()` | `20260824202000_moderation_queue` |
+| `approve_entity()`, `is_moderator()`, triggers de guarda de status | `20260825060000_moderation_approve_and_status_guard` |
+| `external_events_cache` | `20260824000000_external_events_cache` |
+| `get_expenses_summary()`, `get_venue_artist_spend_estimate()` | `20260824205600_expenses_aggregations` |
+| `event_checklist_items`, `event_checklist_checks`, `checklist_template_items` | `20260823100000_show_mode` |
+
+`events.status` sigue siendo `text default 'scheduled'` — la columna original,
+no el enum de verificación. Las 16 tablas tienen 0 filas. Siguen existiendo
+`tours`, `festival_editions` y `memories`, que migraciones posteriores debían
+eliminar o plegar.
+
+El historial de migraciones registra 7 entradas, pero `wishlist` existe y la crea
+la octava. Se aplicaron cambios a mano desde el SQL Editor, así que el historial
+no sirve como referencia: el esquema real es la única fuente de verdad.
+
+### Qué rompe hoy
+
+- `createGraphQLContext` llama a `get_user_role`, que no existe. El catch degrada
+  a `'usuario'`, así que `requireModerator` rechaza a todos — **el panel de
+  moderación no lo puede abrir nadie, ni el Owner**.
+- `getExpensesSummary()` y `getVenueArtistSpendEstimate()` llaman a RPCs
+  inexistentes y devuelven su fallback vacío. El resumen de gastos muestra ceros
+  sin avisar.
+- La cola de moderación consulta `.eq('status','unverified')` sobre columnas que
+  no existen en `artists` ni `venues`.
+
+La degradación elegante del proyecto es lo que evita que esto explote: falla en
+silencio en lugar de gritar.
+
+### Acción
+
+1. Determinar si la base se sincroniza (`supabase db push`) o si hay divergencia
+   que resolver primero con `supabase db pull`. Dado que hay 0 filas, un reset
+   limpio es viable y probablemente lo más simple.
+2. **Antes de sincronizar**, corregir P1.1 y P1.2 — están dentro de las
+   migraciones no aplicadas, así que se arreglan sin necesidad de una migración
+   correctiva encima.
+
+---
+
+## P0.2 — Dos bugs encontrados al levantar el entorno local, uno arreglado
+
+**[verificado]** de punta a punta: levanté Supabase local (`supabase start`),
+sembré datos de prueba y navegué la home logueado.
+
+### Arreglado — el talón 3D no podía renderizar dentro de la app
+
+`next.config.ts` aplicaba `X-Frame-Options: DENY` y `frame-ancestors 'none'` a
+`source: '/(.*)'`, sin excepción para `/tickets/`. `TicketEmbed.tsx` monta el
+talón como iframe same-origin, y `DENY` bloquea el framing incluso desde el
+propio origen — sólo `SAMEORIGIN` lo permite. Resultado: la request al HTML del
+talón respondía `200 OK` pero el navegador la descartaba con
+`net::ERR_BLOCKED_BY_RESPONSE`, sin ningún error en consola. El talón se veía
+negro dentro de la home; la misma URL abierta directo funcionaba perfecto, lo
+que hacía parecer un problema de three.js cuando era un header.
+
+Cronología: los headers son del 18 de febrero (`b140686`); el talón se
+empaquetó como iframe reusable el 31 de julio (`f5b292f`). El fix de esa fecha
+resolvió un bloqueo distinto (CSP del `script-src` contra unpkg) y
+probablemente se verificó abriendo el HTML suelto, no montado en la app — así
+nunca se notó el framing roto.
+
+Arreglado en `next.config.ts`: una regla para `/tickets/:path*` que afloja
+`X-Frame-Options` a `SAMEORIGIN` y `frame-ancestors` a `'self'`, después de la
+regla global para que la pise. El resto del sitio conserva `DENY`. Pendiente de
+commitear.
+
+### Sin arreglar en el repo — faltan GRANT a nivel tabla
+
+Con RLS habilitada pero sin `GRANT SELECT`/`INSERT`/etc. a `anon` y
+`authenticated`, todas las lecturas fallaban con
+`permission denied for table events` (42501), incluso con policies correctas.
+Ninguna migración del repo otorga estos privilegios explícitamente — el
+proyecto remoto probablemente los tiene por un `GRANT` aplicado a mano alguna
+vez, igual que los objetos de P0.1.
+
+Lo apliqué manualmente en la base local para poder probar (no está en una
+migración versionada):
+
+```sql
+grant usage on schema public to anon, authenticated;
+grant select on all tables in schema public to anon, authenticated;
+grant insert, update, delete on all tables in schema public to authenticated;
+grant usage, select on all sequences in schema public to anon, authenticated;
+alter default privileges in schema public grant select on tables to anon, authenticated;
+```
+
+Falta decidir el alcance correcto por tabla (no necesariamente todas necesitan
+los cuatro privilegios para `authenticated`) y escribirlo como migración,
+porque hoy un `supabase db reset` desde cero no deja el entorno funcional.
+
+---
+
+## P1 — Bugs dentro de migraciones todavía no aplicadas
+
+Se arreglan editando el archivo, porque nunca corrieron.
+
+### P1.1 — Los merge apuntan a dos tablas que no existen
+
+**[verificado]** contra la base: sólo existen `lineups` y `wishlist`.
+
+`20260824202000_moderation_queue.sql` y su reescritura
+`20260825060000_moderation_approve_and_status_guard.sql` usan `event_artists` y
+`user_wishlist`. Esos identificadores no aparecen en ningún otro archivo del
+repo. Las tablas reales son `lineups` y `wishlist`.
+
+`plpgsql` no valida catálogos al crear la función, así que la migración aplica
+limpia y el error aparece recién al ejecutar la fusión:
+`42P01 relation "event_artists" does not exist`.
+
+Alcance: `merge_artists` y `merge_events` abortan en su primera sentencia.
+`merge_venues` es la única que funcionaría.
+
+Nota de proceso: la guarda de rol de esos tres RPC se endureció el 2026-08-25 sin
+verificar que las tablas que tocan existieran.
+
+### P1.2 — `events.status` colisiona
+
+**[verificado]**: la base tiene `events.status text default 'scheduled'`, creada
+en `20260216230841_remote_schema.sql:41`. Ninguna migración la elimina — los
+únicos `drop column` son `tour_id`, `festival_edition_id` e `is_child_event`.
+
+`20260824202000_moderation_queue.sql:13-16` hace
+`ALTER TABLE events ADD COLUMN status verification_status, ADD COLUMN created_by ...`
+en una sola sentencia. Sobre la base actual falla con
+`column "status" of relation "events" already exists`, y al ser una única
+sentencia tampoco se agrega `created_by` — que el trigger
+`check_creation_rate_limit` escribe incondicionalmente, con lo cual todo INSERT
+en `events` pasaría a fallar.
+
+Hay que decidir si la columna vieja se renombra, se elimina o si la de
+verificación usa otro nombre, y reflejarlo en `src/graphql/events.ts:96`, que hoy
+expone `status` sin distinguir cuál de las dos semánticas devuelve.
+
+### P1.3 — Fusionar deja registros huérfanos
+
+**[reportado]**, cruzado contra las FK de las migraciones.
+
+| FK | ON DELETE | ¿la mueve el merge? | Consecuencia |
+|---|---|---|---|
+| `expenses.event_id` | SET NULL | no | el gasto pierde su show |
+| `festival_events.event_id` | CASCADE | no | el evento desaparece del festival |
+| `event_checklist_items.event_id` | CASCADE | no | se borra el checklist |
+| `event_checklist_checks.event_id` | CASCADE | no | se borra el estado tildado |
+| `festivals.venue_id` | SET NULL | no | el festival queda sin sede |
+
+Ninguna levanta excepción: `merge_*` devuelve éxito y la pérdida es silenciosa.
+
+---
+
+## P2 — Seguridad
+
+### P2.1 — El cron falla abierto — CRÍTICO
+
+**[verificado]** en `app/api/cron/sync-external-sources/route.ts:14`.
+
+```ts
+if (process.env.CRON_SECRET && authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+  return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+}
+```
+
+Si `CRON_SECRET` no está seteada, la condición completa es falsa y el chequeo se
+saltea entero. El handler sigue con `SUPABASE_SERVICE_ROLE_KEY`, que bypassa RLS.
+Un olvido de variable en un deploy de preview deja el endpoint público con la
+llave maestra.
+
+Corrección: fallar cerrado cuando el secreto no está configurado, y comparar con
+`crypto.timingSafeEqual`.
+
+### P2.2 — Cualquier autenticado puede borrar cualquier evento o festival
+
+**[verificado]**: `"Allow update events"` y `"Allow delete events"` son
+`using (true) with check (true)`, restringidas sólo a `authenticated`
+(`20260217000000` + `20260721000000`). `removeEvent`
+(`src/domains/events/service.ts:248`) sólo comprueba que haya sesión — sin
+ownership ni rol. Mismo patrón en festivales.
+
+El trigger de guarda de status protege únicamente esa columna. El resto de las
+columnas y el `DELETE` completo siguen abiertos.
+
+Si el catálogo colaborativo estilo wiki es la intención, conviene al menos
+reservar el `DELETE` a moderadores. La migración original lo dejó anotado como
+deuda: *"Más adelante se puede restringir a auth.uid() o rol"*.
+
+### P2.3 — `search_catalog` del MCP no escapa comodines de LIKE
+
+**[reportado]**, `mcp/src/index.ts:118`. Es el mismo bug que ya se corrigió del
+lado de la app con `escapeLikeWildcards`
+(`src/domains/moderation/service.ts:67`). Un `%` en el término ensancha el match
+justo antes de una fusión destructiva.
+
+### P2.4 — `check_creation_rate_limit()` sin `SET search_path`
+
+**[reportado]**, `20260824202000_moderation_queue.sql:19`. Es la única función
+`SECURITY DEFINER` del repo sin esa cláusula.
+
+### P2.5 — `spatial_ref_sys` con RLS deshabilitada
+
+**[verificado]** vía el advisor de Supabase. Es la tabla de sistema de PostGIS,
+datos de referencia — riesgo bajo, pero el advisor lo marca como crítico.
+Habilitar RLS sin policies bloquea el acceso, así que es una decisión a tomar,
+no algo a aplicar automáticamente.
+
+---
+
+## P3 — Los scrapers no funcionan
+
+### P3.1 — El cron nunca se ejecuta
+
+**[verificado]**: no existe `vercel.json`, no hay bloque `crons`, `.vercel/` sólo
+tiene el `project.json` de vinculación, y `ci.yml` no lo invoca. Buscando
+`sync-external-sources` en todo el repo, la única aparición es la propia route.
+
+Sumado a que `external_events_cache` tampoco existe en la base (P0), la feature
+de scraping está muerta por dos razones independientes.
+
+### P3.2 — El CI está en rojo
+
+**[verificado]**: `npm run lint` → exit 1 (190 errores), `npx tsc --noEmit` →
+exit 1. `ci.yml` corre ambos. Los tests pasan (1011/1011). Un CI que siempre
+falla es un CI que nadie mira.
+
+La mayoría de los errores de lint vienen de archivos que no deberían lintearse
+(`coverage/`, `supabase/.temp/`, un bundle minificado en `public/`). El error de
+`tsc` es real: `relayOptions` no existe en Pothos v4
+(`src/graphql/builder.ts:12`).
+
+### P3.3 — Importar un evento scrapeado falla en la mayoría de las fuentes
+
+**[reportado]**, con la premisa verificada: `events.date` es `timestamptz not null`.
+
+El `datetime` crudo del adaptador va directo a esa columna sin validación en
+ningún punto — ni el input GraphQL, ni el resolver, ni el service. Varias fuentes
+producen fechas en prosa (`"Domingo 06 de Septiembre"`), que Postgres rechaza y
+`sanitizeError` convierte en un mensaje genérico.
+
+En la práctica el botón de importar sólo funciona con Ticketmaster, enigma y
+norteticket. `livepass` produce como fecha las primeras tres palabras del texto
+de la tarjeta. `konex` devuelve `datetime: ''` siempre.
+
+Lo mismo se filtra a la UI: `FutureEventsResults` renderiza literalmente el texto
+`"Invalid Date"`.
+
+### P3.4 — Ceros silenciosos
+
+**[reportado]**. Cuando un sitio cambia su HTML, el adaptador devuelve
+`{ events: [], total: 0 }` sin `error`. El cron lo cuenta como éxito y responde
+`{ success: true }`. No hay forma de distinguir "el selector se rompió" de "hoy
+no hay recitales". Sentry está inicializado pero sin `captureConsoleIntegration`,
+así que los `console.error` no llegan.
+
+Los tests seguirán en verde indefinidamente porque corren contra fixtures
+congelados — y **6 de los 11 fixtures son miniaturas escritas a mano** (konex 147
+bytes, puntoticket 214, tuentrada 304, norteticket 497/541, pulsotickets 1.5 KB),
+que validan una forma inventada por quien escribió el adaptador. Los de
+allaccess, enigma, entraste y livepass sí son capturas reales de 230–450 KB.
+
+### P3.5 — Otros
+
+- **[reportado]** `events` no tiene constraint de unicidad. El mismo show
+  importado dos veces crea dos filas — justo lo que la cola de moderación
+  después tiene que fusionar a mano.
+- **[reportado]** `isConfigured()` es código muerto: los 13 adaptadores lo
+  implementan como `() => true` y nadie lo llama.
+- **[reportado]** `norteticket` hace un loop secuencial sin cota; cada iteración
+  cuesta hasta 16.5 s y puede agotar sola los 300 s de `maxDuration`.
+- **[reportado]** Ningún adaptador manda User-Agent, aunque el diseño se
+  compromete a `RitualBot/1.0` y a un crawl delay de 1-2 s.
+
+---
+
+## P4 — Flujo de usuario
+
+### P4.1 — Aprobar por MCP miente en artistas y sedes
+
+**[reportado]**, `mcp/src/index.ts:125`. Hace `UPDATE` directo — el mismo camino
+que se reemplazó por RPC del lado web. Sin policy de UPDATE en `artists` ni
+`venues`, RLS deniega, PostgREST devuelve 0 filas con `error: null`, y el MCP
+responde `Éxito`. En `events` sí funciona.
+
+### P4.2 — Los festivales no están restringidos a Admin
+
+**[reportado]**. El `01-spec.md` §4 los excluye del scope comunitario, pero
+`insertFestival` (`src/domains/festivals/service.ts:63`) sólo valida que haya
+sesión, y `createFestival` no tiene guarda de rol. `/festivals/nuevo` está
+publicada en `routes.ts:49`.
+
+### P4.3 — Importar carga la cola con tres filas
+
+**[reportado]**. `addExternalEvent` crea venue + artista + evento, los tres
+`unverified`. El flujo de alta más común es el que más carga la cola. Y
+`/admin/moderacion/eventos` dice "Recitales creados a mano que no vinieron por
+APIs externas", que es falso.
+
+Relacionado: el rate limit corta en 5 creaciones por hora **por tabla**, así que
+a la sexta importación en una hora el usuario recibe un error genérico —
+`sanitizeError` no mapea `rate_limit_exceeded`.
+
+### P4.4 — La cola de eventos ordena por fecha del recital
+
+**[reportado]**, `service.ts:54` usa `.order('date')` en vez de `created_at`. Lo
+recién cargado cae al fondo. Artistas y sedes sí ordenan por `created_at desc`.
+
+### P4.5 — El buscador de fusión está construido y desconectado
+
+**[verificado]**. `searchMergeTargets` y la query `mergeTargets` están escritas,
+testeadas y con escapado de comodines; `Combobox` existe. Ningún componente los
+consume: la UI sigue pidiendo el UUID tipeado a mano. Es trabajo de UI pausado a
+propósito, anotado acá para que no se pierda.
+
+### P4.6 — Soft-publish funciona como dice el spec
+
+**[verificado]**. Ningún `data.ts` filtra por `status`. Es la decisión del
+`01-spec.md` §2, no un bug. Lo que falta es cualquier marca visual de "sin
+verificar" en la vista pública — eso es trabajo de diseño, no de filtrado.
+
+---
+
+## P5 — Carga sobre la base
+
+Todos **[reportado]**. Ninguno duele hoy con 0 filas; importan a medida que crezca.
+
+| Hallazgo | Ubicación |
+|---|---|
+| `getPersonalStats()` trae la tabla `events` entera con tres joins, sin límite, y filtra en JS | `src/domains/stats/data.ts:84` |
+| `/wrapped` hace dos barridas casi idénticas del catálogo en el mismo request | `app/wrapped/page.tsx:33` |
+| N+1 vivo en `Artist.events` y `Venue.events` — el pase de DataLoader no los cubrió | `src/graphql/artists.ts:67`, `venues.ts:57` |
+| El home carga tres catálogos completos por request | `app/page.tsx:166` |
+| El trigger de rate limit hace `count(*)` sin índice sobre `created_by` | `20260824202000:37` |
+| Los filtros de la cola no tienen índice sobre `status`; ninguna pagina | `moderation/service.ts:18` |
+| `attendance` no tiene índice por `event_id` solo — `merge_events` hace dos seq scans con lock | `20260216230841:142` |
+| Policies RLS con `auth.uid()` sin envolver en `(select ...)` — se re-evalúa por fila | ~15 policies |
+| Ninguna página declara revalidación; todo es dinámico porque `createClient()` llama a `cookies()` | global |
+| `sitemap.ts` trae 1000 eventos con joins para usar sólo el `id` | `app/sitemap.ts:6` |
+| `getCurrentUserId()` sin `cache()` — 5 validaciones del mismo JWT por render | `src/core/auth/session.ts:10` |
+
+Nota sobre el trigger de guarda de status: **no** agrega una query por cada
+UPDATE. El `AND` de `NEW.status IS DISTINCT FROM OLD.status AND NOT is_moderator()`
+corta a la izquierda, así que `is_moderator()` sólo corre cuando `status`
+efectivamente cambia. Un UPDATE de nombre o fecha paga cero queries.
+
+---
+
+## P6 — Estructura y limpieza
+
+Todos **[reportado]**.
+
+- `app/buscar/page.tsx:28` tiene `createClient` y lógica de negocio en la ruta, con
+  `ilike` sin escapar comodines. Es la única violación real de la convención.
+- `moderation` es el único dominio sin `data.ts`.
+- El seam `service.ts` ya estaba erosionado: `src/graphql/` importa `data.ts`
+  directo en 7 archivos y `app/` en 16.
+- Imports cruzados entre dominios: `expenses` → `events`, `showmode` → `expenses`
+  y `weather`.
+- Tres documentos de convención desactualizados: `src/README.md` describe
+  `actions.ts` (borrado), `docs/estructura-del-proyecto.md` no lista tres
+  dominios, y `docs/access-control.md` afirma que no hay roles ni panel admin.
+- Versionado y no debería: `msg.txt`, `test-adapters.ts`, `scratch/`.
+- Sin trackear, para borrar: `refactor.js`, `refactor-waterfall.js`.
+- `.gitignore` no cubre `mcp/node_modules/` ni `mcp/dist/`. Un `git add mcp/`
+  metería 4355 archivos.
+
+---
+
+## Verificado y sano
+
+- Los DataLoaders de `attendance` y `photos` están bien construidos: `.in()` con
+  remapeo que preserva el orden de las claves.
+- Paginación de `events` con `resolveOffsetConnection` y la cota `MAX_EVENTS`.
+- El cliente GraphQL corre en proceso vía `yoga.fetch`, sin vuelta por HTTP.
+- `findOrCreateByName`: upsert-then-select atómico contra `name_key`, sin TOCTOU.
+- Los índices de gastos cubren exactamente los shapes que usan sus RPCs.
+- Los 13 adaptadores usan `fetchWithRetry`, ninguno tira hacia arriba, y ninguno
+  es alcanzable desde una Server Component — un sitio caído no puede colgar una
+  página.
+- Los cuatro clientes de API externa cumplen el ADR 0003.
+- `assign_user_role` usa `IS DISTINCT FROM` para fallar cerrado ante rol NULL.
+- El JSON-LD con `dangerouslySetInnerHTML` está correctamente mitigado.
+- `safeHref` bloquea `javascript:`; `sanitizeError` no filtra detalles internos.
+- `/admin` sin guard no filtra datos: `requireModerator` corta en el resolver.
+
+---
+
+## Requiere verificación con la base viva o con red
+
+- Si algún sitio scrapeado ya cambió su HTML. Sin red, los fixtures sólo prueban
+  que el parser maneja ese snapshot.
+- Si los endpoints de `alpogo` y `quehacemos` existen. `alpogo.ts:14` se
+  auto-declara adivinado.
+- Si los sitios rechazan requests sin User-Agent.
+- Volumen y frecuencia reales del cron, que multiplican todo P5.
+- Contenido de `mcp/.env.example` — el sandbox bloquea la lectura de archivos
+  `.env`. Está commiteado a propósito; conviene confirmar a mano que sólo tiene
+  placeholders.
+- A qué proyecto de Supabase apunta `.env.local`. `ritual-db` es el único de la
+  cuenta, pero no pude leer el archivo.

--- a/docs/auditoria-2026-08-25.md
+++ b/docs/auditoria-2026-08-25.md
@@ -34,8 +34,28 @@ Arreglado y verificado contra un `supabase db reset` limpio, con `npm test`
 - GRANTs de tabla, que ninguna migración otorgaba
   (`20260826000000_table_grants.sql`).
 
-Sigue pendiente todo lo listado en P5 (carga sobre la base) y P6 (estructura),
-más los ítems de UI pausados a propósito.
+P5 (carga sobre la base) cerrado:
+
+- N+1 en `Artist.events` y `Venue.events`, con DataLoader. Medido: una query
+  GraphQL sobre 3 artistas ejecuta 1 sentencia.
+- Cuatro índices faltantes (rate limit, colas de moderación, `attendance` por
+  evento, `expires_at` del cache), verificados con EXPLAIN.
+- `getCurrentUserId` memoizado por request con `cache()` de React.
+- Sitemap con lectura dedicada de `id, date`: 1 sentencia sin joins.
+- `getPersonalStats` invertida: parte de `attendance` del usuario en vez de
+  barrer la tabla `events` entera.
+- Home y `/wrapped` dejan de leer el catálogo completo. Un render anónimo del
+  home pasa a ejecutar cero queries contra el catálogo.
+- Las ~46 policies con `auth.uid()` sin envolver quedan en 17, todas con
+  `(select auth.uid())`.
+
+Encontrado al hacer P5, no estaba en el informe original: `event_photos` tenía
+un `with check (true)` conviviendo con la policy de dueño. Como las permisivas
+se combinan con OR, cualquier autenticado podía insertar una foto atribuida a
+otro usuario. Corregido y verificado con dos cuentas reales (403 al intentar
+suplantar, 201 al subir la propia).
+
+Sigue pendiente P6 (estructura) y los ítems de UI pausados a propósito.
 
 ---
 

--- a/docs/backlog-producto.md
+++ b/docs/backlog-producto.md
@@ -1,0 +1,30 @@
+# Backlog de producto — ideas futuras
+
+Ideas anotadas para revisar mucho después. No son compromisos ni tienen fecha.
+
+## Mapa de recitales
+
+Anotado 2026-08-25. Dos variantes posibles, sin decidir todavía cuál (o si las
+dos):
+
+- **Mapa personal**: los lugares a los que fuiste, marcados sobre un mapa.
+  Tendría data ya disponible — `attendance` con `status = 'went'` más
+  `venues.address`/`city`/`country` — pero ninguna venue tiene lat/lng
+  guardada hoy (columnas `lat`/`lng` existen en `venues` pero no se llenan en
+  ningún flujo de alta).
+- **Mapa de próximos shows**: recitales agendados o disponibles, geolocalizados.
+  Se apoyaría en las mismas coordenadas de venue, más los eventos futuros del
+  catálogo.
+
+No evaluado todavía: costo de un proveedor de mapas, si conviene geocodificar
+las direcciones existentes o pedir lat/lng en el alta de venue de acá en más,
+ni si esto es una pantalla nueva o un modo de vista dentro de `/coleccion`.
+
+## Reliquias — entradas fijadas en el perfil
+
+Ya estaba evaluada y pospuesta a propósito por el propio commit que reconstruyó
+el perfil (`7568d676`, 2026-07-31): *"reliquias (pinned shows — needs a new
+pinned column on attendance that doesn't exist)"*. Depende de la capa social
+(issue #5), pausada con `attendance` privada por defecto hasta que esa capa se
+diseñe. No se perdió código: nunca se construyó. Se deja anotada acá para que
+no se re-litigue el motivo cada vez que se retome.

--- a/docs/design-backlog.md
+++ b/docs/design-backlog.md
@@ -1,0 +1,218 @@
+# Backlog de diseño — RITUAL
+
+Inventario de **qué** falta diseñar, para que Claude Design (o cualquier agente de
+UI) sepa dónde entrar sin tener que relevar el repo de cero.
+
+Este documento no propone estética ni decide criterios visuales: lista rutas,
+estado real y restricciones técnicas que el diseño no puede romper. Las
+decisiones de diseño son de quien diseñe.
+
+Relevado el 2026-08-25 contra la rama `main` con el working tree sin commitear.
+
+---
+
+## 1. Sistema de diseño ya existente
+
+Antes de inventar vocabulario nuevo, conviene saber que ya hay uno. Está en
+`app/globals.css`.
+
+### Color
+
+Paleta oscura, brutalista. Se usan como clases de Tailwind v4 (`bg-ritual-panel`,
+`text-ritual-bone`, `border-ritual-border-subtle`).
+
+| Grupo | Tokens |
+|---|---|
+| Fondos | `ritual-bg` `#08080A`, `ritual-panel` `#0B0B0C`, `ritual-panel-2` `#0C0C0F` |
+| Superficies | `ritual-surface` `#101013`, `ritual-surface-2`, `ritual-surface-high` `#17171A`, `ritual-surface-high-2` |
+| Bordes | `ritual-border-subtle` `#15151A`, `ritual-border-subtle-2`, `ritual-border` `#1E1E22`, `ritual-border-2`, `ritual-border-3` |
+| Grises | `ritual-gray-muted`, `-muted-2`, `-mid`, `-mid-2`, `ritual-gray-text` `#8A8A90`, `-text-2`, `ritual-gray-light`, `-light-2`, `-light-3` |
+| Texto principal | `ritual-bone` `#EDEBE6` |
+| Acento | `ritual-red` `#D6202A`, `ritual-red-hover` `#F0464F`, `ritual-red-dark`, `ritual-red-dark-2` |
+| Papel (superficies claras) | `ritual-paper` `#EDE9DF`, `ritual-paper-2`, `ritual-paper-ink` `#141210`, `ritual-paper-red` |
+
+### Tipografía
+
+Ocho roles cargados por `next/font/google` en `app/layout.tsx`:
+
+| Clase | Familia | Uso observado |
+|---|---|---|
+| `font-display` | Anton | Títulos grandes en mayúscula |
+| `font-badge` | Archivo Black | Badges, énfasis pesado |
+| `font-dense` | Archivo | Nombres de entidad, filas de tabla |
+| `font-subtitle` | Big Shoulders | Subtítulos |
+| `font-figure` | Bebas Neue | Cifras y números destacados |
+| `font-label` | Space Mono | Etiquetas en mayúscula con tracking amplio, texto de 10px |
+| `font-body` / `font-sans` | Space Grotesk | Cuerpo, texto corrido |
+
+### Componentes reutilizables ya construidos
+
+En `src/core/components/ui/`: `Button`, `LinkButton`, `Card`, `Combobox`
+(buscar-y-elegir con creación inline, accesible por teclado), `ConfirmDeleteButton`,
+`EmptyState`, `FormField`, `Input`, `Textarea`, `Skeleton`, `StarRating`, `Tabs`,
+`TicketEmbed`.
+
+En `src/core/components/layout/`: `Navbar`, `Footer`, `PageShell` (envoltorio de
+página con back link, título y descripción), `ProfileDropdown`.
+
+Conviene reusar estos antes de crear variantes nuevas.
+
+---
+
+## 2. Prioridad 1 — Panel de admin y moderación
+
+**Todo el panel está sin diseñar.** Existe como esqueleto funcional: usa los
+tokens correctos pero no pasó por ninguna pasada de diseño.
+
+| Ruta | Archivo | Estado |
+|---|---|---|
+| `/admin` | `app/admin/page.tsx` | Redirect a la cola de artistas. No requiere diseño. |
+| (layout) | `app/admin/layout.tsx` | Sidebar con navegación. Único responsive: colapsa a columna en `md`. Falta el enlace "Usuarios" (marcado como próximamente, deshabilitado). |
+| `/admin/moderacion/artistas` | `app/admin/moderacion/artistas/page.tsx` | Tabla funcional con acciones cableadas. |
+| `/admin/moderacion/sedes` | `app/admin/moderacion/sedes/page.tsx` | Tabla maquetada, **botones sin `onClick`**. |
+| `/admin/moderacion/eventos` | `app/admin/moderacion/eventos/page.tsx` | Tabla maquetada, **botones sin `onClick`**. |
+
+El contrato funcional detallado de estas tres pantallas (queries, mutations,
+comportamiento esperado de aprobar y fusionar) está en
+`sdd/ritual-roles-moderation-phase-2/04-ui-claude-design-handoff.md`. Leerlo antes
+de diseñar: define el modelo de post-moderación y por qué la elección de la
+entidad canónica va por buscador y no por pegado de UUID.
+
+Las tres tablas usan `<table>` con anchos en fracciones. En viewport angosto no
+hay estrategia definida: es el punto a resolver.
+
+Pantallas del panel que el sidebar promete y todavía no existen:
+- `/admin/usuarios` — gestión de roles. El backend ya tiene el RPC `assign_user_role`.
+- No hay pantalla de métricas, aunque el `01-spec.md` la menciona como parte del rol Admin.
+
+---
+
+## 3. Prioridad 2 — Mobile en todo el sitio
+
+Medida usada: cantidad de prefijos responsive (`sm:` `md:` `lg:` `xl:` `2xl:`) por
+archivo. **Es una señal, no una prueba**: una pantalla de una sola columna puede
+funcionar bien en mobile sin un solo breakpoint. Sirve para saber dónde mirar
+primero, no para concluir que está rota.
+
+### Navegación
+
+`Navbar` (`src/core/components/layout/Navbar.tsx`) ya tiene una estrategia mobile
+deliberada: los links van en un contenedor con scroll horizontal y un degradado de
+fade en el borde derecho, comentado en el código como tal. No hay menú hamburguesa
+ni drawer. Si eso alcanza o no es una decisión de diseño abierta, pero no es un
+olvido.
+
+`Footer` tiene 2 breakpoints. `ProfileDropdown`, 1.
+
+### Rutas con contenido real y cero breakpoints
+
+Las candidatas más fuertes a revisar, ordenadas por tamaño:
+
+| Ruta | Líneas |
+|---|---|
+| `/buscar` | 276 |
+| `/festivals/nuevo` | 170 |
+| `/wishlist` | 168 |
+| `/events/[id]/gastos` | 160 |
+| `/expenses` | 145 |
+| `/expenses/[id]` | 84 (1 breakpoint) |
+| `/events/[id]/editar` | 68 |
+| `/events/nuevo` | 56 |
+| `/reset-password` | 45 |
+| `/modo-recital` | 44 |
+| `/expenses/[id]/editar` | 41 |
+| `/profile/edit` | 35 |
+| `/expenses/nuevo` | 30 |
+| `/artists/nuevo` | 26 |
+| `/venues/nuevo` | 26 |
+| `/login`, `/signup`, `/forgot-password` | 25 c/u |
+
+### Componentes con contenido pesado y cero breakpoints
+
+Acá vive buena parte de la UI real, porque muchas páginas son envoltorios finos:
+
+| Componente | Líneas |
+|---|---|
+| `domains/events/components/EventForm.tsx` | 385 |
+| `domains/showmode/components/PreShowChecklist.tsx` | 229 |
+| `domains/expenses/components/EventExpensesPanel.tsx` | 219 |
+| `domains/stats/components/WrappedStories.tsx` | 150 |
+| `domains/expenses/components/ExpenseQuickAdd.tsx` | 145 |
+| `domains/expenses/components/ExpenseForm.tsx` | 131 |
+| `domains/festivals/components/FestivalAttendanceButton.tsx` | 117 |
+| `domains/events/components/RatingAndReviewForm.tsx` | 111 |
+| `domains/events/components/SearchEventsForm.tsx` | 109 |
+| `domains/expenses/components/ExpenseInlineEdit.tsx` | 102 |
+| `domains/auth/components/*Form.tsx` | 79–91 c/u |
+| `domains/events/components/AttendanceStatusButtons.tsx` | 91 |
+| `domains/venues/components/VenueForm.tsx` | 88 |
+| `domains/artists/components/ArtistForm.tsx` | 80 |
+
+`EventForm` es el más grande del proyecto y concentra datos del show, lineup,
+puntaje, reseña y gasto en un solo submit. Es el caso mobile más difícil.
+
+### Lo que ya tiene tratamiento responsive
+
+Para no tocar de más: `MemoryCard` (10 breakpoints), `/profile` (9), `/events/[id]`
+(7), `/coleccion` (5), `/festivals/[id]` (5), `ArtistProfile` (5), `HomeHero` (4),
+`/artists/[id]` (4), `Hero` (3), `ProfileForm` (3), la home (3).
+
+---
+
+## 4. Rutas que no hay que diseñar
+
+Son redirects de compatibilidad tras fusiones de rutas ya hechas. Existen sólo
+para no romper links viejos:
+
+| Ruta | Redirige a |
+|---|---|
+| `/artists` | `/coleccion?tab=artistas` |
+| `/venues` | `/coleccion?tab=sedes` |
+| `/festivals` | `/coleccion?tab=festivales` |
+| `/search` | `/buscar?tab=archivo` |
+| `/admin` | `/admin/moderacion/artistas` |
+
+---
+
+## 5. Restricciones que el diseño no puede romper
+
+1. **Degradación elegante.** Fijada en `docs/adr/0003-optional-external-api-keys-graceful-degradation.md`.
+   Las cuatro APIs externas (Last.fm, Setlist.fm, Spotify, Ticketmaster) son
+   opcionales. `fetchWithTimeout` (`src/core/lib/http.ts`) aborta a los 8 segundos
+   y los clientes devuelven `{ artist: null, error }` en vez de tirar. Toda
+   pantalla que muestre datos enriquecidos de terceros necesita un estado para
+   cuando esos datos no llegan, y la información propia de Supabase tiene que
+   seguir visible y operable. Nada de loaders infinitos.
+
+2. **Server Components por defecto.** Sólo se marca `'use client'` cuando hace
+   falta interactividad, hooks o APIs del browser. Las páginas leen datos en el
+   servidor; los formularios y acciones son islas cliente.
+
+3. **Post-moderación.** Lo que crea un usuario se publica al instante con
+   `status = 'unverified'`. El diseño de las vistas públicas tiene que contemplar
+   que puede haber contenido sin verificar a la vista — es intencional, no un bug.
+
+4. **`framer-motion` no está instalado.** El handoff de moderación lo pide para las
+   animaciones de la cola. Es la única dependencia nueva prevista para esa fase y
+   todavía no se agregó.
+
+5. **Sin librerías de íconos.** La convención actual es usar caracteres (`✓`, `→`)
+   o trazos minimalistas.
+
+---
+
+## 6. Pendientes conocidos que no son de diseño
+
+Anotados acá para que no se confundan con huecos visuales:
+
+- **El panel de admin no se puede abrir hoy, con ninguna cuenta.** La base
+  desplegada no tiene la columna `profiles.role` ni la función `get_user_role()`,
+  así que el rol resuelve a `usuario` para todo el mundo y el guard de GraphQL
+  rechaza a todos. Diseñar sobre estas pantallas requiere trabajar contra los
+  archivos, no contra la app corriendo, hasta que se sincronice la base. Detalle
+  completo en `docs/auditoria-2026-08-25.md`.
+- `/admin` no tiene guard de rol todavía, y no figura en `protectedPaths` de
+  `src/core/lib/supabase/middleware.ts`.
+- Las tres páginas de moderación hacen `throw new Error(...)` si falla el query,
+  en vez de degradar como hace el resto del repo.
+- `src/graphql/builder.ts` tiene un error de tipos con `relayOptions` de Pothos v4.

--- a/docs/estructura-del-proyecto.md
+++ b/docs/estructura-del-proyecto.md
@@ -28,7 +28,7 @@ src/
   domains/                    # Un folder por dominio (datos + acciones + vistas + componentes)
     events/
       data.ts                 # getEvents, getEventById, getEventsWithAttendance
-      actions.ts               # createEvent, updateEvent, deleteEvent
+      service.ts               # createEvent, updateEvent, deleteEvent y casos de uso
       attendance-data.ts / attendance-actions.ts
       photo-actions.ts
       home-view.ts             # Lógica pura para el hero del Home (testeada sin renderizar)
@@ -77,7 +77,7 @@ proxy.ts                       # Auth guard + refresh de cookies (antes middlewa
 ### Imports
 
 - Páginas en `app/`: importan de `@/src/core/*`, `@/src/domains/*` y (progresivamente) `@/src/graphql/*`.
-- Dentro de un dominio: `data.ts` y `actions.ts` importan de `@/src/core/lib/supabase/server` y `@/src/core/types`.
+- Dentro de un dominio: `data.ts` y `service.ts` importan de `@/src/core/lib/supabase/server` y `@/src/core/types`.
 - Componentes de dominio: importan de `@/src/core/components/ui` y `@/src/core/lib/routes`.
 
 ---

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -33,7 +33,21 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
-    "public/tickets/vendor/**",
+
+    // Generated: istanbul/vitest coverage reporter output.
+    "coverage/**",
+
+    // Generated: Supabase CLI scratch space. Holds the bundled edge runtime,
+    // which is minified onto a handful of lines and lints as ~200 problems.
+    "supabase/.temp/**",
+
+    // Vendored: third-party libs plus the copied omelette starter components,
+    // which are overwritten wholesale whenever the starter is re-copied.
+    "public/tickets/**",
+
+    // Single-use codemods run against app/page.tsx, kept out of the app build.
+    "refactor.js",
+    "refactor-waterfall.js",
   ]),
 ]);
 

--- a/mcp/.env.example
+++ b/mcp/.env.example
@@ -1,0 +1,4 @@
+SUPABASE_URL=http://127.0.0.1:54321
+SUPABASE_ANON_KEY=eyJhbG...
+ADMIN_EMAIL=tu_email_de_owner@ritual.com
+ADMIN_PASSWORD=tu_password

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,0 +1,41 @@
+# Ritual MCP Server para Auto-Moderación
+
+Este servidor MCP le permite a Claude (o cualquier otra IA) administrar tu base de datos de Ritual, aprobando y fusionando artistas, sedes y eventos directamente desde el chat.
+
+## Setup
+
+1. Entrar a esta carpeta: `cd mcp`
+2. Instalar dependencias: `npm install`
+3. Copiar `.env.example` a `.env` y poner tus credenciales. 
+   - **Nota de seguridad:** Se requiere un `ADMIN_EMAIL` y `ADMIN_PASSWORD` reales de un usuario que tenga el rol `admin` o `moderador` en la base de datos de Ritual. Si usas otra cuenta, el motor de base de datos rechazará las fusiones.
+4. Compilar el servidor: `npm run build`
+
+## Conectar a Claude Desktop
+
+Abrí el archivo de configuración de Claude Desktop (en Windows suele estar en `%APPDATA%\Claude\claude_desktop_config.json`, en Mac en `~/Library/Application Support/Claude/claude_desktop_config.json`) y agregá el servidor:
+
+```json
+{
+  "mcpServers": {
+    "ritual-moderator": {
+      "command": "node",
+      "args": [
+        "C:/Users/lantieri/code/personal/Ritual/mcp/dist/index.js"
+      ],
+      "env": {
+        "SUPABASE_URL": "Tu url",
+        "SUPABASE_ANON_KEY": "Tu key",
+        "ADMIN_EMAIL": "...",
+        "ADMIN_PASSWORD": "..."
+      }
+    }
+  }
+}
+```
+*Opcional: podés obviar el bloque `"env"` si ya tenés un archivo `.env` en la ruta absoluta y Node lo levanta, pero inyectar el env acá es más robusto.*
+
+## Reiniciar Claude
+Una vez guardado el JSON, reiniciá Claude Desktop y vas a ver el ícono del martillo de herramientas con `ritual-moderator`. Desde ahí vas a poder decirle:
+- *"Revisá la cola de moderación"*
+- *"Aprobá el artista tal"*
+- *"Fusioná el artista 'Las Pastillas' (ID tal) hacia 'Las Pastillas del Abuelo' (ID original)"*

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,0 +1,1354 @@
+{
+  "name": "ritual-mcp",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ritual-mcp",
+      "version": "1.0.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.5.0",
+        "@supabase/supabase-js": "^2.39.0",
+        "dotenv": "^16.4.5"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "typescript": "^5.3.3"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.1.tgz",
+      "integrity": "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.112.4",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.112.4.tgz",
+      "integrity": "sha512-z8DesgwLzKM5PiT0yNmJU8VJyh1zAhYi+20Z7drdJQLXg/wWW4yGt/un+He5ERYUo94Vz66t5aeyr1DIDemI5A==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.112.4",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.112.4.tgz",
+      "integrity": "sha512-DQ0aVH8wSQAccVqNoEkec62qCu2QRNyoGN53RqsVZ1k6F1zq4/v8scrlR6LNT2RJmT97apiTmORijPVhErCS2g==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.5.tgz",
+      "integrity": "sha512-aAn9H9ovVyeApKy11OWOrrOGq8DV68yWeH4ud2lN9fzn4aO8Zb5GLL9m1pUg9nLqIcT+ZDfAcsZe0E/nqdv2lw==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.112.4",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.112.4.tgz",
+      "integrity": "sha512-uaubtPSeg2TR4wrtfQoQWgkTAe+a0qWX2KhmwvTfNl5mGN9+U7owiJt6abk3o/V6O899PSRD1yzxs5RlF4xTug==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.112.4",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.112.4.tgz",
+      "integrity": "sha512-vZ+j079SKrM0Xiq7MJCvQKLDpaH2kfKfLY68xuQE1sqsCsMmx1CyrDBJHsxZ3cX01VOs5SI9igmoZAF3BmdZxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "0.4.5",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.112.4",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.112.4.tgz",
+      "integrity": "sha512-lQ0JemuTlMIXVKgSci1qez8yPnM5hyDngeAfEBjZS2Om4D+Cus0EE5BE6glFobrxdyii1OF4UzWfF0zcQgDq5A==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.112.4",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.112.4.tgz",
+      "integrity": "sha512-UiCX1udlFY1fQQrO7Z3GU7obQsju0w5Vk9mOOwalfo/+Gy+tahWVenSSuu5E/GTy/q//HxvGv2IrCdW66/61kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.112.4",
+        "@supabase/functions-js": "2.112.4",
+        "@supabase/postgrest-js": "2.112.4",
+        "@supabase/realtime-js": "2.112.4",
+        "@supabase/storage-js": "2.112.4"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
+      "integrity": "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.13.4",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.4.tgz",
+      "integrity": "sha512-AGEwKIyRMHRv1t8Wjwa3LHxQ61X5CqrdFT+4BRNTpqS5aJNnpl5WLjADb7vFlJzI/8uK7T5QLVApCMQKNa3LgQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.10",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.10.tgz",
+      "integrity": "sha512-iiW7J9qRFlGxvCOIBDBDxFePQSn7ZMAnrYGhrrOo6siO/MIqwfyilLR27pkfDgUk+raLuzADS8A3S/KLBisc0g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.1.0.tgz",
+      "integrity": "sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/negotiator/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "ritual-mcp",
+  "version": "1.0.0",
+  "description": "MCP Server para automoderación de Ritual",
+  "main": "dist/index.js",
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.5.0",
+    "@supabase/supabase-js": "^2.39.0",
+    "dotenv": "^16.4.5"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.3.3"
+  }
+}

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -1,0 +1,172 @@
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import { createClient } from '@supabase/supabase-js';
+import * as dotenv from 'dotenv';
+
+dotenv.config();
+
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_ANON_KEY;
+const ADMIN_EMAIL = process.env.ADMIN_EMAIL;
+const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD;
+
+if (!SUPABASE_URL || !SUPABASE_KEY || !ADMIN_EMAIL || !ADMIN_PASSWORD) {
+  console.error("Missing SUPABASE_URL, SUPABASE_ANON_KEY, ADMIN_EMAIL, or ADMIN_PASSWORD in .env");
+  process.exit(1);
+}
+
+// Inicializar cliente (se loguea como el Owner para pasar los chequeos de RLS y get_user_role)
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY, {
+  auth: { persistSession: false }
+});
+
+type ModeratedTable = 'artists' | 'venues' | 'events';
+
+interface SearchCatalogArgs { table: ModeratedTable; query: string }
+interface ApproveEntityArgs { table: ModeratedTable; id: string }
+interface MergeEntityArgs { table: ModeratedTable; sourceId: string; targetId: string }
+
+/**
+ * Neutraliza los comodines de LIKE del término de búsqueda. Sin esto un "%"
+ * matchea el catálogo entero justo antes de que la IA elija un target de
+ * fusión destructiva. Espeja escapeLikeWildcards de
+ * src/domains/moderation/service.ts, que resuelve lo mismo del lado web.
+ */
+function escapeLikeWildcards(term: string): string {
+  return term.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_');
+}
+
+const server = new Server(
+  {
+    name: 'ritual-moderation-mcp',
+    version: '1.0.0',
+  },
+  {
+    capabilities: { tools: {} },
+  }
+);
+
+// Conectar con credenciales del Owner
+async function ensureAuth() {
+  const { data: { session } } = await supabase.auth.getSession();
+  if (!session) {
+    const { error } = await supabase.auth.signInWithPassword({
+      email: ADMIN_EMAIL!,
+      password: ADMIN_PASSWORD!
+    });
+    if (error) throw new Error(`Fallo de login MCP: ${error.message}`);
+  }
+}
+
+server.setRequestHandler(ListToolsRequestSchema, async () => {
+  return {
+    tools: [
+      {
+        name: 'get_unverified_queue',
+        description: 'Obtiene todos los artistas, sedes y eventos que están pendientes de moderación (status = "unverified").',
+        inputSchema: { type: 'object', properties: {} }
+      },
+      {
+        name: 'search_catalog',
+        description: 'Busca artistas, sedes o eventos verificados en el catálogo para encontrar el ID canónico antes de fusionar.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            table: { type: 'string', enum: ['artists', 'venues', 'events'], description: 'Tabla donde buscar' },
+            query: { type: 'string', description: 'Nombre o término a buscar' }
+          },
+          required: ['table', 'query']
+        }
+      },
+      {
+        name: 'approve_entity',
+        description: 'Aprueba una entidad pendiente, marcándola como verified.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            table: { type: 'string', enum: ['artists', 'venues', 'events'] },
+            id: { type: 'string', description: 'UUID de la entidad' }
+          },
+          required: ['table', 'id']
+        }
+      },
+      {
+        name: 'merge_entity',
+        description: 'Fusiona una entidad duplicada/pendiente hacia una entidad canónica verificada. Destruye el origen.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            table: { type: 'string', enum: ['artists', 'venues', 'events'] },
+            sourceId: { type: 'string', description: 'UUID de la entidad basura/duplicada a destruir' },
+            targetId: { type: 'string', description: 'UUID de la entidad original a mantener' }
+          },
+          required: ['table', 'sourceId', 'targetId']
+        }
+      }
+    ]
+  };
+});
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  await ensureAuth();
+  
+  if (request.params.name === 'get_unverified_queue') {
+    const [artists, venues, events] = await Promise.all([
+      supabase.from('artists').select('id, name, genre').eq('status', 'unverified'),
+      supabase.from('venues').select('id, name, city, address').eq('status', 'unverified'),
+      supabase.from('events').select('id, name, date, venues(name)').eq('status', 'unverified')
+    ]);
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          pendingArtists: artists.data,
+          pendingVenues: venues.data,
+          pendingEvents: events.data
+        }, null, 2)
+      }]
+    };
+  }
+
+  if (request.params.name === 'search_catalog') {
+    const { table, query } = request.params.arguments as unknown as SearchCatalogArgs;
+    const { data, error } = await supabase
+      .from(table)
+      .select('*')
+      .eq('status', 'verified')
+      .ilike('name', `%${escapeLikeWildcards(query)}%`)
+      .limit(5);
+    if (error) return { content: [{ type: 'text', text: `Error: ${error.message}` }], isError: true };
+    return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+  }
+
+  if (request.params.name === 'approve_entity') {
+    const { table, id } = request.params.arguments as unknown as ApproveEntityArgs;
+    // Pasa por el RPC y no por un UPDATE directo. `artists` y `venues` no
+    // tienen policy de UPDATE, así que RLS denegaba, PostgREST devolvía 0
+    // filas con error null, y este tool respondía "Éxito" sin haber cambiado
+    // nada. El RPC valida el rol adentro y falla ruidosamente si no alcanza.
+    const { error } = await supabase.rpc('approve_entity', { entity_type: table, entity_id: id });
+    if (error) return { content: [{ type: 'text', text: `Error: ${error.message}` }], isError: true };
+    return { content: [{ type: 'text', text: `Éxito: ${table} ${id} aprobado.` }] };
+  }
+
+  if (request.params.name === 'merge_entity') {
+    const { table, sourceId, targetId } = request.params.arguments as unknown as MergeEntityArgs;
+    const rpcName = `merge_${table}`;
+    const { error } = await supabase.rpc(rpcName, { source_id: sourceId, target_id: targetId });
+    if (error) return { content: [{ type: 'text', text: `Error en RPC ${rpcName}: ${error.message}` }], isError: true };
+    return { content: [{ type: 'text', text: `Éxito: ${sourceId} fusionado hacia ${targetId}.` }] };
+  }
+
+  throw new Error('Tool not found');
+});
+
+async function run() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error('Ritual MCP Moderation Server running on stdio');
+}
+
+run().catch(console.error);

--- a/mcp/tsconfig.json
+++ b/mcp/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"]
+}

--- a/msg.txt
+++ b/msg.txt
@@ -1,0 +1,1 @@
+fix(graphql): resolver N+1 queries con DataLoader  

--- a/next.config.ts
+++ b/next.config.ts
@@ -52,6 +52,25 @@ const noIndexHeaders = [
   { key: 'X-Robots-Tag', value: 'noindex, nofollow' },
 ]
 
+/**
+ * El talón 3D vive en public/tickets/ y TicketEmbed lo monta como iframe
+ * same-origin. `X-Frame-Options: DENY` bloquea el framing incluso desde el
+ * propio origen, así que con los headers globales el iframe respondía 200 y
+ * el navegador lo descartaba con ERR_BLOCKED_BY_RESPONSE: el talón quedaba
+ * en negro dentro de la app, sin error visible en consola, aunque la misma
+ * URL abierta directo funcionara. Se afloja a same-origin sólo en esta ruta;
+ * el resto del sitio sigue con DENY.
+ */
+const ticketEmbedHeaders = securityHeaders.map((header) => {
+  if (header.key === 'X-Frame-Options') {
+    return { key: 'X-Frame-Options', value: 'SAMEORIGIN' }
+  }
+  if (header.key === 'Content-Security-Policy') {
+    return { ...header, value: header.value.replace("frame-ancestors 'none'", "frame-ancestors 'self'") }
+  }
+  return header
+})
+
 const nextConfig: NextConfig = {
   images: {
     remotePatterns: [
@@ -76,6 +95,12 @@ const nextConfig: NextConfig = {
       {
         source: '/(.*)',
         headers: securityHeaders,
+      },
+      // El talón 3D se embebe como iframe same-origin; va después de la regla
+      // global para que su X-Frame-Options pise al DENY heredado.
+      {
+        source: '/tickets/:path*',
+        headers: ticketEmbedHeaders,
       },
       // No-index for personal/private pages
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@urql/next": "^2.0.1",
         "cheerio": "^1.2.0",
         "clsx": "^2.1.1",
+        "dataloader": "^2.2.3",
         "graphql": "^16.14.2",
         "graphql-yoga": "^5.21.2",
         "html-to-image": "^1.11.13",
@@ -5712,6 +5713,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/dataloader": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.2.3.tgz",
+      "integrity": "sha512-y2krtASINtPFS1rSDjacrFgn1dcUuoREVabwlOGOe4SdxenREqwjwjElAdwvbGM7kgZz9a3KVicWR7vcz8rnzA==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@pothos/core": "^4.13.1",
+        "@pothos/plugin-relay": "^4.7.1",
         "@sentry/nextjs": "^10.70.0",
         "@supabase/ssr": "^0.8.0",
         "@supabase/supabase-js": "^2.95.3",
@@ -1920,6 +1921,16 @@
       "integrity": "sha512-2hkLxmvrT7VnbiWAfYhfF09PjaHeflZ5HrBHYzU6Tn/P9tDviuZS7IS5xO4k/KnK5GkRo3YxDzXyn+HnkEkVNw==",
       "license": "ISC",
       "peerDependencies": {
+        "graphql": "^16.10.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@pothos/plugin-relay": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@pothos/plugin-relay/-/plugin-relay-4.7.1.tgz",
+      "integrity": "sha512-aj0xgdcvktx0k6iOvtkfJvb6FYdoWnlQkDMumr1WQm7uTXsJOASYQndytfnS0/0wsctCF/UTTK6Y53+F0UIeMw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "@pothos/core": "*",
         "graphql": "^16.10.0 || ^17.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@urql/next": "^2.0.1",
     "cheerio": "^1.2.0",
     "clsx": "^2.1.1",
+    "dataloader": "^2.2.3",
     "graphql": "^16.14.2",
     "graphql-yoga": "^5.21.2",
     "html-to-image": "^1.11.13",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@pothos/core": "^4.13.1",
+    "@pothos/plugin-relay": "^4.7.1",
     "@sentry/nextjs": "^10.70.0",
     "@supabase/ssr": "^0.8.0",
     "@supabase/supabase-js": "^2.95.3",

--- a/scratch/cleanup-events.ts
+++ b/scratch/cleanup-events.ts
@@ -1,0 +1,22 @@
+import { createClient } from '@supabase/supabase-js'
+
+const envUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
+const envKey = process.env.SUPABASE_SERVICE_ROLE_KEY!
+
+const supabase = createClient(envUrl, envKey)
+
+async function run() {
+  const { data: events, error: evErr } = await supabase.from('events').select('id, name').ilike('name', '%Coca Cola%')
+  if (evErr) console.error(evErr)
+  
+  if (events && events.length > 0) {
+    for (const ev of events) {
+      console.log(`Deleting event: ${ev.name} (${ev.id})`)
+      await supabase.from('events').delete().eq('id', ev.id)
+    }
+  } else {
+    console.log('No Coca Cola events found')
+  }
+}
+
+run()

--- a/scratch/cleanup.ts
+++ b/scratch/cleanup.ts
@@ -1,0 +1,76 @@
+import { createClient } from '@supabase/supabase-js'
+
+const envUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
+const envKey = process.env.SUPABASE_SERVICE_ROLE_KEY!
+
+const supabase = createClient(envUrl, envKey)
+
+async function run() {
+  console.log('Cleaning up cosmetic data...')
+
+  // 1. Delete the "Coca Cola 2.25L" event
+  const { data: events, error: evErr } = await supabase.from('events').select('id, title').ilike('title', '%Coca Cola%')
+  if (evErr) console.error(evErr)
+  
+  if (events && events.length > 0) {
+    for (const ev of events) {
+      console.log(`Deleting event: ${ev.title} (${ev.id})`)
+      await supabase.from('events').delete().eq('id', ev.id)
+    }
+  }
+
+  // 2. "asdasdasd" in Movistar Arena address
+  const { data: venues, error: venErr } = await supabase.from('venues').select('id, name, address').ilike('name', '%Movistar Arena%')
+  if (venErr) console.error(venErr)
+  
+  if (venues) {
+    for (const v of venues) {
+      if (v.address === '📍 asdasdasd' || v.address?.includes('asdasdasd')) {
+        console.log(`Fixing address for venue: ${v.name} (${v.id})`)
+        await supabase.from('venues').update({ address: 'Humboldt 450' }).eq('id', v.id)
+      }
+    }
+  }
+
+  // 3. Deduplicate Los Piojos
+  const { data: piojos, error: artErr } = await supabase.from('artists').select('id, name').ilike('name', 'Los Piojos')
+  if (artErr) console.error(artErr)
+
+  if (piojos && piojos.length > 1) {
+    const { data: linked } = await supabase.from('event_artists').select('artist_id, event_id').in('artist_id', piojos.map(p => p.id))
+    
+    const counts = piojos.map(p => ({
+      ...p,
+      links: linked?.filter(l => l.artist_id === p.id).length || 0
+    })).sort((a, b) => b.links - a.links)
+    
+    console.log('Los Piojos found:', counts)
+    for (let i = 1; i < counts.length; i++) {
+      console.log(`Deleting duplicate Los Piojos: ${counts[i].id}`)
+      await supabase.from('artists').delete().eq('id', counts[i].id)
+    }
+  }
+
+  // 4. Deduplicate Estadio River Plate
+  const { data: river, error: rivErr } = await supabase.from('venues').select('id, name').ilike('name', 'Estadio River Plate')
+  if (rivErr) console.error(rivErr)
+
+  if (river && river.length > 1) {
+    const { data: linked } = await supabase.from('events').select('id, venue_id').in('venue_id', river.map(r => r.id))
+    
+    const counts = river.map(r => ({
+      ...r,
+      links: linked?.filter(l => l.venue_id === r.id).length || 0
+    })).sort((a, b) => b.links - a.links)
+    
+    console.log('Estadio River Plate found:', counts)
+    for (let i = 1; i < counts.length; i++) {
+      console.log(`Deleting duplicate Estadio River Plate: ${counts[i].id}`)
+      await supabase.from('venues').delete().eq('id', counts[i].id)
+    }
+  }
+  
+  console.log('Cleanup finished.')
+}
+
+run()

--- a/sdd/architecture-decisions/001-graphql-dataloader.md
+++ b/sdd/architecture-decisions/001-graphql-dataloader.md
@@ -1,0 +1,19 @@
+# ADR 001: GraphQL DataLoader para resolución de N+1
+
+## Contexto
+En `src/graphql/events.ts`, los resolvers de `myAttendance` y `photos` sobre el tipo `EventRef` estaban ejecutando consultas individuales a Supabase (via `getAttendanceForEvent` y `getEventPhotos`) por cada evento evaluado.
+Si bien esto no era problemático para la consulta `event(id)` individual, generaba un problema de N+1 crítico al solicitar estos campos dentro de consultas que devuelven colecciones de eventos (`events` o `eventsWithAttendance`).
+
+## Decisión
+Se decidió implementar el patrón **DataLoader** (librería `dataloader` de GraphQL) a nivel del contexto (`GraphQLContext`).
+
+## Implementación
+1. **Batch Functions**: Se agregaron dos funciones a la capa de datos (`attendance-data.ts` y `photo-actions.ts`) preparadas para recibir un arreglo de `eventIds`:
+   - `getAttendanceForEventsBatch(eventIds, userId)`
+   - `getEventPhotosBatch(eventIds)`
+2. **Contexto por request**: En `createGraphQLContext` (`context.ts`) se instancian `attendanceLoader` y `photosLoader`. Al hacerlo por request, nos aseguramos de que el caché de DataLoader no se filtre transversalmente entre distintos usuarios.
+3. **Resolvers**: Se modificó `EventRef` para que dependa del loader: `context.attendanceLoader.load(e.id)` y `context.photosLoader.load(e.id)`. DataLoader se encarga de acumular todas las promesas en el mismo tick de ejecución y disparar la consulta a la base de datos de manera agrupada (`IN (...)`).
+
+## Consecuencias
+- **Rendimiento**: Una lista de 50 eventos con fotos y asistencia ahora ejecuta 1 query de eventos, 1 de fotos y 1 de asistencia (3 queries totales) en lugar de 101 queries individuales.
+- **Testing**: Los tests de GraphQL (`events.test.ts`) ahora mockean las funciones batch en lugar de las unitarias para simular el comportamiento.

--- a/sdd/ritual-roles-moderation-phase-2/01-spec.md
+++ b/sdd/ritual-roles-moderation-phase-2/01-spec.md
@@ -1,0 +1,25 @@
+# Especificación: Fase 2 - Cola de Moderación & MCP Automático
+
+## Objetivo
+Permitir que la base de datos de Ritual (catálogo colaborativo) escale sin perder calidad, mediante un sistema de "post-moderación" y fusión (merge) de duplicados, operable tanto por humanos (vía web) como por IA (vía MCP).
+
+## Decisiones Arquitectónicas (Grill-me)
+
+1. **Límites de Roles**: 
+   - **Admin (Owner)**: Acceso total, métricas, roles, y uso exclusivo del servidor MCP para moderación automática por IA.
+   - **Moderador**: Operador de catálogo humano, usa una UI web para aprobar o limpiar datos.
+2. **Modelo Post-Moderación (Soft-Publish)**:
+   - Para no matar la retención, lo que crea el usuario se publica al instante, pero nace con un estado `unverified`.
+   - La cola de moderación es simplemente un listado de todas las entidades `unverified`.
+3. **El superpoder es el Merge**:
+   - En lugar de simplemente borrar duplicados y dejar a usuarios huérfanos de su historial, la herramienta core es el **Merge (Fusión)**. Mueve asociaciones (attendance, lineups) al registro canónico y elimina el duplicado.
+4. **Scope de Entidades**:
+   - Aplica a: `events`, `artists`, `venues`.
+   - **Festivales excluidos**: Por su complejidad (multi-día, multi-escenario), quedan restringidos a creación exclusiva por Admins (top-down).
+5. **Doble Cliente**:
+   - **Next.js UI**: Pantallas en `/admin/moderation` para los moderadores humanos.
+   - **MCP Server**: Un servidor Node/TypeScript independiente en el repo para que la IA asista al Owner, con herramientas como `get_unverified_queue`, `approve_entity`, `merge_entities`.
+
+## Casos de Uso
+- Un usuario agrega un show under. Un moderador humano entra al `/admin/moderation`, verifica que está bien escrito, y le da "Aprobar" (pasa a `verified`).
+- Un usuario agrega "Radiohead" pero ya existía "Radiohead UK". El Owner usa Claude (vía MCP) para pedirle: "Revisá los artistas pendientes". La IA detecta el duplicado, llama a la herramienta MCP `merge_artists` y unifica ambos sin romper el historial del usuario.

--- a/sdd/ritual-roles-moderation-phase-2/02-design.md
+++ b/sdd/ritual-roles-moderation-phase-2/02-design.md
@@ -1,0 +1,55 @@
+# Diseño Técnico: Fase 2 - Cola de Moderación & MCP
+
+## 1. Cambios en la Base de Datos (Supabase)
+
+### Nuevo Tipo Enum
+```sql
+CREATE TYPE verification_status AS ENUM ('unverified', 'verified');
+```
+
+### Alteración de Tablas
+Agregar la columna `verification_status` con default `unverified` a:
+- `artists`
+- `venues`
+- `events`
+
+*(Nota: los cargados por cron/adapters pueden nacer directamente como `verified`)*.
+
+### Funciones RPC de Fusión (Merge)
+La magia ocurre en la DB para garantizar transaccionalidad atómica. 
+Se crearán 3 RPCs (Postgres Functions):
+- `merge_artists(source_id UUID, target_id UUID)`
+- `merge_venues(source_id UUID, target_id UUID)`
+- `merge_events(source_id UUID, target_id UUID)`
+
+**Ejemplo de flujo en `merge_artists`**:
+1. Actualizar `event_artists` donde `artist_id = source_id` a `target_id`. (Manejar conflictos si el target ya tocaba en ese evento).
+2. Mover registros en `user_wishlist`.
+3. Borrar el `source_id` de `artists`.
+
+## 2. Servidor MCP (Headless AI Moderation)
+
+Un paquete Node ligero en `src/mcp-server/` (o paquete independiente en el repo) usando `@modelcontextprotocol/sdk`.
+
+**Herramientas Expuestas:**
+- `ritual_get_unverified(entity_type)`: Devuelve la cola.
+- `ritual_approve(entity_type, id)`: Pasa a `verified`.
+- `ritual_merge(entity_type, source_id, target_id)`: Llama a la RPC correspondiente.
+
+## 3. Interfaz Gráfica (Next.js)
+
+Rutas dentro de `app/admin/`:
+- `app/admin/layout.tsx`: Sidebar con navegación (Cola de Moderación, Usuarios, etc).
+- `app/admin/moderacion/artistas/page.tsx`: Tabla de artistas `unverified`.
+- `app/admin/moderacion/sedes/page.tsx`: Tabla de sedes.
+- `app/admin/moderacion/eventos/page.tsx`: Tabla de eventos.
+
+**Componentes Core:**
+- Botón "Aprobar".
+- Modal "Fusionar con...": Abre un buscador de la entidad (combo box) para elegir la canónica y confirmar la fusión.
+
+## 4. GraphQL API
+Exponer mutations seguras controladas por RLS / Guards:
+- `approveArtist`, `approveVenue`, `approveEvent`.
+- `mergeArtist`, `mergeVenue`, `mergeEvent`.
+Solo accesibles si el usuario tiene rol `admin` o `moderador`.

--- a/sdd/ritual-roles-moderation-phase-2/03-tasks.md
+++ b/sdd/ritual-roles-moderation-phase-2/03-tasks.md
@@ -1,0 +1,101 @@
+# Tareas: Fase 2 - Cola de Moderación & MCP
+
+> Estado auditado contra el working tree el 2026-08-25. Los tildes reflejan lo
+> que existe en el código, no lo que se planeó.
+
+## Task 1: Capa de Datos (Supabase)
+
+Migración: `supabase/migrations/20260824202000_moderation_queue.sql`
+
+- [x] Crear migración SQL para el enum `verification_status` (`unverified`, `verified`).
+- [x] Agregar la columna `status` (tipo `verification_status`, default `unverified`) a las tablas `artists`, `venues` y `events`.
+- [x] Escribir la función RPC `merge_artists(source_id UUID, target_id UUID)`.
+- [x] Escribir la función RPC `merge_venues(source_id UUID, target_id UUID)`.
+- [x] Escribir la función RPC `merge_events(source_id UUID, target_id UUID)`.
+
+Entregado además de lo planeado: columna `created_by` con FK a `auth.users`, y
+un trigger `check_creation_rate_limit()` que limita altas por hora a los roles
+sin privilegios. Los tres RPC son `SECURITY DEFINER` y validan
+`get_user_role(auth.uid()) IN ('admin','moderador')` en su cuerpo, así que el
+`GRANT EXECUTE ... TO authenticated` no abre un agujero.
+
+## Task 1b: Corregir el camino de aprobación (BLOQUEANTE — descubierto en auditoría)
+
+`approve*` no pasa por RPC: hace `supabase.from(tabla).update({status:'verified'})`
+con el cliente de `@supabase/ssr`, que corre con el JWT del usuario.
+
+- `artists` y `venues` **no tienen ninguna policy de UPDATE** en las 28 migraciones
+  → RLS deniega por defecto → PostgREST afecta 0 filas y devuelve `error: null`
+  → el resolver reporta `success: true`. La aprobación falla en silencio.
+- `events` tiene `"Allow update events" ... to authenticated using (true) with check (true)`
+  → cualquier autenticado puede auto-aprobar su evento pegándole directo a
+  PostgREST, salteando el guard `requireModerator` de GraphQL.
+
+- [x] Migración nueva con `approve_entity(entity_type, id)` como RPC `SECURITY DEFINER`,
+      con el mismo chequeo de rol que los tres merge.
+      → `supabase/migrations/20260825060000_moderation_approve_and_status_guard.sql`
+- [x] Cerrar el cambio de `status` a usuarios comunes. No se hizo tocando la policy:
+      en una policy de UPDATE, `USING` ve la fila vieja y `WITH CHECK` la nueva, y no
+      hay forma de correlacionarlas para expresar "permitido salvo que cambie status".
+      Va por trigger `BEFORE UPDATE` en las tres tablas, que es el único mecanismo que
+      ve OLD y NEW juntos. `"Allow update events"` se mantiene porque la necesita la
+      edición legítima de recitales.
+- [x] Reapuntar `approveArtist/Venue/Event` en `src/domains/moderation/service.ts` al RPC.
+- [x] Chequeo de rol NULL-safe compartido (`is_moderator()`). Los tres merge usaban
+      `IF get_user_role(...) NOT IN ('admin','moderador')`, y `get_user_role()` devuelve
+      NULL cuando el usuario no tiene fila en `profiles`: `NULL NOT IN (...)` es NULL y
+      `IF NULL THEN` es falsy en plpgsql, así que la guarda se salteaba y la fusión
+      seguía. Es el mismo trap que `assign_user_role()` ya documenta y evita con
+      `IS DISTINCT FROM` en `20260823202400_user_roles.sql`.
+
+## Task 2: Capa API (GraphQL)
+
+Archivo: `src/graphql/moderation.ts`, registrado en `src/graphql/schema.ts`.
+
+- [x] Exponer el `status` en `EventRef`, `ArtistRef` y `VenueRef`.
+- [x] Mutations con chequeo de rol de contexto `admin|moderador`.
+- [x] Queries de la cola: `unverifiedArtists`, `unverifiedVenues`, `unverifiedEvents`.
+- [x] Query `mergeTargets(entityType, query, excludeId)` para buscar la entidad
+      canónica por nombre. Espejo del tool `search_catalog` del MCP: `ilike %q%`,
+      sólo `status = 'verified'`, límite 8. Los índices GIN trigram sobre
+      `artists.name`, `venues.name` y `events.name` ya existían en
+      `20260824205500_performance_indexes.sql`. Devuelve `{ id, name, detail }`,
+      donde `detail` es género / ciudad—dirección / fecha según la entidad, listo
+      para el `sublabel` del `Combobox`.
+- [x] Escapado de comodines de LIKE en el término de búsqueda. Sin esto, buscar
+      "100%" matchea el catálogo entero justo antes de una fusión destructiva.
+- [x] `requireModerator` tipado con `GraphQLContext` en vez de `any`, y tirando
+      `GraphQLError` para que una denegación de permisos no viaje como error interno.
+- [x] Tests: `src/domains/moderation/service.test.ts` y `src/graphql/moderation.test.ts`.
+
+## Task 3: Pantallas UI (Next.js)
+
+- [x] Layout `/app/admin/layout.tsx` con sidebar de navegación.
+- [~] Panel `/app/admin/moderacion/artistas/page.tsx` con tabla.
+  - [x] Tabla, empty state y estética brutalista.
+  - [x] Acciones por fila cableadas a las mutations.
+  - [ ] Leer `error`/`success` de la mutation en vez de asumir que salió bien.
+  - [ ] Reemplazar el `confirm()` nativo del browser por la confirmación in-place.
+  - [ ] Buscador de la entidad canónica en vez del input de UUID pelado.
+- [ ] Instalar `framer-motion` y construir la fila animada compartida:
+      colapso con `AnimatePresence` al aprobar, layout animation al expandir
+      el panel de fusión.
+- [~] Sedes (`/app/admin/moderacion/sedes/page.tsx`): tabla lista, botones sin `onClick`.
+- [~] Eventos (`/app/admin/moderacion/eventos/page.tsx`): tabla lista, botones sin `onClick`.
+      Falta la animación de advertencia sobre el movimiento de asistencias.
+- [ ] Guard de rol: `/admin` no está en `protectedPaths` de
+      `src/core/lib/supabase/middleware.ts`.
+- [ ] Degradación: las tres páginas hacen `throw new Error(result.error.message)`.
+      El resto del repo degrada (`getArtists()` loguea y devuelve `[]`;
+      `/events/nuevo` hace `data?.venues ?? []`).
+
+## Task 4: Servidor MCP (Headless AI)
+
+Paquete: `mcp/` (Node independiente, `@modelcontextprotocol/sdk`).
+
+- [x] Inicializar paquete independiente.
+- [x] Exponer tools: `get_unverified_queue`, `search_catalog`, `approve_entity`, `merge_entity`.
+- [ ] Probar conexión local interactiva.
+
+Nota: `approve_entity` del MCP pega al mismo `UPDATE` bloqueado por RLS descripto
+en Task 1b, así que arrastra el mismo fallo silencioso hasta que esa tarea cierre.

--- a/sdd/ritual-roles-moderation-phase-2/04-ui-claude-design-handoff.md
+++ b/sdd/ritual-roles-moderation-phase-2/04-ui-claude-design-handoff.md
@@ -1,0 +1,136 @@
+# Handoff: Claude Design - UI de Moderación (Ritual)
+
+Este documento contiene el contexto técnico y funcional necesario para que Claude Design (o cualquier agente de UI) pueda refinar, animar o reconstruir las pantallas de Moderación de Ritual sin romper la lógica de negocio ni la integración con GraphQL.
+
+## Contexto de Arquitectura
+- **Stack**: Next.js App Router (React 19), Tailwind CSS v4, `urql` para GraphQL.
+- **Tema Visual**: Brutalista, oscuro. Fondos `bg-ritual-bg` y `bg-ritual-panel`, texto `text-ritual-bone`, acentos `text-ritual-red-hover`. Tipografías `font-display`, `font-dense`, `font-label`. Sin íconos pesados, usar caracteres ASCII (`✓`, `→`) o trazos minimalistas.
+- **Paradigma de Moderación**: Post-moderación. Los registros se muestran acá si tienen `status = 'unverified'`. El moderador tiene dos opciones: **Aprobar** (marca como verificado) o **Fusionar** (destruye el registro actual y mueve su data histórica a un ID canónico).
+
+---
+
+## 1. Pantalla: Moderación de Artistas (`/admin/moderacion/artistas`)
+
+### Datos de Entrada (GraphQL)
+```graphql
+query getUnverifiedArtists {
+  unverifiedArtists {
+    id
+    name
+    genre
+    status
+  }
+}
+```
+
+### Acciones Requeridas (Mutations)
+1. **Aprobar:**
+   ```graphql
+   mutation ApproveArtist($id: ID!) {
+     approveArtist(id: $id) { success }
+   }
+   ```
+2. **Fusionar:**
+   ```graphql
+   mutation MergeArtists($sourceId: ID!, $targetId: ID!) {
+     mergeArtists(sourceId: $sourceId, targetId: $targetId) { success }
+   }
+   ```
+
+### UX & Animaciones (Crítico)
+- **Instalar y usar `framer-motion`**. El usuario exige que la interfaz sea **extremadamente "smooth" y fluida**.
+- **Acción Aprobar:** Al hacer clic, usar `<AnimatePresence>` para que la fila entera colapse suavemente y desaparezca (animando `height` a 0 y `opacity` a 0).
+- **Acción Fusionar:** En lugar de abrir un modal genérico, la fila debe hacer un **Layout Animation** y expandirse fluidamente para revelar el buscador de la entidad canónica.
+- Las transiciones deben tener un feeling "premium" (springs suaves) pero manteniendo la estética brutalista.
+
+### Cómo se elige la entidad canónica (decidido 2026-08-25)
+
+Se busca por nombre, no se pega un UUID. El input de UUID pelado quedó descartado
+por cuatro razones verificadas contra el código:
+
+- El unique sobre `name_key` (`20260712000000_venues_artists_name_unique.sql`) hace
+  imposible el duplicado exacto en `artists` y `venues`. Todo lo que llega a la cola
+  es un *casi*-duplicado ("Radiohead" vs "Radiohead UK"), así que buscar por nombre
+  exacto no sirve.
+- El servidor MCP ya le da búsqueda a la IA: el tool `search_catalog` en
+  `mcp/src/index.ts` está descripto como "para encontrar el ID canónico antes de
+  fusionar". El `01-spec.md` §5 declara UI humana y MCP como clientes pares; darle
+  buscador a uno y pegado de UUID al otro rompe esa paridad.
+- Los índices GIN trigram sobre `artists.name`, `venues.name` y `events.name` ya
+  existen (`20260824205500_performance_indexes.sql`). La búsqueda no cuesta trabajo
+  de base de datos.
+- Para conseguir un UUID el moderador tendría que salir de `/admin`, ir a `/buscar`,
+  abrir la entidad y copiarlo de la URL — para después ejecutar una operación
+  destructiva e irreversible.
+
+**Componente:** se reusa `src/core/components/ui/Combobox.tsx`, que ya existe, está
+testeado, tiene la estética correcta y es accesible por teclado (`role="combobox"`,
+`role="listbox"`, `role="option"`). Sus props `excludeIds` (para dejar afuera la
+entidad origen) y `sublabel` (género, ciudad, fecha) cubren exactamente este caso.
+Ya lo consume `EventForm`.
+
+**Fuente de datos:** query `mergeTargets`, espejo semántico de `search_catalog`
+(sólo `status = 'verified'`, `ilike`, con límite). No se precarga el catálogo
+completo: `artists` y `venues` devuelven listas sin límite pero `events` es una
+Relay connection paginada por diseño, y precargar daría dos UX divergentes dentro
+de la misma familia de pantallas.
+
+---
+
+## 2. Pantalla: Moderación de Sedes (`/admin/moderacion/sedes`)
+
+### Datos de Entrada
+```graphql
+query getUnverifiedVenues {
+  unverifiedVenues {
+    id
+    name
+    city
+    address
+    status
+  }
+}
+```
+
+### Acciones Requeridas
+1. **Aprobar:** `approveVenue(id: ID!)`
+2. **Fusionar:** `mergeVenues(sourceId: ID!, targetId: ID!)`
+
+### UX & Animaciones (Crítico)
+- Misma exigencia de `framer-motion` para las interacciones de tabla.
+- Debe mostrar claramente la ciudad y dirección para discernir si es un estadio duplicado (ej. "River Plate" vs "Estadio Mas Monumental").
+
+---
+
+## 3. Pantalla: Moderación de Eventos (`/admin/moderacion/eventos`)
+
+### Datos de Entrada
+```graphql
+query getUnverifiedEvents {
+  unverifiedEvents {
+    id
+    name
+    date
+    status
+    venue { name }
+    lineups { artist { name } }
+  }
+}
+```
+
+### Acciones Requeridas
+1. **Aprobar:** `approveEvent(id: ID!)`
+2. **Fusionar:** `mergeEvents(sourceId: ID!, targetId: ID!)`
+
+### UX & Animaciones (Crítico)
+- Es la vista más compleja. Aplican las mismas layout animations.
+- El panel expansible de "Fusión" tiene que tener una animación de advertencia (quizás un shake sutil o un resaltado rojo en delay) remarcando fuertemente que "Fusionar eventos moverá todas las asistencias al evento destino".
+
+---
+
+## 4. Graceful Degradation y Timeouts (Core Architecture)
+
+- **Resiliencia de Red**: Si en alguna vista intentás enriquecer datos usando Spotify o Ticketmaster (ej. mostrar la foto del artista al expandir), **asumí que la API puede fallar o colgarse**.
+- El backend usa el wrapper `fetchWithTimeout` (`src/core/lib/http.ts`), que aborta la request a los 8 segundos. Los clientes externos nunca tiran: `searchSpotifyArtist` devuelve `{ artist: null, error: '...' }` incluso en el abort. El principio está fijado en el ADR `docs/adr/0003-optional-external-api-keys-graceful-degradation.md`.
+- **UI Contract**: La interfaz **NO DEBE** explotar ni quedar en loaders infinitos. Diseñá estados vacíos (empty states) sutiles y elegantes si falta data de terceros, priorizando siempre mostrar la información crítica (la de nuestra base de datos en Supabase) para que el flujo de moderación continúe sin interrupciones.
+- **Aplicado a estas pantallas**: hoy las tres hacen `throw new Error(result.error.message)` si falla el query de la cola, lo que produce una pantalla de error en vez de una vista degradada. La convención del repo es la contraria — `getArtists()` loguea y devuelve `[]`, y `app/events/nuevo/page.tsx` hace `data?.venues ?? []`. Las pantallas de moderación tienen que alinearse con eso: la cola de Supabase siempre se muestra y siempre se puede operar.

--- a/src/README.md
+++ b/src/README.md
@@ -1,11 +1,14 @@
 # Estructura de `src/`
 
 - **`core/`** – Lo que usa toda la app: tipos, Supabase, rutas, componentes UI y layout. No contiene lógica de un dominio concreto.
-- **`domains/`** – Un folder por dominio (events, venues, artists, expenses). Cada uno tiene:
+- **`domains/`** – Un folder por dominio. Hoy: `artists`, `auth`, `events`, `expenses`, `festivals`, `moderation`, `search`, `showmode`, `stats`, `venues`, `weather`. Cada uno tiene:
   - **`data.ts`** – Lectura de datos (getX, getXById).
-  - **`actions.ts`** – Server Actions (create, update, delete).
+  - **`service.ts`** – Casos de uso y escrituras. Es el seam que consumen las páginas y los resolvers.
   - **`components/`** – Componentes específicos del dominio (formularios, listas, etc.).
+- **`graphql/`** – El schema de Pothos: un archivo por dominio, más el builder, el contexto (con los DataLoaders) y el cliente in-process.
 
 Las páginas en **`app/`** solo importan de `core` y `domains`; no hay lógica de negocio en `app/`.
 
-Para agregar un nuevo dominio (ej. “perfil” o “amigos”): crear `domains/nuevo-dominio/` con data, actions y components, y las rutas en `app/`.
+Para agregar un nuevo dominio: crear `domains/nuevo-dominio/` con data, service y components, sumar su archivo en `graphql/` si expone API, y las rutas en `app/`.
+
+**Deuda conocida:** la capa `actions.ts` que describía este documento se eliminó en el issue #23 y su contenido vive hoy en `service.ts`. La regla de que todo pase por `service.ts` está declarada en los comentarios de varios dominios pero no se cumple en todos lados: `src/graphql/` y varias páginas importan `data.ts` directo. El dominio `moderation` todavía no tiene `data.ts` separado.

--- a/src/core/auth/session.ts
+++ b/src/core/auth/session.ts
@@ -1,4 +1,5 @@
 import 'server-only'
+import { cache } from 'react'
 import { isAuthSessionMissingError } from '@supabase/supabase-js'
 import { createClient } from '@/src/core/lib/supabase/server'
 
@@ -6,8 +7,16 @@ import { createClient } from '@/src/core/lib/supabase/server'
  * Returns the current authenticated user's ID.
  * Returns null if no session exists or error occurs.
  * Use this instead of getDevUserId().
+ *
+ * Va envuelto en `cache()` de React porque `supabase.auth.getUser()` sale al
+ * servidor de Auth a revalidar el JWT en cada llamada (a diferencia de
+ * `getSession()`, que resuelve local). Hay unos 40 puntos de llamada y un
+ * render del home encadenaba cinco validaciones del mismo token en el mismo
+ * request: el middleware, getEventsWithAttendance, createGraphQLContext,
+ * getWishlistArtistIds y getFestivals. El scope de `cache()` es el request,
+ * así que deduplica sin riesgo de cruzar sesiones entre usuarios.
  */
-export async function getCurrentUserId(): Promise<string | null> {
+export const getCurrentUserId = cache(async function getCurrentUserId(): Promise<string | null> {
     const supabase = await createClient()
     try {
         const { data: { user }, error: getUserError } = await supabase.auth.getUser()
@@ -19,4 +28,4 @@ export async function getCurrentUserId(): Promise<string | null> {
         console.error('Error fetching current user:', error)
         return null
     }
-}
+})

--- a/src/core/components/ui/StarRating.tsx
+++ b/src/core/components/ui/StarRating.tsx
@@ -35,10 +35,11 @@ export function StarRating({
 
     if (!onChange) {
         return (
-            <div className={`flex gap-0.5 ${className}`}>
+            <div className={`flex gap-0.5 ${className}`} aria-label={`${value} de 5 estrellas`} role="img">
                 {[1, 2, 3, 4, 5].map((star) => (
                     <span
                         key={star}
+                        aria-hidden="true"
                         className={`${SIZE_CLASS[size]} ${star <= value ? 'text-ritual-red' : 'text-ritual-border-2'}`}
                     >
                         ★
@@ -62,7 +63,7 @@ export function StarRating({
                     className={`${SIZE_CLASS[size]} transition-transform hover:scale-110 focus:outline-none`}
                     aria-label={`${star} estrella${star > 1 ? 's' : ''}`}
                 >
-                    <span className={displayValue >= star ? 'text-ritual-red' : 'text-ritual-border-2'}>★</span>
+                    <span aria-hidden="true" className={displayValue >= star ? 'text-ritual-red' : 'text-ritual-border-2'}>★</span>
                 </button>
             ))}
         </div>

--- a/src/core/lib/dates.test.ts
+++ b/src/core/lib/dates.test.ts
@@ -9,6 +9,7 @@ import {
   daysUntil,
   combineDateAndTime,
   eventTimeOfDay,
+  parseExternalDateTime,
 } from './dates'
 
 // Regression tests for a timezone bug: a date-only string like "2026-07-21"
@@ -188,5 +189,54 @@ describe('eventTimeOfDay', () => {
   it('round-trips with combineDateAndTime', () => {
     const iso = combineDateAndTime('2026-07-21', '21:15')
     expect(eventTimeOfDay(iso)).toBe('21:15')
+  })
+})
+
+// Las fechas que llegan de los adaptadores de fuentes externas: cada sitio
+// las emite en su propio formato, y antes de parsearlas terminaban como el
+// texto "Invalid Date" en la cartelera y rechazadas por Postgres al importar.
+describe('parseExternalDateTime', () => {
+  const reference = new Date(2026, 7, 25) // 25 de agosto de 2026
+
+  it('acepta el ISO que mandan enigma y quehacemos', () => {
+    expect(parseExternalDateTime('2026-08-26T20:00:00')?.getTime())
+      .toBe(new Date('2026-08-26T20:00:00').getTime())
+  })
+
+  it('acepta el ISO con zona explícita', () => {
+    expect(parseExternalDateTime('2026-09-26T03:00:00.000Z')?.toISOString())
+      .toBe('2026-09-26T03:00:00.000Z')
+  })
+
+  it('lee la prosa de entradaweb con año', () => {
+    const d = parseExternalDateTime('Domingo 30 de Agosto, 2026', reference)
+    expect([d?.getFullYear(), d?.getMonth(), d?.getDate()]).toEqual([2026, 7, 30])
+  })
+
+  it('toma la hora cuando la prosa la incluye', () => {
+    const d = parseExternalDateTime('Viernes 11 de Septiembre, 2026 - 21:00hs.', reference)
+    expect([d?.getMonth(), d?.getDate(), d?.getHours(), d?.getMinutes()]).toEqual([8, 11, 21, 0])
+  })
+
+  it('lee el "13 SEP" de livepass, sin año', () => {
+    const d = parseExternalDateTime('13 SEP', reference)
+    expect([d?.getFullYear(), d?.getMonth(), d?.getDate()]).toEqual([2026, 8, 13])
+  })
+
+  it('asume el año siguiente cuando el día y mes ya pasaron', () => {
+    // En diciembre, un "13 SEP" es del año que viene, no de tres meses atrás.
+    const d = parseExternalDateTime('13 SEP', new Date(2026, 11, 1))
+    expect(d?.getFullYear()).toBe(2027)
+  })
+
+  it('tolera el mes con tilde y en mayúsculas', () => {
+    expect(parseExternalDateTime('5 de Diciembre, 2026', reference)?.getMonth()).toBe(11)
+  })
+
+  it('devuelve null cuando el texto no es una fecha, en vez de un Date inválido', () => {
+    expect(parseExternalDateTime('SOBREDOSIS DE SODA')).toBeNull()
+    expect(parseExternalDateTime('')).toBeNull()
+    expect(parseExternalDateTime(null)).toBeNull()
+    expect(parseExternalDateTime(undefined)).toBeNull()
   })
 })

--- a/src/core/lib/dates.ts
+++ b/src/core/lib/dates.ts
@@ -37,8 +37,13 @@ const BARE_DATE = /^\d{4}-\d{2}-\d{2}$/
  * timezone to find which calendar day it actually falls on there.
  */
 function toDateOnly(isoString: string): string {
+    if (!isoString) return ''
     if (BARE_DATE.test(isoString)) return isoString
-    return new Intl.DateTimeFormat('en-CA', { timeZone: APP_TIMEZONE }).format(new Date(isoString))
+    try {
+        return new Intl.DateTimeFormat('en-CA', { timeZone: APP_TIMEZONE }).format(new Date(isoString))
+    } catch {
+        return ''
+    }
 }
 
 /** Today's calendar date (YYYY-MM-DD) in the app's timezone, not the server's. */
@@ -147,4 +152,85 @@ export function eventTimeOfDay(dateStr: string): string {
     const hour = parts.find((p) => p.type === 'hour')?.value ?? '00'
     const minute = parts.find((p) => p.type === 'minute')?.value ?? '00'
     return `${hour}:${minute}`
+}
+
+/**
+ * Los adaptadores de fuentes externas emiten la fecha en el formato que usa
+ * cada sitio, no en ISO: `enigma` y `quehacemos` mandan ISO, pero
+ * `entradaweb` manda prosa ("Domingo 30 de Agosto, 2026 - 21:00hs.") y
+ * `livepass` manda día + mes abreviado sin año ("13 SEP"). `new Date()` no
+ * entiende ninguno de los dos últimos, así que el valor crudo terminaba
+ * renderizado como el texto "Invalid Date" en la cartelera y rechazado por
+ * Postgres al importar (`events.date` es `timestamptz not null`).
+ */
+const SPANISH_MONTHS: Record<string, number> = {
+    ene: 0, feb: 1, mar: 2, abr: 3, may: 4, jun: 5,
+    jul: 6, ago: 7, sep: 8, set: 8, oct: 9, nov: 10, dic: 11,
+}
+
+function monthFromSpanish(name: string): number | null {
+    const key = name
+        .toLowerCase()
+        .normalize('NFD')
+        .replace(/[̀-ͯ]/g, '')
+        .slice(0, 3)
+    return key in SPANISH_MONTHS ? SPANISH_MONTHS[key] : null
+}
+
+/**
+ * Interpreta la fecha cruda de un evento externo. Devuelve null cuando el
+ * texto no representa una fecha reconocible — quien llama decide si mostrar
+ * el crudo o descartar el evento, en vez de propagar un Date inválido.
+ *
+ * Sin año explícito se asume la próxima ocurrencia: un "13 SEP" listado en
+ * diciembre es de septiembre del año siguiente, no de nueve meses atrás.
+ */
+export function parseExternalDateTime(raw: string | null | undefined, reference: Date = new Date()): Date | null {
+    if (!raw) return null
+    const text = raw.trim()
+    if (!text) return null
+
+    // Sólo se delega en el parser nativo cuando el texto ya es ISO 8601.
+    // `new Date()` es deliberadamente permisivo y acepta cosas como "13 SEP"
+    // devolviendo el año 2001, así que dejarlo interpretar formatos libres
+    // produce fechas plausibles pero falsas en vez de un fallo visible.
+    if (/^\d{4}-\d{2}-\d{2}([T ]|$)/.test(text)) {
+        const iso = new Date(text)
+        if (!Number.isNaN(iso.getTime())) return iso
+    }
+
+    const time = text.match(/(\d{1,2}):(\d{2})/)
+    const hours = time ? Number(time[1]) : 0
+    const minutes = time ? Number(time[2]) : 0
+
+    // "30 de Agosto, 2026" / "Viernes 11 de Septiembre, 2026 - 21:00hs."
+    const withYear = text.match(/(\d{1,2})\s+de\s+([a-zA-ZáéíóúÁÉÍÓÚ]+)(?:\s*,?\s*(?:de\s+)?(\d{4}))?/)
+    if (withYear) {
+        const month = monthFromSpanish(withYear[2])
+        if (month !== null) {
+            const day = Number(withYear[1])
+            const year = withYear[3] ? Number(withYear[3]) : inferYear(month, day, reference)
+            return new Date(year, month, day, hours, minutes)
+        }
+    }
+
+    // "13 SEP" / "16 OCT" — día y mes abreviado, sin año.
+    const dayMonth = text.match(/\b(\d{1,2})\s+([a-zA-ZáéíóúÁÉÍÓÚ]{3,10})\b/)
+    if (dayMonth) {
+        const month = monthFromSpanish(dayMonth[2])
+        if (month !== null) {
+            const day = Number(dayMonth[1])
+            return new Date(inferYear(month, day, reference), month, day, hours, minutes)
+        }
+    }
+
+    return null
+}
+
+/** Año de la próxima ocurrencia de ese día y mes respecto de la referencia. */
+function inferYear(month: number, day: number, reference: Date): number {
+    const year = reference.getFullYear()
+    const candidate = new Date(year, month, day)
+    const sameDay = new Date(reference.getFullYear(), reference.getMonth(), reference.getDate())
+    return candidate < sameDay ? year + 1 : year
 }

--- a/src/core/lib/external-sources/adapters/alpogo.ts
+++ b/src/core/lib/external-sources/adapters/alpogo.ts
@@ -16,7 +16,7 @@ export const alpogoAdapter: ExternalSourceAdapter = {
       }
 
       const res = await fetchWithRetry(url.toString(), {
-        method: 'GET',
+        method: 'POST',
         // Next.js cache bypass for external background fetching, though cron will handle it
       })
 

--- a/src/core/lib/routes.ts
+++ b/src/core/lib/routes.ts
@@ -50,6 +50,16 @@ export const routes = {
     detail: (id: string) => `/festivals/${id}` as const,
   },
 
+  // Admin & Moderation
+  admin: {
+    home: '/admin',
+    moderation: {
+      artists: '/admin/moderacion/artistas',
+      venues: '/admin/moderacion/sedes',
+      events: '/admin/moderacion/eventos',
+    },
+  },
+
   // Auth
   login: '/login',
   signup: '/signup',

--- a/src/core/lib/utils.test.ts
+++ b/src/core/lib/utils.test.ts
@@ -20,11 +20,15 @@ describe('cn', () => {
 })
 
 describe('formatDate', () => {
-  // new Date('YYYY-MM-DD') parses as UTC midnight, which reads back as the
-  // previous day in a timezone behind UTC (like the test runner's local
-  // zone here) — construct with explicit local components to avoid that,
-  // same lesson as core/lib/dates.ts.
-  const localDate = new Date(2026, 2, 15) // 15 de marzo de 2026, hora local
+  // formatDate muestra los timestamps en la zona de la app (Argentina, UTC-3),
+  // no en la del runtime, así que el instante se fija de forma explícita en vez
+  // de construirlo con componentes locales: con `new Date(2026, 2, 15)` el
+  // resultado dependía de la zona de la máquina y el test pasaba local pero
+  // fallaba en CI, que corre en UTC.
+  //
+  // 15:00 UTC son las 12:00 del 15 de marzo en Argentina — mediodía, lejos de
+  // cualquier borde de día.
+  const localDate = new Date('2026-03-15T15:00:00Z')
 
   it('formats a Date with the default long options', () => {
     expect(formatDate(localDate)).toBe('15 de marzo de 2026')
@@ -53,8 +57,15 @@ describe('formatDate con fechas sin hora', () => {
             .toBe('1 de enero de 2026')
     })
 
-    it('sigue respetando la hora cuando el string sí la trae', () => {
-        // 2026-05-26T02:00:00Z son las 23:00 del 25 en Argentina.
+    // Un timestamp sí es un instante y se muestra en la zona de la app, no en
+    // la del runtime: 02:00 UTC son las 23:00 del día anterior en Argentina.
+    // Este test corría distinto en CI (UTC) que en la máquina local (ART) hasta
+    // que formatDate pasó a fijar la timezone explícitamente.
+    it('muestra un timestamp en la zona de la app, no en la del servidor', () => {
         expect(formatDate('2026-05-26T02:00:00Z', { day: 'numeric', month: 'short' })).toBe('25 may')
+    })
+
+    it('no corre el día de un timestamp del mediodía', () => {
+        expect(formatDate('2026-05-26T15:00:00Z', { day: 'numeric', month: 'short' })).toBe('26 may')
     })
 })

--- a/src/core/lib/utils.test.ts
+++ b/src/core/lib/utils.test.ts
@@ -38,3 +38,23 @@ describe('formatDate', () => {
     expect(formatDate(localDate, { month: 'short' })).toBe('mar')
   })
 })
+
+// Regresión del corrimiento de día en las columnas `date` de Postgres:
+// `expenses.date` guarda "2026-05-26" y la UI mostraba "25 may", porque el
+// string pelado se parsea como medianoche UTC y al formatear en horario de
+// Argentina (UTC-3) retrocede al día anterior.
+describe('formatDate con fechas sin hora', () => {
+    it('conserva el día calendario de un "YYYY-MM-DD"', () => {
+        expect(formatDate('2026-05-26', { day: 'numeric', month: 'short' })).toBe('26 may')
+    })
+
+    it('no retrocede en el primer día del mes', () => {
+        expect(formatDate('2026-01-01', { day: 'numeric', month: 'long', year: 'numeric' }))
+            .toBe('1 de enero de 2026')
+    })
+
+    it('sigue respetando la hora cuando el string sí la trae', () => {
+        // 2026-05-26T02:00:00Z son las 23:00 del 25 en Argentina.
+        expect(formatDate('2026-05-26T02:00:00Z', { day: 'numeric', month: 'short' })).toBe('25 may')
+    })
+})

--- a/src/core/lib/utils.ts
+++ b/src/core/lib/utils.ts
@@ -1,5 +1,6 @@
 import { type ClassValue, clsx } from 'clsx'
 import { twMerge } from 'tailwind-merge'
+import { APP_TIMEZONE } from '@/src/core/lib/dates'
 
 export function cn(...inputs: ClassValue[]) {
     return twMerge(clsx(inputs))
@@ -18,24 +19,24 @@ export function formatDate(
     date: string | Date,
     options: Intl.DateTimeFormatOptions = DEFAULT_DATE_OPTIONS
 ): string {
-    let dateObj: Date
-
-    if (typeof date === 'string') {
-        // Un "YYYY-MM-DD" pelado se parsea como medianoche UTC, y al
-        // formatearlo en horario de Argentina (UTC-3) retrocede al día
-        // anterior: `expenses.date` es una columna `date`, así que un gasto
-        // del 26 se mostraba como "25 may". Se construye la fecha en horario
-        // local para que el día calendario sobreviva al formateo.
-        //
-        // Es el mismo trap que ya evitan eventYear/eventMonth/isPastEvent en
-        // core/lib/dates.ts; acá faltaba.
-        const dateOnly = date.match(DATE_ONLY)
-        dateObj = dateOnly
-            ? new Date(Number(dateOnly[1]), Number(dateOnly[2]) - 1, Number(dateOnly[3]))
-            : new Date(date)
-    } else {
-        dateObj = date
+    // Un "YYYY-MM-DD" pelado no representa un instante sino un día calendario:
+    // así llegan las columnas `date` de Postgres, como `expenses.date`. Se lo
+    // ancla en UTC y se lo formatea en UTC para que salga el día tal cual está
+    // guardado. Sin esto se parseaba como medianoche UTC y se formateaba en la
+    // zona del runtime, así que un gasto del 26 aparecía como "25 may".
+    const dateOnly = typeof date === 'string' ? date.match(DATE_ONLY) : null
+    if (dateOnly) {
+        const utc = new Date(
+            Date.UTC(Number(dateOnly[1]), Number(dateOnly[2]) - 1, Number(dateOnly[3]))
+        )
+        return utc.toLocaleDateString('es-AR', { ...options, timeZone: 'UTC' })
     }
 
-    return dateObj.toLocaleDateString('es-AR', options)
+    // Un timestamp sí es un instante, y se muestra en la zona de la app. Fijarla
+    // es necesario: `toLocaleDateString` usa la zona del runtime si no se le
+    // indica una, así que en Vercel (UTC) un show de las 21:00 en Argentina se
+    // renderizaba con la fecha del día siguiente. Mismo criterio que
+    // eventYear/eventMonth/isPastEvent en core/lib/dates.ts.
+    const dateObj = typeof date === 'string' ? new Date(date) : date
+    return dateObj.toLocaleDateString('es-AR', { timeZone: APP_TIMEZONE, ...options })
 }

--- a/src/core/lib/utils.ts
+++ b/src/core/lib/utils.ts
@@ -11,10 +11,31 @@ const DEFAULT_DATE_OPTIONS: Intl.DateTimeFormatOptions = {
     year: 'numeric',
 }
 
+/** "YYYY-MM-DD" sin hora — el formato de las columnas `date` de Postgres. */
+const DATE_ONLY = /^(\d{4})-(\d{2})-(\d{2})$/
+
 export function formatDate(
     date: string | Date,
     options: Intl.DateTimeFormatOptions = DEFAULT_DATE_OPTIONS
 ): string {
-    const dateObj = typeof date === 'string' ? new Date(date) : date
+    let dateObj: Date
+
+    if (typeof date === 'string') {
+        // Un "YYYY-MM-DD" pelado se parsea como medianoche UTC, y al
+        // formatearlo en horario de Argentina (UTC-3) retrocede al día
+        // anterior: `expenses.date` es una columna `date`, así que un gasto
+        // del 26 se mostraba como "25 may". Se construye la fecha en horario
+        // local para que el día calendario sobreviva al formateo.
+        //
+        // Es el mismo trap que ya evitan eventYear/eventMonth/isPastEvent en
+        // core/lib/dates.ts; acá faltaba.
+        const dateOnly = date.match(DATE_ONLY)
+        dateObj = dateOnly
+            ? new Date(Number(dateOnly[1]), Number(dateOnly[2]) - 1, Number(dateOnly[3]))
+            : new Date(date)
+    } else {
+        dateObj = date
+    }
+
     return dateObj.toLocaleDateString('es-AR', options)
 }

--- a/src/core/lib/validation.ts
+++ b/src/core/lib/validation.ts
@@ -154,3 +154,18 @@ export function sanitizeAuthError(error: { message?: string } | null | undefined
     if (process.env.NODE_ENV === 'development') return error.message
     return 'Ocurrió un error inesperado. Intentá de nuevo.'
 }
+
+/**
+ * Neutraliza los comodines de LIKE en un término de búsqueda del usuario.
+ *
+ * Sin esto, un `%` ensancha el patrón a toda la tabla y un `_` matchea
+ * cualquier carácter: en la búsqueda global devuelve resultados que nadie
+ * pidió, y en el buscador de fusión de la cola de moderación eso pasa justo
+ * antes de elegir el destino de una operación destructiva.
+ *
+ * La barra invertida va primero para no re-escapar las que agregan las dos
+ * líneas siguientes.
+ */
+export function escapeLikeWildcards(term: string): string {
+    return term.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_')
+}

--- a/src/core/types/index.ts
+++ b/src/core/types/index.ts
@@ -17,6 +17,7 @@ export interface Artist {
   genre?: string | null
   image_url?: string | null
   spotify_id?: string | null
+  status?: string
 }
 
 /** Payload mínimo para crear un artista (formulario). */
@@ -34,6 +35,7 @@ export interface Venue {
   country?: string | null
   lat?: number | null
   lng?: number | null
+  status?: string
 }
 
 /** Payload mínimo para crear una sede (formulario). */

--- a/src/domains/artists/data.ts
+++ b/src/domains/artists/data.ts
@@ -78,3 +78,51 @@ export async function getArtistEvents(artistId: string): Promise<ArtistEvent[]> 
   const artist = await getArtistById(artistId)
   return artist?.events ?? []
 }
+
+/**
+ * Versión por lote de `getArtistEvents`, para el DataLoader de
+ * `Artist.events`. La versión de a uno llama a `getArtistById`, que es un
+ * select anidado de cuatro niveles: pedir `events` sobre la query de listado
+ * disparaba una de esas por artista del catálogo.
+ *
+ * Devuelve un array alineado con `artistIds`, que es el contrato que espera
+ * DataLoader: misma longitud y mismo orden que las claves.
+ */
+export async function getArtistEventsBatch(
+  artistIds: readonly string[]
+): Promise<ArtistEvent[][]> {
+  if (artistIds.length === 0) return []
+
+  const supabase = await createClient()
+  const { data, error } = await supabase
+    .from('lineups')
+    .select(`
+      artist_id,
+      events (
+        id, name, date,
+        venues ( name, city ),
+        event_photos ( storage_path, caption ),
+        attendance!left ( status, rating, review )
+      )
+    `)
+    .in('artist_id', artistIds as string[])
+
+  if (error) {
+    console.error('Error cargando shows por artista:', error)
+    return artistIds.map(() => [])
+  }
+
+  const rows = (data ?? []) as unknown as Array<{ artist_id: string; events: ArtistEvent | null }>
+
+  const byArtist = new Map<string, ArtistEvent[]>()
+  for (const row of rows) {
+    if (!row.events) continue
+    const list = byArtist.get(row.artist_id)
+    if (list) list.push(row.events)
+    else byArtist.set(row.artist_id, [row.events])
+  }
+
+  return artistIds.map((id) =>
+    (byArtist.get(id) ?? []).sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+  )
+}

--- a/src/domains/artists/service.ts
+++ b/src/domains/artists/service.ts
@@ -120,6 +120,34 @@ export async function getWishlistArtistIds(): Promise<string[]> {
   return (data ?? []).map((r) => r.artist_id)
 }
 
+/**
+ * Los artistas de la wishlist, con su nombre, no sólo los ids.
+ *
+ * El home pedía `wishlistArtistIds` más el catálogo COMPLETO de artistas sólo
+ * para resolver el nombre de los primeros seis de la wishlist. Traer una tabla
+ * entera para cruzarla en memoria contra seis ids es trabajo que la base puede
+ * hacer con un join.
+ */
+export async function getWishlistArtists(): Promise<Array<{ id: string; name: string }>> {
+  const userId = await getCurrentUserId()
+  if (!userId) return []
+  const supabase = await createClient()
+  const { data, error } = await supabase
+    .from('wishlist')
+    .select('artists ( id, name )')
+    .eq('user_id', userId)
+
+  if (error) {
+    console.error('[Wishlist] Error cargando artistas:', error)
+    return []
+  }
+
+  const rows = (data ?? []) as unknown as Array<{ artists: { id: string; name: string } | null }>
+  return rows
+    .map((row) => row.artists)
+    .filter((artist): artist is { id: string; name: string } => artist !== null)
+}
+
 export async function toggleWishlist(
   artistId: string
 ): Promise<ActionResult<{ inWishlist: boolean }>> {

--- a/src/domains/events/attendance-data.ts
+++ b/src/domains/events/attendance-data.ts
@@ -40,3 +40,34 @@ export async function getAttendanceForEvent(
         notes: data.notes,
     }
 }
+
+export async function getAttendanceForEventsBatch(
+    eventIds: readonly string[],
+    userId: string
+): Promise<(EventAttendance | null)[]> {
+    if (!userId || eventIds.length === 0) return eventIds.map(() => null)
+
+    const supabase = await createClient()
+    const { data, error } = await supabase
+        .from('attendance')
+        .select('id, event_id, status, rating, review, notes')
+        .in('event_id', eventIds)
+        .eq('user_id', userId)
+
+    if (error || !data) return eventIds.map(() => null)
+
+    const attendanceByEventId = new Map(
+        data.map((row) => [
+            row.event_id,
+            {
+                id: row.id,
+                status: row.status as AttendanceStatus,
+                rating: row.rating,
+                review: row.review,
+                notes: row.notes,
+            }
+        ])
+    )
+
+    return eventIds.map((id) => attendanceByEventId.get(id) ?? null)
+}

--- a/src/domains/events/components/FutureEventsResults.tsx
+++ b/src/domains/events/components/FutureEventsResults.tsx
@@ -6,6 +6,7 @@ import { useMutation, gql } from 'urql'
 import { unwrapMutation } from '@/src/graphql/mutation-result'
 import { routes } from '@/src/core/lib/routes'
 import { formatDate } from '@/src/core/lib/utils'
+import { parseExternalDateTime } from '@/src/core/lib/dates'
 import { FutureEvent } from '@/src/core/types'
 
 const AddExternalEventMutation = gql`
@@ -79,13 +80,19 @@ export function FutureEventsResults({ events, searchQuery, compact }: FutureEven
                 const isLoading = loadingId === ev.id
                 const isAdded = addedIds.has(ev.id)
                 const error = errors[ev.id]
-                const date = new Date(ev.datetime)
-                const dateLabel = formatDate(date, {
-                    weekday: 'short',
-                    day: 'numeric',
-                    month: 'short',
-                    year: compact ? undefined : 'numeric', // hide year in compact?
-                })
+                // Cada fuente externa emite la fecha en su propio formato y
+                // algunas no son parseables. Con `new Date()` a secas, esas
+                // caían en el label como el texto "Invalid Date"; mostrar el
+                // crudo del sitio ("13 SEP") le dice algo al usuario.
+                const date = parseExternalDateTime(ev.datetime)
+                const dateLabel = date
+                    ? formatDate(date, {
+                        weekday: 'short',
+                        day: 'numeric',
+                        month: 'short',
+                        year: compact ? undefined : 'numeric',
+                    })
+                    : ev.datetime
                 const venueLabel = [ev.venue.name, ev.venue.city].filter(Boolean).join(', ')
 
                 return (

--- a/src/domains/events/components/HomeHero.tsx
+++ b/src/domains/events/components/HomeHero.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, use } from 'react'
 import Link from 'next/link'
 import { TicketEmbed } from '@/src/core/components/ui'
 import { routes } from '@/src/core/lib/routes'
@@ -9,7 +9,7 @@ import type { HomeHeroState } from '@/src/domains/events/home-view'
 
 interface HomeHeroProps {
   state: HomeHeroState
-  backgroundImage: string | null
+  backgroundImage: Promise<string | null> | string | null
 }
 
 /**
@@ -19,6 +19,7 @@ interface HomeHeroProps {
  * tiene "una" entrada, tiene un evento por día.
  */
 export function HomeHero({ state, backgroundImage }: HomeHeroProps) {
+  const resolvedBg = backgroundImage instanceof Promise ? use(backgroundImage) : backgroundImage
   const [open, setOpen] = useState(false)
 
   if (state.kind === 'festival') {
@@ -75,10 +76,10 @@ export function HomeHero({ state, backgroundImage }: HomeHeroProps) {
 
   return (
     <section className="relative min-h-screen overflow-hidden bg-ritual-panel">
-      {backgroundImage && (
+      {resolvedBg && (
         <div
           className="absolute inset-0 ritual-photo"
-          style={{ backgroundImage: `url(${backgroundImage})`, backgroundSize: 'cover', backgroundPosition: 'center' }}
+          style={{ backgroundImage: `url(${resolvedBg})`, backgroundSize: 'cover', backgroundPosition: 'center' }}
         />
       )}
       <div className="absolute inset-0 bg-gradient-to-t from-ritual-bg via-ritual-bg/40 to-transparent" />

--- a/src/domains/events/data.ts
+++ b/src/domains/events/data.ts
@@ -50,13 +50,23 @@ export interface EventWithAttendance extends EventWithRelations {
 // cualquier visitante, logueado o no, paga el costo de traer todo.
 export const MAX_EVENTS = 1000
 
-export async function getEvents(): Promise<EventWithRelations[]> {
+export async function getEvents(options?: { limit?: number; offset?: number }): Promise<EventWithRelations[]> {
+  const limit = options?.limit ?? MAX_EVENTS
+  const offset = options?.offset ?? 0
+
   const supabase = await createClient()
-  const { data, error } = await supabase
+  let query = supabase
     .from('events')
     .select(EVENTS_SELECT)
     .order('date', { ascending: false })
-    .limit(MAX_EVENTS)
+
+  if (options?.limit !== undefined || options?.offset !== undefined) {
+    query = query.range(offset, offset + limit - 1)
+  } else {
+    query = query.limit(limit)
+  }
+
+  const { data, error } = await query
 
   if (error) {
     console.error('Error cargando eventos:', error)
@@ -69,13 +79,23 @@ export async function getEvents(): Promise<EventWithRelations[]> {
  * Carga todos los eventos con su attendance del usuario actual.
  * Permite filtrar y mostrar badges de estado en el home.
  */
-export async function getEventsWithAttendance(): Promise<EventWithAttendance[]> {
+export async function getEventsWithAttendance(options?: { limit?: number; offset?: number }): Promise<EventWithAttendance[]> {
+  const limit = options?.limit ?? MAX_EVENTS
+  const offset = options?.offset ?? 0
+
   const supabase = await createClient()
-  const { data, error } = await supabase
+  let query = supabase
     .from('events')
     .select(EVENTS_WITH_ATTENDANCE_SELECT)
     .order('date', { ascending: false })
-    .limit(MAX_EVENTS)
+
+  if (options?.limit !== undefined || options?.offset !== undefined) {
+    query = query.range(offset, offset + limit - 1)
+  } else {
+    query = query.limit(limit)
+  }
+
+  const { data, error } = await query
 
   if (error) {
     console.error('Error cargando eventos con attendance:', error)

--- a/src/domains/events/data.ts
+++ b/src/domains/events/data.ts
@@ -155,3 +155,57 @@ export async function getEventIdsForSitemap(): Promise<Array<{ id: string; date:
   }
   return (data ?? []) as Array<{ id: string; date: string }>
 }
+
+/**
+ * Sólo los eventos donde el usuario registró asistencia (de cualquier estado:
+ * went, going o interested), con la suya adjunta.
+ *
+ * /wrapped llamaba a getEventsWithAttendance() —hasta MAX_EVENTS del catálogo
+ * compartido, con venue, lineup y attendance— para después quedarse nada más
+ * que con los 'went' del usuario del año elegido. Sumado a getPersonalStats()
+ * en el mismo Promise.all, eran dos barridas casi idénticas del catálogo por
+ * cada carga de la página.
+ *
+ * Igual que en stats, se parte de `attendance` filtrada por usuario y se
+ * embebe el evento, así la base devuelve sólo el historial propio.
+ */
+export async function getMyEvents(): Promise<EventWithAttendance[]> {
+  const userId = await getCurrentUserId()
+  if (!userId) return []
+
+  const supabase = await createClient()
+  const { data, error } = await supabase
+    .from('attendance')
+    .select(`
+      id, status, user_id, rating, review,
+      events (
+        *,
+        venues ( name, city, country ),
+        lineups ( artists ( id, name, genre ) )
+      )
+    `)
+    .eq('user_id', userId)
+
+  if (error) {
+    console.error('Error cargando los shows del usuario:', error)
+    return []
+  }
+
+  type Row = {
+    id: string
+    status: string
+    user_id: string
+    rating: number | null
+    review: string | null
+    events: Omit<EventWithAttendance, 'attendance'> | null
+  }
+
+  return (data as unknown as Row[])
+    .filter((row): row is Row & { events: Omit<EventWithAttendance, 'attendance'> } => row.events !== null)
+    .map((row) => ({
+      ...row.events,
+      attendance: [
+        { id: row.id, status: row.status, user_id: row.user_id, rating: row.rating, review: row.review },
+      ],
+    })) as EventWithAttendance[]
+}

--- a/src/domains/events/data.ts
+++ b/src/domains/events/data.ts
@@ -134,3 +134,24 @@ export async function getEventById(
   return data as EventWithRelations
 }
 
+
+/**
+ * Sólo `id` y `date` de cada evento, para el sitemap. `getEvents()` trae
+ * `*` más los embeds de venues y lineups→artists, y el sitemap descartaba
+ * todo eso salvo el id — pagando el join completo en cada visita de un
+ * crawler.
+ */
+export async function getEventIdsForSitemap(): Promise<Array<{ id: string; date: string }>> {
+  const supabase = await createClient()
+  const { data, error } = await supabase
+    .from('events')
+    .select('id, date')
+    .order('date', { ascending: false })
+    .limit(MAX_EVENTS)
+
+  if (error) {
+    console.error('Error cargando ids de eventos para el sitemap:', error)
+    return []
+  }
+  return (data ?? []) as Array<{ id: string; date: string }>
+}

--- a/src/domains/events/photo-actions.ts
+++ b/src/domains/events/photo-actions.ts
@@ -44,6 +44,34 @@ export async function getEventPhotos(eventId: string): Promise<EventPhoto[]> {
     }))
 }
 
+export async function getEventPhotosBatch(
+    eventIds: readonly string[]
+): Promise<EventPhoto[][]> {
+    if (eventIds.length === 0) return []
+
+    const supabase = await createClient()
+    const { data, error } = await supabase
+        .from('event_photos')
+        .select('id, event_id, storage_path, caption, created_at')
+        .in('event_id', eventIds)
+        .order('created_at', { ascending: true })
+
+    if (error || !data) return eventIds.map(() => [])
+
+    const photosByEventId = new Map<string, EventPhoto[]>()
+    for (const photo of data) {
+        if (!photosByEventId.has(photo.event_id)) {
+            photosByEventId.set(photo.event_id, [])
+        }
+        photosByEventId.get(photo.event_id)!.push({
+            ...photo,
+            url: supabase.storage.from(BUCKET).getPublicUrl(photo.storage_path).data.publicUrl,
+        })
+    }
+
+    return eventIds.map((id) => photosByEventId.get(id) ?? [])
+}
+
 /**
  * Sube una foto a Supabase Storage y guarda la referencia en la DB.
  * Acepta FormData con campos: eventId, file, caption (opcional).

--- a/src/domains/events/service.test.ts
+++ b/src/domains/events/service.test.ts
@@ -28,6 +28,14 @@ const VALID_VENUE_ID = '11111111-1111-1111-1111-111111111111'
 const VALID_EVENT_ID = '22222222-2222-2222-2222-222222222222'
 const VALID_ARTIST_ID = '33333333-3333-3333-3333-333333333333'
 
+/**
+ * `removeEvent` consulta el RPC `is_moderator` antes de borrar nada, porque
+ * `lineups` no cascadea y un borrado frenado por RLS a mitad de camino dejaba
+ * el recital sin lineup. Por defecto los tests corren como moderador; los que
+ * prueban el rechazo lo sobrescriben.
+ */
+const moderatorRpc = vi.fn(() => Promise.resolve({ data: true, error: null }))
+
 function makeQueryBuilder(result: { data: unknown; error: unknown }) {
   const builder: Record<string, unknown> = {}
   const chain = () => builder
@@ -71,7 +79,7 @@ describe('insertEvent', () => {
     const eventsBuilder = makeQueryBuilder({ data: { id: VALID_EVENT_ID }, error: null })
     const lineupsBuilder = makeQueryBuilder({ data: null, error: null })
     const fromMock = vi.fn((table: string) => (table === 'events' ? eventsBuilder : lineupsBuilder))
-    mockCreateClient.mockReturnValue(Promise.resolve({ from: fromMock }))
+    mockCreateClient.mockReturnValue(Promise.resolve({ from: fromMock, rpc: moderatorRpc }))
 
     const result = await insertEvent({
       name: 'Show',
@@ -88,7 +96,7 @@ describe('insertEvent', () => {
     const eventsBuilder = makeQueryBuilder({ data: { id: VALID_EVENT_ID }, error: null })
     const lineupsBuilder = makeQueryBuilder({ data: null, error: null })
     const fromMock = vi.fn((table: string) => (table === 'events' ? eventsBuilder : lineupsBuilder))
-    mockCreateClient.mockReturnValue(Promise.resolve({ from: fromMock }))
+    mockCreateClient.mockReturnValue(Promise.resolve({ from: fromMock, rpc: moderatorRpc }))
 
     const result = await insertEvent({
       name: 'Show',
@@ -110,7 +118,7 @@ describe('insertEvent', () => {
     const eventsBuilder = makeQueryBuilder({ data: { id: VALID_EVENT_ID }, error: null })
     const lineupsBuilder = makeQueryBuilder({ data: null, error: { message: 'boom' } })
     const fromMock = vi.fn((table: string) => (table === 'events' ? eventsBuilder : lineupsBuilder))
-    mockCreateClient.mockReturnValue(Promise.resolve({ from: fromMock }))
+    mockCreateClient.mockReturnValue(Promise.resolve({ from: fromMock, rpc: moderatorRpc }))
 
     const result = await insertEvent({
       name: 'Show',
@@ -176,7 +184,7 @@ describe('addExternalEvent', () => {
       const eventsBuilder = makeQueryBuilder({ data: { id: VALID_EVENT_ID }, error: null })
       const lineupsBuilder = makeQueryBuilder({ data: null, error: null })
       const fromMock = vi.fn((table: string) => (table === 'events' ? eventsBuilder : lineupsBuilder))
-      mockCreateClient.mockReturnValue(Promise.resolve({ from: fromMock }))
+      mockCreateClient.mockReturnValue(Promise.resolve({ from: fromMock, rpc: moderatorRpc }))
 
       const result = await addExternalEvent(baseEvent)
 
@@ -193,9 +201,13 @@ describe('addExternalEvent', () => {
         'artists',
         'Bandalos Chinos'
       )
+      // La fecha se normaliza a ISO canónico antes de insertar: el crudo de
+      // cada fuente externa pasa por parseExternalDateTime, así que llega con
+      // los milisegundos explícitos. Mismo instante que el '...T20:00:00Z' de
+      // entrada.
       expect(eventsBuilder.insert).toHaveBeenCalledWith({
         name: 'Show en Niceto',
-        date: '2024-05-01T20:00:00Z',
+        date: '2024-05-01T20:00:00.000Z',
         venue_id: VALID_VENUE_ID,
       })
       expect(lineupsBuilder.insert).toHaveBeenCalledWith({
@@ -217,7 +229,7 @@ describe('addExternalEvent', () => {
     const eventsBuilder = makeQueryBuilder({ data: { id: VALID_EVENT_ID }, error: null })
     const lineupsBuilder = makeQueryBuilder({ data: null, error: { message: 'boom' } })
     const fromMock = vi.fn((table: string) => (table === 'events' ? eventsBuilder : lineupsBuilder))
-    mockCreateClient.mockReturnValue(Promise.resolve({ from: fromMock }))
+    mockCreateClient.mockReturnValue(Promise.resolve({ from: fromMock, rpc: moderatorRpc }))
 
     const result = await addExternalEvent(baseEvent)
 
@@ -242,7 +254,7 @@ describe('addExternalEvent', () => {
       if (table === 'lineups') return lineupsBuilder
       return { upsert: attendanceUpsert }
     })
-    mockCreateClient.mockReturnValue(Promise.resolve({ from: fromMock }))
+    mockCreateClient.mockReturnValue(Promise.resolve({ from: fromMock, rpc: moderatorRpc }))
 
     const result = await addExternalEvent(baseEvent, undefined, '1. Cumbia Rara\n2. Ela')
 
@@ -266,7 +278,7 @@ describe('addExternalEvent', () => {
       if (table === 'lineups') return lineupsBuilder
       return { upsert: attendanceUpsert }
     })
-    mockCreateClient.mockReturnValue(Promise.resolve({ from: fromMock }))
+    mockCreateClient.mockReturnValue(Promise.resolve({ from: fromMock, rpc: moderatorRpc }))
 
     await addExternalEvent(baseEvent)
 
@@ -289,7 +301,7 @@ describe('addExternalEvent', () => {
     const eventsBuilder = makeQueryBuilder({ data: { id: VALID_EVENT_ID }, error: null })
     const lineupsBuilder = makeQueryBuilder({ data: null, error: null })
     const fromMock = vi.fn((table: string) => (table === 'events' ? eventsBuilder : lineupsBuilder))
-    mockCreateClient.mockReturnValue(Promise.resolve({ from: fromMock }))
+    mockCreateClient.mockReturnValue(Promise.resolve({ from: fromMock, rpc: moderatorRpc }))
 
     await addExternalEvent({
       title: '',
@@ -331,7 +343,7 @@ describe('modifyEvent', () => {
     const eventsBuilder = makeQueryBuilder({ data: null, error: null })
     const lineupsBuilder = makeQueryBuilder({ data: null, error: null })
     const fromMock = vi.fn((table: string) => (table === 'events' ? eventsBuilder : lineupsBuilder))
-    mockCreateClient.mockReturnValue(Promise.resolve({ from: fromMock }))
+    mockCreateClient.mockReturnValue(Promise.resolve({ from: fromMock, rpc: moderatorRpc }))
 
     await modifyEvent(VALID_EVENT_ID, { artist_ids: [VALID_ARTIST_ID] })
 
@@ -345,7 +357,7 @@ describe('modifyEvent', () => {
     const eventsBuilder = makeQueryBuilder({ data: null, error: null })
     const lineupsBuilder = makeQueryBuilder({ data: null, error: null })
     const fromMock = vi.fn((table: string) => (table === 'events' ? eventsBuilder : lineupsBuilder))
-    mockCreateClient.mockReturnValue(Promise.resolve({ from: fromMock }))
+    mockCreateClient.mockReturnValue(Promise.resolve({ from: fromMock, rpc: moderatorRpc }))
 
     const result = await modifyEvent(VALID_EVENT_ID, { artist_ids: ['not-a-uuid'] })
 
@@ -376,7 +388,7 @@ describe('removeEvent', () => {
     const eventsBuilder = makeQueryBuilder({ data: null, error: null })
     const lineupsBuilder = makeQueryBuilder({ data: null, error: null })
     const fromMock = vi.fn((table: string) => (table === 'events' ? eventsBuilder : lineupsBuilder))
-    mockCreateClient.mockReturnValue(Promise.resolve({ from: fromMock }))
+    mockCreateClient.mockReturnValue(Promise.resolve({ from: fromMock, rpc: moderatorRpc }))
 
     await removeEvent(VALID_EVENT_ID)
 
@@ -388,7 +400,7 @@ describe('removeEvent', () => {
     const eventsBuilder = makeQueryBuilder({ data: null, error: null })
     const lineupsBuilder = makeQueryBuilder({ data: null, error: { message: 'boom' } })
     const fromMock = vi.fn((table: string) => (table === 'events' ? eventsBuilder : lineupsBuilder))
-    mockCreateClient.mockReturnValue(Promise.resolve({ from: fromMock }))
+    mockCreateClient.mockReturnValue(Promise.resolve({ from: fromMock, rpc: moderatorRpc }))
 
     const result = await removeEvent(VALID_EVENT_ID)
 
@@ -473,15 +485,43 @@ describe('insertEvent / modifyEvent / removeEvent — sin redirect', () => {
   })
 
   it('removeEvent deletes lineups and the event', async () => {
-    const eventsBuilder = makeQueryBuilder({ data: null, error: null })
+    // El delete del evento pide la fila de vuelta con .select('id'), así que
+    // el mock tiene que devolverla: es lo que distingue un borrado real de uno
+    // que RLS frenó, que en PostgREST llega como 0 filas sin error.
+    const eventsBuilder = makeQueryBuilder({ data: [{ id: VALID_EVENT_ID }], error: null })
     const lineupsBuilder = makeQueryBuilder({ data: null, error: null })
     const fromMock = vi.fn((table: string) => (table === 'events' ? eventsBuilder : lineupsBuilder))
-    mockCreateClient.mockReturnValue(Promise.resolve({ from: fromMock }))
+    mockCreateClient.mockReturnValue(Promise.resolve({ from: fromMock, rpc: moderatorRpc }))
 
     const result = await removeEvent(VALID_EVENT_ID)
 
     expect(lineupsBuilder.delete).toHaveBeenCalled()
     expect(eventsBuilder.delete).toHaveBeenCalled()
     expect(result).toEqual({})
+  })
+
+  it('removeEvent no borra nada cuando el usuario no es moderador', async () => {
+    const eventsBuilder = makeQueryBuilder({ data: null, error: null })
+    const lineupsBuilder = makeQueryBuilder({ data: null, error: null })
+    const fromMock = vi.fn((table: string) => (table === 'events' ? eventsBuilder : lineupsBuilder))
+    const notModerator = vi.fn(() => Promise.resolve({ data: false, error: null }))
+    mockCreateClient.mockReturnValue(Promise.resolve({ from: fromMock, rpc: notModerator }))
+
+    const result = await removeEvent(VALID_EVENT_ID)
+
+    expect(result.error).toBeTruthy()
+    expect(lineupsBuilder.delete).not.toHaveBeenCalled()
+    expect(eventsBuilder.delete).not.toHaveBeenCalled()
+  })
+
+  it('removeEvent reporta error cuando RLS frena el borrado y no afecta filas', async () => {
+    const eventsBuilder = makeQueryBuilder({ data: [], error: null })
+    const lineupsBuilder = makeQueryBuilder({ data: null, error: null })
+    const fromMock = vi.fn((table: string) => (table === 'events' ? eventsBuilder : lineupsBuilder))
+    mockCreateClient.mockReturnValue(Promise.resolve({ from: fromMock, rpc: moderatorRpc }))
+
+    const result = await removeEvent(VALID_EVENT_ID)
+
+    expect(result.error).toBeTruthy()
   })
 })

--- a/src/domains/events/service.ts
+++ b/src/domains/events/service.ts
@@ -1,6 +1,7 @@
 import { createClient } from '@/src/core/lib/supabase/server'
 import { validateUUID, validateDate, sanitizeText, sanitizeError } from '@/src/core/lib/validation'
 import { findOrCreateByName } from '@/src/core/lib/find-or-create'
+import { parseExternalDateTime } from '@/src/core/lib/dates'
 import { getCurrentUserId } from '@/src/core/auth/session'
 import type { ActionResult, EventCreateInput, EventUpdateInput, FutureEvent } from '@/src/core/types'
 
@@ -108,8 +109,16 @@ export async function addExternalEvent(
   const venueName = sanitizeText(event.venue?.name, MAX_VENUE_NAME_LENGTH)
   if (!venueName) return { error: 'El evento no tiene sede.' }
 
-  const dateStr = event.datetime
-  if (!dateStr) return { error: 'El evento no tiene fecha.' }
+  // `events.date` es `timestamptz not null`, y varias fuentes externas mandan
+  // la fecha en prosa ("Domingo 30 de Agosto, 2026") o abreviada sin año
+  // ("13 SEP"). Pasar el crudo hacía que Postgres rechazara el insert y que
+  // `sanitizeError` lo devolviera como un error genérico, así que importar
+  // sólo funcionaba desde las fuentes que ya mandaban ISO.
+  const parsedDate = parseExternalDateTime(event.datetime)
+  if (!parsedDate) {
+    return { error: 'No se pudo interpretar la fecha del evento. Cargalo a mano.' }
+  }
+  const dateStr = parsedDate.toISOString()
 
   const artistName =
     sanitizeText(artistNameForLineup, MAX_ARTIST_NAME_LENGTH) ||
@@ -253,16 +262,42 @@ export async function removeEvent(id: string): Promise<ActionResult> {
   if (idErr) return { error: idErr }
 
   const supabase = await createClient()
+
+  // El permiso se chequea antes de tocar nada. `lineups` no tiene ON DELETE
+  // CASCADE, así que hay que borrarlo primero para que el DELETE del evento no
+  // choque contra la foreign key — y si el borrado del evento después lo
+  // frenara RLS, el recital quedaría sin lineup igual. Preguntar primero evita
+  // esa pérdida parcial.
+  const { data: canDelete, error: roleError } = await supabase.rpc('is_moderator')
+  if (roleError) {
+    console.error('No se pudo verificar el rol para eliminar el evento:', roleError)
+    return { error: sanitizeError(roleError) }
+  }
+  if (!canDelete) {
+    return { error: 'Solo un moderador puede eliminar un recital del catálogo.' }
+  }
+
   const { error: lineupsError } = await supabase.from('lineups').delete().eq('event_id', id)
   if (lineupsError) {
     console.error('Error eliminando lineups:', lineupsError)
     return { error: sanitizeError(lineupsError) }
   }
 
-  const { error: eventError } = await supabase.from('events').delete().eq('id', id)
+  // Se pide la fila borrada de vuelta: un DELETE que RLS bloquea no es un
+  // error para PostgREST, afecta 0 filas y devuelve `error: null`. Sin este
+  // chequeo, un borrado denegado se reportaba como éxito.
+  const { data: deleted, error: eventError } = await supabase
+    .from('events')
+    .delete()
+    .eq('id', id)
+    .select('id')
+
   if (eventError) {
     console.error('Error eliminando evento:', eventError)
     return { error: sanitizeError(eventError) }
+  }
+  if (!deleted || deleted.length === 0) {
+    return { error: 'No se pudo eliminar el recital.' }
   }
 
   return {}

--- a/src/domains/expenses/data.test.ts
+++ b/src/domains/expenses/data.test.ts
@@ -86,24 +86,46 @@ describe('getExpensesSummary', () => {
     vi.clearAllMocks()
   })
 
-  it('aggregates total, by category and by year through the session-aware client', async () => {
-    const mockExpenses = [
-      { amount: 1000, category: 'Entrada', date: '2026-01-15' },
-      { amount: 500, category: 'Transporte', date: '2026-01-20' },
-      { amount: 2000, category: 'Entrada', date: '2027-03-01' },
-    ]
-    const fromMock = vi.fn(() => makeQueryBuilder({ data: mockExpenses, error: null }))
-    mockCreateClient.mockReturnValue(Promise.resolve({ from: fromMock }))
+  const emptySummary = { total: 0, byCategory: {}, byYear: {}, count: 0 }
+
+  function mockRpc(result: { data: unknown; error: unknown }) {
+    const rpc = vi.fn().mockResolvedValue(result)
+    mockCreateClient.mockReturnValue(Promise.resolve({ rpc }))
+    return rpc
+  }
+
+  it('returns an empty summary without querying when there is no user', async () => {
+    const summary = await getExpensesSummary(null)
+
+    expect(mockCreateClient).not.toHaveBeenCalled()
+    expect(summary).toEqual(emptySummary)
+  })
+
+  it('delegates the aggregation to the RPC and returns what it produced', async () => {
+    const aggregated = {
+      total: 3500,
+      byCategory: { Entrada: 3000, Transporte: 500 },
+      byYear: { '2026': 1500, '2027': 2000 },
+      count: 3,
+    }
+    const rpc = mockRpc({ data: aggregated, error: null })
 
     const summary = await getExpensesSummary('user-1')
 
-    expect(mockCreateClient).toHaveBeenCalledTimes(1)
-    expect(summary.total).toBe(3500)
-    expect(summary.byCategory['Entrada']).toBe(3000)
-    expect(summary.byCategory['Transporte']).toBe(500)
-    expect(summary.byYear['2026']).toBe(1500)
-    expect(summary.byYear['2027']).toBe(2000)
-    expect(summary.count).toBe(3)
+    expect(rpc).toHaveBeenCalledWith('get_expenses_summary', { user_uuid: 'user-1' })
+    expect(summary).toEqual(aggregated)
+  })
+
+  it('falls back to an empty summary when the RPC errors', async () => {
+    mockRpc({ data: null, error: { message: 'boom' } })
+
+    await expect(getExpensesSummary('user-1')).resolves.toEqual(emptySummary)
+  })
+
+  it('falls back to an empty summary when the RPC returns no data', async () => {
+    mockRpc({ data: null, error: null })
+
+    await expect(getExpensesSummary('user-1')).resolves.toEqual(emptySummary)
   })
 })
 
@@ -112,8 +134,14 @@ describe('getVenueArtistSpendEstimate', () => {
     vi.clearAllMocks()
   })
 
-  it('returns null without querying when there is no user id', async () => {
-    const result = await getVenueArtistSpendEstimate(null, 'venue-1', [], 'ev-1')
+  function mockRpc(result: { data: unknown; error: unknown }) {
+    const rpc = vi.fn().mockResolvedValue(result)
+    mockCreateClient.mockReturnValue(Promise.resolve({ rpc }))
+    return rpc
+  }
+
+  it('returns null without querying when there is no user', async () => {
+    const result = await getVenueArtistSpendEstimate(null, 'venue-1', ['artist-1'], 'ev-1')
     expect(mockCreateClient).not.toHaveBeenCalled()
     expect(result).toBeNull()
   })
@@ -124,90 +152,40 @@ describe('getVenueArtistSpendEstimate', () => {
     expect(result).toBeNull()
   })
 
-  it('averages total spend per past event at the same venue', async () => {
-    const fromMock = vi.fn((table: string) => {
-      if (table === 'events') return makeQueryBuilder({ data: [{ id: 'ev-2' }, { id: 'ev-3' }], error: null })
-      if (table === 'expenses') {
-        return makeQueryBuilder({
-          data: [
-            { amount: 3000, event_id: 'ev-2' },
-            { amount: 5000, event_id: 'ev-2' },
-            { amount: 4000, event_id: 'ev-3' },
-          ],
-          error: null,
-        })
-      }
-      return makeQueryBuilder({ data: [], error: null })
+  it('delegates the aggregation to the RPC, passing the current event as the exclusion', async () => {
+    const rpc = mockRpc({ data: { averageTotal: 6000, eventsConsidered: 2 }, error: null })
+
+    await getVenueArtistSpendEstimate('user-1', 'venue-1', ['artist-1'], 'ev-1')
+
+    expect(rpc).toHaveBeenCalledWith('get_venue_artist_spend_estimate', {
+      p_user_id: 'user-1',
+      p_venue_id: 'venue-1',
+      p_artist_ids: ['artist-1'],
+      p_exclude_event_id: 'ev-1',
     })
-    mockCreateClient.mockReturnValue(Promise.resolve({ from: fromMock }))
+  })
+
+  it('returns the estimate the RPC produced', async () => {
+    mockRpc({ data: { averageTotal: 6000, eventsConsidered: 2 }, error: null })
 
     const result = await getVenueArtistSpendEstimate('user-1', 'venue-1', [], 'ev-1')
 
-    expect(fromMock).toHaveBeenCalledWith('events')
-    expect(fromMock).toHaveBeenCalledWith('expenses')
-    expect(fromMock).not.toHaveBeenCalledWith('lineups')
-    // ev-2 totals 8000, ev-3 totals 4000 -> average 6000 across 2 events
     expect(result).toEqual({ averageTotal: 6000, eventsConsidered: 2 })
   })
 
-  it('unions venue and artist matches, deduping overlaps and excluding the current event, before querying expenses', async () => {
-    const expensesBuilder = makeQueryBuilder({
-      data: [
-        { amount: 1000, event_id: 'ev-2' },
-        { amount: 2000, event_id: 'ev-4' },
-      ],
-      error: null,
-    })
-    const fromMock = vi.fn((table: string) => {
-      if (table === 'events') return makeQueryBuilder({ data: [{ id: 'ev-2' }], error: null })
-      // ev-2 overlaps with the venue match (must be deduped, not double-counted),
-      // ev-1 is the current event itself (must be excluded).
-      if (table === 'lineups') {
-        return makeQueryBuilder({
-          data: [{ event_id: 'ev-2' }, { event_id: 'ev-4' }, { event_id: 'ev-1' }],
-          error: null,
-        })
-      }
-      if (table === 'expenses') return expensesBuilder
-      return makeQueryBuilder({ data: [], error: null })
-    })
-    mockCreateClient.mockReturnValue(Promise.resolve({ from: fromMock }))
-
-    const result = await getVenueArtistSpendEstimate('user-1', 'venue-1', ['artist-1'], 'ev-1')
-
-    const queriedIds = (expensesBuilder.in as ReturnType<typeof vi.fn>).mock.calls[0][1] as string[]
-    expect(new Set(queriedIds)).toEqual(new Set(['ev-2', 'ev-4']))
-    expect(result).toEqual({ averageTotal: 1500, eventsConsidered: 2 })
-  })
-
-  it('returns null when no past events match the venue or artists', async () => {
-    const fromMock = vi.fn(() => makeQueryBuilder({ data: [], error: null }))
-    mockCreateClient.mockReturnValue(Promise.resolve({ from: fromMock }))
+  it('returns null when the RPC finds no past events to average', async () => {
+    mockRpc({ data: null, error: null })
 
     const result = await getVenueArtistSpendEstimate('user-1', 'venue-1', [], 'ev-1')
+
     expect(result).toBeNull()
   })
 
-  it('returns null when matching events exist but none have any recorded expenses', async () => {
-    const fromMock = vi.fn((table: string) => {
-      if (table === 'events') return makeQueryBuilder({ data: [{ id: 'ev-2' }], error: null })
-      if (table === 'expenses') return makeQueryBuilder({ data: [], error: null })
-      return makeQueryBuilder({ data: [], error: null })
-    })
-    mockCreateClient.mockReturnValue(Promise.resolve({ from: fromMock }))
+  it('returns null (without throwing) when the RPC errors', async () => {
+    mockRpc({ data: null, error: { message: 'boom' } })
 
     const result = await getVenueArtistSpendEstimate('user-1', 'venue-1', [], 'ev-1')
-    expect(result).toBeNull()
-  })
 
-  it('returns null (without throwing) when the events lookup errors', async () => {
-    const fromMock = vi.fn((table: string) => {
-      if (table === 'events') return makeQueryBuilder({ data: null, error: { message: 'boom' } })
-      return makeQueryBuilder({ data: [], error: null })
-    })
-    mockCreateClient.mockReturnValue(Promise.resolve({ from: fromMock }))
-
-    const result = await getVenueArtistSpendEstimate('user-1', 'venue-1', [], 'ev-1')
     expect(result).toBeNull()
   })
 })

--- a/src/domains/expenses/data.ts
+++ b/src/domains/expenses/data.ts
@@ -1,12 +1,11 @@
-import { createClient } from '@/src/core/lib/supabase/server'
-import { eventYear } from '@/src/core/lib/dates'
-import type { Expense } from '@/src/core/types'
+import { createClient } from "@/src/core/lib/supabase/server";
+import type { Expense } from "@/src/core/types";
 
 export interface ExpenseSummary {
-  total: number
-  byCategory: Record<string, number>
-  byYear: Record<string, number>
-  count: number
+  total: number;
+  byCategory: Record<string, number>;
+  byYear: Record<string, number>;
+  count: number;
 }
 
 /**
@@ -14,91 +13,90 @@ export interface ExpenseSummary {
  * RLS filtra por user_id = auth.uid(); si no hay sesión devuelve [].
  */
 export async function getExpenses(userId: string | null): Promise<Expense[]> {
-  if (!userId) return []
-  const supabase = await createClient()
+  if (!userId) return [];
+  const supabase = await createClient();
   const { data, error } = await supabase
-    .from('expenses')
-    .select('id, user_id, amount, category, note, event_id, date, created_at')
-    .eq('user_id', userId)
-    .order('date', { ascending: false })
+    .from("expenses")
+    .select("id, user_id, amount, category, note, event_id, date, created_at")
+    .eq("user_id", userId)
+    .order("date", { ascending: false });
   if (error) {
-    console.error('Error cargando gastos:', error)
-    return []
+    console.error("Error cargando gastos:", error);
+    return [];
   }
-  return (data ?? []) as Expense[]
+  return (data ?? []) as Expense[];
 }
 
 /** Obtiene un gasto por id. RLS asegura que solo el dueño pueda verlo. */
 export async function getExpenseById(
   id: string,
-  userId: string | null
+  userId: string | null,
 ): Promise<Expense | null> {
-  if (!userId) return null
-  const supabase = await createClient()
+  if (!userId) return null;
+  const supabase = await createClient();
   const { data, error } = await supabase
-    .from('expenses')
-    .select('id, user_id, amount, category, note, event_id, date, created_at')
-    .eq('id', id)
-    .eq('user_id', userId)
-    .single()
-  if (error || !data) return null
-  return data as Expense
+    .from("expenses")
+    .select("id, user_id, amount, category, note, event_id, date, created_at")
+    .eq("id", id)
+    .eq("user_id", userId)
+    .single();
+  if (error || !data) return null;
+  return data as Expense;
 }
 
 /** Gastos vinculados a un evento puntual, del usuario actual. RLS filtra por user_id. */
-export async function getExpensesForEvent(eventId: string, userId: string | null): Promise<Expense[]> {
-  if (!userId) return []
-  const supabase = await createClient()
+export async function getExpensesForEvent(
+  eventId: string,
+  userId: string | null,
+): Promise<Expense[]> {
+  if (!userId) return [];
+  const supabase = await createClient();
   const { data, error } = await supabase
-    .from('expenses')
-    .select('id, user_id, amount, category, note, event_id, date, created_at')
-    .eq('event_id', eventId)
-    .eq('user_id', userId)
-    .order('date', { ascending: false })
+    .from("expenses")
+    .select("id, user_id, amount, category, note, event_id, date, created_at")
+    .eq("event_id", eventId)
+    .eq("user_id", userId)
+    .order("date", { ascending: false });
   if (error) {
-    console.error('Error cargando gastos del evento:', error)
-    return []
+    console.error("Error cargando gastos del evento:", error);
+    return [];
   }
-  return (data ?? []) as Expense[]
+  return (data ?? []) as Expense[];
 }
 
 /**
  * Calcula el resumen de gastos: total general, por categoría y por año.
  */
-export async function getExpensesSummary(userId: string | null): Promise<ExpenseSummary> {
-  const empty: ExpenseSummary = { total: 0, byCategory: {}, byYear: {}, count: 0 }
-  if (!userId) return empty
+export async function getExpensesSummary(
+  userId: string | null,
+): Promise<ExpenseSummary> {
+  const empty: ExpenseSummary = {
+    total: 0,
+    byCategory: {},
+    byYear: {},
+    count: 0,
+  };
+  if (!userId) return empty;
 
-  const supabase = await createClient()
-  const { data, error } = await supabase
-    .from('expenses')
-    .select('amount, category, date')
-    .eq('user_id', userId)
+  const supabase = await createClient();
+  const { data, error } = await supabase.rpc("get_expenses_summary", {
+    user_uuid: userId,
+  });
 
-  if (error || !data) return empty
-
-  const result: ExpenseSummary = { total: 0, byCategory: {}, byYear: {}, count: data.length }
-
-  for (const ex of data) {
-    const amount = Number(ex.amount)
-    result.total += amount
-
-    const cat = ex.category ?? 'Otro'
-    result.byCategory[cat] = (result.byCategory[cat] ?? 0) + amount
-
-    const year = eventYear(ex.date).toString()
-    result.byYear[year] = (result.byYear[year] ?? 0) + amount
+  if (error || !data) {
+    if (error) console.error("Error calculando resumen de gastos:", error);
+    return empty;
   }
 
-  return result
+  return data as ExpenseSummary;
 }
 
 /** Soft, informational estimate of what a user tends to spend at a given venue or artist. */
 export interface VenueArtistSpendEstimate {
   /** Average total spent per past event at this venue/artist, in ARS. */
-  averageTotal: number
+  averageTotal: number;
   /** How many past events (with at least one expense) this average is based on. */
-  eventsConsidered: number
+  eventsConsidered: number;
 }
 
 /**
@@ -119,64 +117,29 @@ export async function getVenueArtistSpendEstimate(
   userId: string | null,
   venueId: string | null,
   artistIds: string[],
-  excludeEventId: string
+  excludeEventId: string,
 ): Promise<VenueArtistSpendEstimate | null> {
-  if (!userId) return null
-  if (!venueId && artistIds.length === 0) return null
+  if (!userId) return null;
+  if (!venueId && artistIds.length === 0) return null;
 
-  const supabase = await createClient()
-  const matchingEventIds = new Set<string>()
+  const supabase = await createClient();
 
-  if (venueId) {
-    const { data: venueEvents, error: venueError } = await supabase
-      .from('events')
-      .select('id')
-      .eq('venue_id', venueId)
-      .neq('id', excludeEventId)
-    if (venueError) {
-      console.error('Error buscando eventos de la misma sede:', venueError)
-    } else {
-      for (const row of venueEvents ?? []) matchingEventIds.add(row.id)
-    }
+  const { data, error } = await supabase.rpc(
+    "get_venue_artist_spend_estimate",
+    {
+      p_user_id: userId,
+      p_venue_id: venueId,
+      p_artist_ids: artistIds,
+      p_exclude_event_id: excludeEventId,
+    },
+  );
+
+  if (error) {
+    console.error("Error calculando gasto histórico por sede/artista:", error);
+    return null;
   }
 
-  if (artistIds.length > 0) {
-    const { data: lineupRows, error: lineupError } = await supabase
-      .from('lineups')
-      .select('event_id')
-      .in('artist_id', artistIds)
-    if (lineupError) {
-      console.error('Error buscando eventos del mismo artista:', lineupError)
-    } else {
-      for (const row of lineupRows ?? []) {
-        if (row.event_id !== excludeEventId) matchingEventIds.add(row.event_id)
-      }
-    }
-  }
+  if (!data) return null;
 
-  if (matchingEventIds.size === 0) return null
-
-  const { data: expenseRows, error: expenseError } = await supabase
-    .from('expenses')
-    .select('amount, event_id')
-    .eq('user_id', userId)
-    .in('event_id', Array.from(matchingEventIds))
-
-  if (expenseError) {
-    console.error('Error calculando gasto histórico por sede/artista:', expenseError)
-    return null
-  }
-  if (!expenseRows || expenseRows.length === 0) return null
-
-  const totalsByEvent = new Map<string, number>()
-  for (const row of expenseRows) {
-    if (!row.event_id) continue
-    totalsByEvent.set(row.event_id, (totalsByEvent.get(row.event_id) ?? 0) + Number(row.amount))
-  }
-
-  const totals = Array.from(totalsByEvent.values())
-  if (totals.length === 0) return null
-
-  const averageTotal = totals.reduce((sum, t) => sum + t, 0) / totals.length
-  return { averageTotal, eventsConsidered: totals.length }
+  return data as VenueArtistSpendEstimate;
 }

--- a/src/domains/moderation/service.test.ts
+++ b/src/domains/moderation/service.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockCreateClient = vi.fn()
+
+vi.mock('@/src/core/lib/supabase/server', () => ({
+  createClient: () => mockCreateClient(),
+}))
+
+import {
+  searchMergeTargets,
+  approveArtist,
+  approveVenue,
+  approveEvent,
+  mergeArtists,
+} from '@/src/domains/moderation/service'
+
+/** Registra la cadena de llamadas para poder afirmar sobre el filtro construido. */
+function makeQueryBuilder(result: { data: unknown; error: unknown }) {
+  const calls: Record<string, unknown[][]> = {}
+  const builder: Record<string, unknown> = {}
+  const record = (name: string) =>
+    vi.fn((...args: unknown[]) => {
+      calls[name] = [...(calls[name] ?? []), args]
+      return builder
+    })
+
+  builder.select = record('select')
+  builder.eq = record('eq')
+  builder.neq = record('neq')
+  builder.ilike = record('ilike')
+  builder.order = record('order')
+  builder.limit = record('limit')
+  builder.then = (onFulfilled: (v: unknown) => unknown, onRejected?: (e: unknown) => unknown) =>
+    Promise.resolve(result).then(onFulfilled, onRejected)
+
+  return { builder, calls }
+}
+
+function mockFrom(result: { data: unknown; error: unknown }) {
+  const { builder, calls } = makeQueryBuilder(result)
+  const from = vi.fn(() => builder)
+  mockCreateClient.mockResolvedValue({ from })
+  return { from, calls }
+}
+
+function mockRpc(result: { error: unknown }) {
+  const rpc = vi.fn().mockResolvedValue(result)
+  mockCreateClient.mockResolvedValue({ rpc })
+  return rpc
+}
+
+describe('searchMergeTargets', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('does not touch the database for an empty or whitespace-only term', async () => {
+    mockFrom({ data: [], error: null })
+
+    await expect(searchMergeTargets('artists', '   ')).resolves.toEqual([])
+    expect(mockCreateClient).not.toHaveBeenCalled()
+  })
+
+  it('restricts candidates to already verified rows', async () => {
+    const { calls } = mockFrom({ data: [], error: null })
+
+    await searchMergeTargets('artists', 'radiohead')
+
+    expect(calls.eq).toContainEqual(['status', 'verified'])
+  })
+
+  it('escapes LIKE wildcards so a term like "100%" cannot match the whole catalog', async () => {
+    const { calls } = mockFrom({ data: [], error: null })
+
+    await searchMergeTargets('artists', '100%_x')
+
+    expect(calls.ilike).toEqual([['name', '%100\\%\\_x%']])
+  })
+
+  it('escapes backslashes before adding its own, so the escape char is not doubled away', async () => {
+    const { calls } = mockFrom({ data: [], error: null })
+
+    await searchMergeTargets('artists', 'AC\\DC')
+
+    expect(calls.ilike).toEqual([['name', '%AC\\\\DC%']])
+  })
+
+  it('excludes the source entity when an id is given', async () => {
+    const { calls } = mockFrom({ data: [], error: null })
+
+    await searchMergeTargets('artists', 'radiohead', 'a-1')
+
+    expect(calls.neq).toEqual([['id', 'a-1']])
+  })
+
+  it('omits the exclusion filter when no source id is given', async () => {
+    const { calls } = mockFrom({ data: [], error: null })
+
+    await searchMergeTargets('artists', 'radiohead')
+
+    expect(calls.neq).toBeUndefined()
+  })
+
+  it('maps an artist row to its genre as the disambiguating detail', async () => {
+    mockFrom({ data: [{ id: 'a-1', name: 'Radiohead', genre: 'rock' }], error: null })
+
+    await expect(searchMergeTargets('artists', 'radio')).resolves.toEqual([
+      { id: 'a-1', name: 'Radiohead', detail: 'rock' },
+    ])
+  })
+
+  it('joins city and address for a venue, skipping the missing half', async () => {
+    mockFrom({ data: [{ id: 'v-1', name: 'Niceto', city: 'CABA', address: null }], error: null })
+
+    await expect(searchMergeTargets('venues', 'niceto')).resolves.toEqual([
+      { id: 'v-1', name: 'Niceto', detail: 'CABA' },
+    ])
+  })
+
+  it('leaves the detail null when a venue has neither city nor address', async () => {
+    mockFrom({ data: [{ id: 'v-1', name: 'Niceto', city: null, address: null }], error: null })
+
+    await expect(searchMergeTargets('venues', 'niceto')).resolves.toEqual([
+      { id: 'v-1', name: 'Niceto', detail: null },
+    ])
+  })
+
+  it('uses the date as the detail for an event', async () => {
+    mockFrom({ data: [{ id: 'e-1', name: 'Show', date: '2026-09-01' }], error: null })
+
+    await expect(searchMergeTargets('events', 'show')).resolves.toEqual([
+      { id: 'e-1', name: 'Show', detail: '2026-09-01' },
+    ])
+  })
+
+  it('propagates a query error instead of returning a silently empty list', async () => {
+    mockFrom({ data: null, error: new Error('boom') })
+
+    await expect(searchMergeTargets('artists', 'radiohead')).rejects.toThrow('boom')
+  })
+})
+
+describe('approve*', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it.each([
+    ['artists', approveArtist],
+    ['venues', approveVenue],
+    ['events', approveEvent],
+  ] as const)('routes %s through the approve_entity RPC', async (entityType, approve) => {
+    const rpc = mockRpc({ error: null })
+
+    await approve('x-1')
+
+    expect(rpc).toHaveBeenCalledWith('approve_entity', {
+      entity_type: entityType,
+      entity_id: 'x-1',
+    })
+  })
+
+  it('propagates the RPC error so an insufficient_privilege never reads as success', async () => {
+    mockRpc({ error: new Error('insufficient_privilege') })
+
+    await expect(approveArtist('a-1')).rejects.toThrow('insufficient_privilege')
+  })
+})
+
+describe('mergeArtists', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('calls the merge_artists RPC with the source and target ids', async () => {
+    const rpc = mockRpc({ error: null })
+
+    await mergeArtists('a-source', 'a-target')
+
+    expect(rpc).toHaveBeenCalledWith('merge_artists', {
+      source_id: 'a-source',
+      target_id: 'a-target',
+    })
+  })
+
+  it('propagates the RPC error', async () => {
+    mockRpc({ error: new Error('insufficient_privilege') })
+
+    await expect(mergeArtists('a-source', 'a-target')).rejects.toThrow('insufficient_privilege')
+  })
+})

--- a/src/domains/moderation/service.ts
+++ b/src/domains/moderation/service.ts
@@ -1,5 +1,6 @@
 import { createClient } from '@/src/core/lib/supabase/server'
 import type { Artist, Venue, EventWithRelations } from '@/src/core/types'
+import { escapeLikeWildcards } from '@/src/core/lib/validation'
 
 export type ModeratedEntity = 'artists' | 'venues' | 'events'
 
@@ -55,17 +56,6 @@ export async function getUnverifiedEvents(): Promise<EventWithRelations[]> {
 
     if (error) throw error
     return data as unknown as EventWithRelations[]
-}
-
-/**
- * Neutraliza los comodines de LIKE que venga en el término del usuario. Sin
- * esto, buscar "100%" matchea todo el catálogo y "_" matchea cualquier letra:
- * el moderador vería resultados que no pidió justo antes de ejecutar una
- * fusión destructiva. La barra invertida va primero para no re-escapar las
- * que agregan las dos líneas siguientes.
- */
-function escapeLikeWildcards(term: string): string {
-    return term.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_')
 }
 
 const MERGE_TARGET_COLUMNS: Record<ModeratedEntity, string> = {

--- a/src/domains/moderation/service.ts
+++ b/src/domains/moderation/service.ts
@@ -1,0 +1,173 @@
+import { createClient } from '@/src/core/lib/supabase/server'
+import type { Artist, Venue, EventWithRelations } from '@/src/core/types'
+
+export type ModeratedEntity = 'artists' | 'venues' | 'events'
+
+/** Una entidad canónica candidata a recibir la fusión, lista para el combobox. */
+export interface MergeTarget {
+    id: string
+    name: string
+    /** Dato secundario para desambiguar homónimos: género, ubicación o fecha. */
+    detail: string | null
+}
+
+const MERGE_TARGET_LIMIT = 8
+
+export async function getUnverifiedArtists(): Promise<Artist[]> {
+    const supabase = await createClient()
+    const { data, error } = await supabase
+        .from('artists')
+        .select('*')
+        .eq('status', 'unverified')
+        .order('created_at', { ascending: false })
+
+    if (error) throw error
+    return data as Artist[]
+}
+
+export async function getUnverifiedVenues(): Promise<Venue[]> {
+    const supabase = await createClient()
+    const { data, error } = await supabase
+        .from('venues')
+        .select('*')
+        .eq('status', 'unverified')
+        .order('created_at', { ascending: false })
+
+    if (error) throw error
+    return data as Venue[]
+}
+
+const EVENTS_SELECT = `
+  *,
+  venues ( name, city, country ),
+  lineups (
+    artists ( id, name, genre )
+  )
+`
+
+export async function getUnverifiedEvents(): Promise<EventWithRelations[]> {
+    const supabase = await createClient()
+    const { data, error } = await supabase
+        .from('events')
+        .select(EVENTS_SELECT)
+        .eq('status', 'unverified')
+        .order('date', { ascending: true })
+
+    if (error) throw error
+    return data as unknown as EventWithRelations[]
+}
+
+/**
+ * Neutraliza los comodines de LIKE que venga en el término del usuario. Sin
+ * esto, buscar "100%" matchea todo el catálogo y "_" matchea cualquier letra:
+ * el moderador vería resultados que no pidió justo antes de ejecutar una
+ * fusión destructiva. La barra invertida va primero para no re-escapar las
+ * que agregan las dos líneas siguientes.
+ */
+function escapeLikeWildcards(term: string): string {
+    return term.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_')
+}
+
+const MERGE_TARGET_COLUMNS: Record<ModeratedEntity, string> = {
+    artists: 'id, name, genre',
+    venues: 'id, name, city, address',
+    events: 'id, name, date',
+}
+
+function toMergeTarget(entityType: ModeratedEntity, row: Record<string, unknown>): MergeTarget {
+    const id = String(row.id)
+    const name = (row.name as string | null) ?? 'Sin nombre'
+
+    if (entityType === 'artists') {
+        return { id, name, detail: (row.genre as string | null) ?? null }
+    }
+
+    if (entityType === 'venues') {
+        const parts = [row.city, row.address].filter(Boolean) as string[]
+        return { id, name, detail: parts.length ? parts.join(' — ') : null }
+    }
+
+    return { id, name, detail: (row.date as string | null) ?? null }
+}
+
+/**
+ * Busca la entidad canónica hacia la que fusionar. Espejo del tool
+ * `search_catalog` del servidor MCP (`mcp/src/index.ts`): sólo candidatos ya
+ * verificados, para que una fusión no mande el historial a otro duplicado
+ * pendiente. Se apoya en los índices GIN trigram de
+ * 20260824205500_performance_indexes.sql.
+ */
+export async function searchMergeTargets(
+    entityType: ModeratedEntity,
+    query: string,
+    excludeId?: string
+): Promise<MergeTarget[]> {
+    const term = query.trim()
+    if (!term) return []
+
+    const supabase = await createClient()
+    let request = supabase
+        .from(entityType)
+        .select(MERGE_TARGET_COLUMNS[entityType])
+        .eq('status', 'verified')
+        .ilike('name', `%${escapeLikeWildcards(term)}%`)
+        .order('name', { ascending: true })
+        .limit(MERGE_TARGET_LIMIT)
+
+    if (excludeId) request = request.neq('id', excludeId)
+
+    const { data, error } = await request
+    if (error) throw error
+
+    // El nombre de la tabla es dinámico, así que el cliente de Supabase no
+    // puede inferir la forma de la fila y cae en GenericStringError. La lista
+    // de columnas por entidad la fija MERGE_TARGET_COLUMNS acá al lado.
+    const rows = (data ?? []) as unknown as Record<string, unknown>[]
+    return rows.map((row) => toMergeTarget(entityType, row))
+}
+
+/**
+ * La aprobación pasa por RPC y no por un UPDATE directo: el cliente de
+ * @supabase/ssr corre con el JWT del usuario, y `artists`/`venues` no tienen
+ * policy de UPDATE. RLS denegaba, PostgREST devolvía 0 filas sin error, y la
+ * aprobación fallaba en silencio reportando éxito. Ver
+ * 20260825060000_moderation_approve_and_status_guard.sql.
+ */
+async function approveEntity(entityType: ModeratedEntity, id: string): Promise<void> {
+    const supabase = await createClient()
+    const { error } = await supabase.rpc('approve_entity', {
+        entity_type: entityType,
+        entity_id: id,
+    })
+    if (error) throw error
+}
+
+export async function approveArtist(id: string): Promise<void> {
+    return approveEntity('artists', id)
+}
+
+export async function approveVenue(id: string): Promise<void> {
+    return approveEntity('venues', id)
+}
+
+export async function approveEvent(id: string): Promise<void> {
+    return approveEntity('events', id)
+}
+
+export async function mergeArtists(sourceId: string, targetId: string): Promise<void> {
+    const supabase = await createClient()
+    const { error } = await supabase.rpc('merge_artists', { source_id: sourceId, target_id: targetId })
+    if (error) throw error
+}
+
+export async function mergeVenues(sourceId: string, targetId: string): Promise<void> {
+    const supabase = await createClient()
+    const { error } = await supabase.rpc('merge_venues', { source_id: sourceId, target_id: targetId })
+    if (error) throw error
+}
+
+export async function mergeEvents(sourceId: string, targetId: string): Promise<void> {
+    const supabase = await createClient()
+    const { error } = await supabase.rpc('merge_events', { source_id: sourceId, target_id: targetId })
+    if (error) throw error
+}

--- a/src/domains/search/service.ts
+++ b/src/domains/search/service.ts
@@ -1,0 +1,61 @@
+import 'server-only'
+import { createClient } from '@/src/core/lib/supabase/server'
+import { escapeLikeWildcards } from '@/src/core/lib/validation'
+
+const MAX_RESULTS_PER_TYPE = 8
+
+export interface CatalogSearchResults {
+    events: Array<{ id: string; name: string | null; date: string }>
+    artists: Array<{ id: string; name: string; genre: string | null }>
+    venues: Array<{ id: string; name: string; city: string | null; country: string | null }>
+}
+
+const EMPTY: CatalogSearchResults = { events: [], artists: [], venues: [] }
+
+/**
+ * Búsqueda por nombre sobre las tres tablas del catálogo, para la pestaña
+ * "en tu archivo" de /buscar.
+ *
+ * Vivía como una función suelta dentro de `app/buscar/page.tsx`, con su propio
+ * `createClient()` — la única ruta del proyecto que salteaba la capa de
+ * dominio. Además interpolaba el término crudo en el `ilike`.
+ *
+ * Se apoya en los índices GIN trigram de
+ * 20260824205500_performance_indexes.sql.
+ */
+export async function searchCatalog(query: string): Promise<CatalogSearchResults> {
+    const term = query.trim()
+    if (!term) return EMPTY
+
+    const pattern = `%${escapeLikeWildcards(term)}%`
+    const supabase = await createClient()
+
+    const [eventsRes, artistsRes, venuesRes] = await Promise.all([
+        supabase
+            .from('events')
+            .select('id, name, date')
+            .ilike('name', pattern)
+            .order('date', { ascending: false })
+            .limit(MAX_RESULTS_PER_TYPE),
+        supabase
+            .from('artists')
+            .select('id, name, genre')
+            .ilike('name', pattern)
+            .limit(MAX_RESULTS_PER_TYPE),
+        supabase
+            .from('venues')
+            .select('id, name, city, country')
+            .ilike('name', pattern)
+            .limit(MAX_RESULTS_PER_TYPE),
+    ])
+
+    for (const res of [eventsRes, artistsRes, venuesRes]) {
+        if (res.error) console.error('Error en la búsqueda del catálogo:', res.error)
+    }
+
+    return {
+        events: eventsRes.data ?? [],
+        artists: artistsRes.data ?? [],
+        venues: venuesRes.data ?? [],
+    }
+}

--- a/src/domains/showmode/service.test.ts
+++ b/src/domains/showmode/service.test.ts
@@ -15,6 +15,7 @@ import {
     getShowDateRange,
 } from '@/src/domains/showmode/data'
 import { DEFAULT_SHOW_MODE_PREFERENCES } from '@/src/domains/showmode/preferences'
+import { todayDateOnly } from '@/src/core/lib/dates'
 
 const completeShow = {
     attendanceStatus: 'went' as const,
@@ -34,7 +35,12 @@ beforeEach(() => {
         checks: [{ templateItemId: 't-1', checked: false }],
     })
     // Un show de hace dos días: dentro de la ventana posterior por default.
-    const twoDaysAgo = new Date(Date.now() - 2 * 86400000).toISOString().slice(0, 10)
+    // Se ancla con todayDateOnly (timezone de Argentina) y no con
+    // `toISOString().slice(0,10)`, que da el día UTC: entre las 21:00 y la
+    // medianoche argentina el día UTC ya es el siguiente, así que "hace dos
+    // días" en UTC era "ayer" para la lógica de la app y el test fallaba solo
+    // en esa franja horaria.
+    const twoDaysAgo = todayDateOnly(new Date(Date.now() - 2 * 86400000))
     vi.mocked(getShowDateRange).mockResolvedValue({ startDate: twoDaysAgo })
 })
 
@@ -54,7 +60,9 @@ describe('getEventShowModeState', () => {
 
     it('resuelve la ventana contra el rango que devuelve data, no contra la fecha cruda del evento', async () => {
         // El evento dice 2020, pero pertenece a un festival que es hoy.
-        const today = new Date().toISOString().slice(0, 10)
+        // Mismo motivo que en el beforeEach: el "hoy" tiene que ser el día
+        // calendario de Argentina, no el UTC.
+        const today = todayDateOnly()
         vi.mocked(getShowDateRange).mockResolvedValue({ startDate: today, endDate: today })
 
         const state = await getEventShowModeState(

--- a/src/domains/stats/data.test.ts
+++ b/src/domains/stats/data.test.ts
@@ -18,13 +18,40 @@ function makeQueryBuilder(result: { data: unknown; error: unknown }) {
   const chain = () => builder
   builder.select = vi.fn(chain)
   builder.order = vi.fn(chain)
+  builder.eq = vi.fn(chain)
   builder.then = (onFulfilled: (v: unknown) => unknown, onRejected?: (e: unknown) => unknown) =>
     Promise.resolve(result).then(onFulfilled, onRejected)
   return builder
 }
 
+type FixtureEvent = {
+  id: string
+  name: string | null
+  date: string
+  venues: unknown
+  lineups: unknown
+  attendance: Array<{ status: string; user_id: string; rating: number | null }>
+}
+
+/**
+ * Los casos siguen describiendo eventos con su attendance embebida, que es
+ * como se leen mejor. La query real ahora es al revés — parte de `attendance`
+ * filtrada por usuario y embebe el evento — así que el helper traduce.
+ *
+ * Los eventos con `attendance: []` no se traducen a ninguna fila, porque la
+ * query nueva directamente no los trae: el filtro que antes ocurría en JS
+ * ahora lo hace la base.
+ */
 function mockEvents(events: unknown[]) {
-  const fromMock = vi.fn(() => makeQueryBuilder({ data: events, error: null }))
+  const rows = (events as FixtureEvent[]).flatMap((ev) =>
+    (ev.attendance ?? []).map((att) => ({
+      status: att.status,
+      user_id: att.user_id,
+      rating: att.rating,
+      events: { id: ev.id, name: ev.name, date: ev.date, venues: ev.venues, lineups: ev.lineups },
+    }))
+  )
+  const fromMock = vi.fn(() => makeQueryBuilder({ data: rows, error: null }))
   mockCreateClient.mockReturnValue(Promise.resolve({ from: fromMock }))
   return fromMock
 }

--- a/src/domains/stats/data.ts
+++ b/src/domains/stats/data.ts
@@ -79,35 +79,45 @@ export async function getPersonalStats(): Promise<StatsData> {
     const userId = await getCurrentUserId()
     if (!userId) return emptyStats()
 
-    // Traer todos los eventos con venue, lineup y attendance (rating incluido)
+    // Se parte de `attendance` filtrada por usuario y se embeben los eventos,
+    // no al revés. La versión anterior traía la tabla `events` COMPLETA —el
+    // catálogo compartido entre todos los usuarios, con venue, lineup y
+    // attendance— y recién después descartaba en JS las filas sin attendance
+    // propia. Era la única lectura del catálogo sin la cota MAX_EVENTS que sí
+    // aplican getEvents y getEventsWithAttendance, y su costo crecía con el
+    // catálogo entero en vez de con el historial del usuario. Pega en dos
+    // páginas: /stats y /wrapped.
     const supabase = await createClient()
-    const { data: events, error } = await supabase
-        .from('events')
+    const { data: rows, error } = await supabase
+        .from('attendance')
         .select(`
-      id, name, date,
-      venues ( name, city, country ),
-      lineups ( artists ( name ) ),
-      attendance!left (
-        status, user_id, rating
+      status, user_id, rating,
+      events (
+        id, name, date,
+        venues ( name, city, country ),
+        lineups ( artists ( name ) )
       )
     `)
-        .order('date', { ascending: false })
+        .eq('user_id', userId)
 
-    if (error || !events) {
+    if (error || !rows) {
         console.error('Error cargando stats:', error)
         return emptyStats()
     }
 
-    const rawEvents = events as unknown as RawEvent[]
+    type AttendanceRow = RawAttendance & { events: Omit<RawEvent, 'attendance'> | null }
 
-    // Filtrar attendance del usuario actual (RLS ya filtra, tomamos el primero si existe)
-    const eventsWithMyAttendance: EventWithMyAttendance[] = rawEvents.map((ev) => ({
-        ...ev,
-        myAttendance: ev.attendance?.[0] ?? null,
-    }))
-
-    // Solo cuentan para las stats personales los eventos donde tengo attendance registrada
-    const userEvents = eventsWithMyAttendance.filter((e) => e.myAttendance !== null)
+    // El orden por fecha descendente se hacía en la query anterior; acá se
+    // ordena en memoria porque el embed no admite ordenar por columna de la
+    // tabla embebida, y el conjunto es el historial de un solo usuario.
+    const userEvents: EventWithMyAttendance[] = (rows as unknown as AttendanceRow[])
+        .filter((row): row is AttendanceRow & { events: Omit<RawEvent, 'attendance'> } => row.events !== null)
+        .map((row) => ({
+            ...row.events,
+            attendance: [{ status: row.status, user_id: row.user_id, rating: row.rating }],
+            myAttendance: { status: row.status, user_id: row.user_id, rating: row.rating },
+        }))
+        .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
 
     const totalShows = userEvents.length
     const showsAttended = userEvents.filter((e) => e.myAttendance?.status === 'went').length

--- a/src/domains/stats/wrapped-view.ts
+++ b/src/domains/stats/wrapped-view.ts
@@ -49,8 +49,14 @@ export function buildWrappedSummary(
         monthCount[m] = (monthCount[m] ?? 0) + 1
     }
     const busiestMonthEntry = Object.entries(monthCount).sort((a, b) => b[1] - a[1])[0]
+    // Se ancla al día 15 y en UTC: acá sólo interesa el nombre del mes, y un
+    // día 1 a medianoche cae en el mes anterior al formatearlo en una zona
+    // detrás de UTC — "marzo" salía "febrero". El medio del mes no puede
+    // cruzar ningún borde.
     const busiestMonth = busiestMonthEntry
-        ? formatDate(new Date(selectedYear, parseInt(busiestMonthEntry[0])), { month: 'long' })
+        ? formatDate(new Date(Date.UTC(selectedYear, parseInt(busiestMonthEntry[0]), 15)), {
+            month: 'long',
+        })
         : null
 
     const availableYears = Object.keys(lifetimeStats.showsByYear)

--- a/src/domains/venues/data.ts
+++ b/src/domains/venues/data.ts
@@ -61,3 +61,46 @@ export async function getVenueEvents(venueId: string): Promise<VenueEvent[]> {
   const venue = await getVenueById(venueId)
   return venue?.events ?? []
 }
+
+/**
+ * Versión por lote de `getVenueEvents`, para el DataLoader de `Venue.events`.
+ * Igual que en artists: la versión de a uno pasa por `getVenueById`, que trae
+ * el detalle anidado completo, y pedir `events` sobre el listado disparaba una
+ * de esas por sede.
+ *
+ * Consulta `events` directo por `venue_id` en vez de `venues` con el embed,
+ * porque acá el punto de entrada es el lote de sedes y lo que se necesita son
+ * sus eventos agrupados.
+ */
+export async function getVenueEventsBatch(
+  venueIds: readonly string[]
+): Promise<VenueEvent[][]> {
+  if (venueIds.length === 0) return []
+
+  const supabase = await createClient()
+  const { data, error } = await supabase
+    .from('events')
+    .select(`
+      id, name, date, venue_id,
+      lineups ( artists ( name ) ),
+      attendance!left ( status )
+    `)
+    .in('venue_id', venueIds as string[])
+    .order('date', { ascending: false })
+
+  if (error) {
+    console.error('Error cargando shows por sede:', error)
+    return venueIds.map(() => [])
+  }
+
+  const rows = (data ?? []) as unknown as Array<VenueEvent & { venue_id: string }>
+
+  const byVenue = new Map<string, VenueEvent[]>()
+  for (const row of rows) {
+    const list = byVenue.get(row.venue_id)
+    if (list) list.push(row)
+    else byVenue.set(row.venue_id, [row])
+  }
+
+  return venueIds.map((id) => byVenue.get(id) ?? [])
+}

--- a/src/graphql/artists.test.ts
+++ b/src/graphql/artists.test.ts
@@ -4,6 +4,7 @@ vi.mock('@/src/domains/artists/data', () => ({
   getArtists: vi.fn(),
   getArtistById: vi.fn(),
   getArtistEvents: vi.fn(),
+  getArtistEventsBatch: vi.fn(),
 }))
 
 vi.mock('@/src/domains/artists/service', () => ({
@@ -23,7 +24,7 @@ vi.mock('@/src/core/auth/session', () => ({
   getCurrentUserId: vi.fn().mockResolvedValue(null),
 }))
 
-import { getArtistEvents } from '@/src/domains/artists/data'
+import { getArtistEvents, getArtistEventsBatch } from '@/src/domains/artists/data'
 import {
   listArtists,
   findArtistById,
@@ -165,22 +166,22 @@ describe('artists GraphQL parity additions', () => {
         attendance: [{ status: 'went', rating: 5, review: 'brutal' }],
       },
     ])
-    expect(getArtistEvents).not.toHaveBeenCalled()
+    expect(getArtistEventsBatch).not.toHaveBeenCalled()
   })
 
   it('loads the show history on demand when the row came from the list query', async () => {
     vi.mocked(listArtists).mockResolvedValue([
       { id: 'a1', name: 'Bandalos Chinos', genre: null, image_url: null, spotify_id: null },
     ])
-    vi.mocked(getArtistEvents).mockResolvedValue([
+    vi.mocked(getArtistEventsBatch).mockResolvedValue([[
       { id: 'e1', name: 'Show', date: '2026-01-01', venues: null, event_photos: [], attendance: [] },
-    ])
+    ]])
 
     const body = await query('{ artists { id events { id } } }')
 
     expect(body.errors).toBeUndefined()
     expect(body.data).toEqual({ artists: [{ id: 'a1', events: [{ id: 'e1' }] }] })
-    expect(getArtistEvents).toHaveBeenCalledWith('a1')
+    expect(getArtistEventsBatch).toHaveBeenCalledWith(['a1'])
   })
 
   // La wishlist no tenia ninguna representacion en el schema: sin esto el

--- a/src/graphql/artists.ts
+++ b/src/graphql/artists.ts
@@ -59,6 +59,7 @@ ArtistRef.implement({
         genre: t.exposeString('genre', { nullable: true }),
         imageUrl: t.exposeString('image_url', { nullable: true }),
         spotifyId: t.exposeString('spotify_id', { nullable: true }),
+        status: t.exposeString('status', { nullable: true }),
         // `getArtists()` no trae la relación y `getArtistById()` sí, así que
         // el campo la carga bajo demanda solo cuando no vino ya resuelta —
         // para que pedir `events` desde la query de listado devuelva el

--- a/src/graphql/artists.ts
+++ b/src/graphql/artists.ts
@@ -5,6 +5,7 @@ import {
     insertArtist,
     findOrCreateArtist,
     getWishlistArtistIds,
+    getWishlistArtists,
     toggleWishlist,
 } from '@/src/domains/artists/service'
 import { getArtistEvents } from '@/src/domains/artists/data'
@@ -95,6 +96,23 @@ builder.queryField('wishlistArtistIds', (t) =>
         type: ['ID'],
         description: 'IDs de los artistas que el usuario actual sigue. Vacío si no hay sesión.',
         resolve: () => getWishlistArtistIds(),
+    })
+)
+
+const WishlistArtistRef = builder.objectRef<{ id: string; name: string }>('WishlistArtist')
+WishlistArtistRef.implement({
+    fields: (t) => ({
+        id: t.exposeID('id'),
+        name: t.exposeString('name'),
+    }),
+})
+
+builder.queryField('wishlistArtists', (t) =>
+    t.field({
+        type: [WishlistArtistRef],
+        description:
+            'Artistas que el usuario actual sigue, con su nombre. Evita traer el catálogo entero sólo para resolverlos.',
+        resolve: () => getWishlistArtists(),
     })
 )
 

--- a/src/graphql/artists.ts
+++ b/src/graphql/artists.ts
@@ -66,7 +66,8 @@ ArtistRef.implement({
         // historial real y no un array vacío silencioso.
         events: t.field({
             type: [ArtistEventRef],
-            resolve: (artist) => ('events' in artist ? artist.events : getArtistEvents(artist.id)),
+            resolve: (artist, _args, context) =>
+                'events' in artist ? artist.events : context.artistEventsLoader.load(artist.id),
         }),
     }),
 })

--- a/src/graphql/builder.ts
+++ b/src/graphql/builder.ts
@@ -1,4 +1,5 @@
 import SchemaBuilder from '@pothos/core'
+import RelayPlugin from '@pothos/plugin-relay'
 import type { GraphQLContext } from './context'
 
 export const builder = new SchemaBuilder<{
@@ -6,7 +7,16 @@ export const builder = new SchemaBuilder<{
     Scalars: {
         JSON: { Input: unknown; Output: unknown }
     }
-}>({})
+}>({
+    plugins: [RelayPlugin],
+    // En Pothos v4 la clave es `relay`; `relayOptions` era la forma de v3 y
+    // quedó tipada como `never`, así que la config anterior no se aplicaba y
+    // el proyecto no compilaba con `tsc --noEmit`.
+    relay: {
+        clientMutationId: 'omit',
+        cursorType: 'String',
+    },
+})
 
 builder.scalarType('JSON', {
     serialize: (value) => value,

--- a/src/graphql/context.ts
+++ b/src/graphql/context.ts
@@ -5,6 +5,8 @@ import type { UserRole } from '@/src/core/types'
 import DataLoader from 'dataloader'
 import { getAttendanceForEventsBatch, type EventAttendance } from '@/src/domains/events/attendance-data'
 import { getEventPhotosBatch, type EventPhoto } from '@/src/domains/events/photo-actions'
+import { getArtistEventsBatch, type ArtistEvent } from '@/src/domains/artists/data'
+import { getVenueEventsBatch, type VenueEvent } from '@/src/domains/venues/data'
 
 export interface GraphQLContext {
     supabase: SupabaseClient
@@ -12,6 +14,8 @@ export interface GraphQLContext {
     role: UserRole | null
     attendanceLoader: DataLoader<string, EventAttendance | null>
     photosLoader: DataLoader<string, EventPhoto[]>
+    artistEventsLoader: DataLoader<string, ArtistEvent[]>
+    venueEventsLoader: DataLoader<string, VenueEvent[]>
 }
 
 export async function createGraphQLContext(): Promise<GraphQLContext> {
@@ -44,5 +48,24 @@ export async function createGraphQLContext(): Promise<GraphQLContext> {
         return getEventPhotosBatch(keys)
     })
 
-    return { supabase, userId, role, attendanceLoader, photosLoader }
+    // `Artist.events` y `Venue.events` quedaron fuera del pase de DataLoader
+    // del commit fbf4b23. Sin batchear, pedir `events` sobre las queries de
+    // listado (que no paginan) dispara un select anidado por fila.
+    const artistEventsLoader = new DataLoader<string, ArtistEvent[]>(async (keys) => {
+        return getArtistEventsBatch(keys)
+    })
+
+    const venueEventsLoader = new DataLoader<string, VenueEvent[]>(async (keys) => {
+        return getVenueEventsBatch(keys)
+    })
+
+    return {
+        supabase,
+        userId,
+        role,
+        attendanceLoader,
+        photosLoader,
+        artistEventsLoader,
+        venueEventsLoader,
+    }
 }

--- a/src/graphql/context.ts
+++ b/src/graphql/context.ts
@@ -2,11 +2,16 @@ import type { SupabaseClient } from '@supabase/supabase-js'
 import { createClient } from '@/src/core/lib/supabase/server'
 import { getCurrentUserId } from '@/src/core/auth/session'
 import type { UserRole } from '@/src/core/types'
+import DataLoader from 'dataloader'
+import { getAttendanceForEventsBatch, type EventAttendance } from '@/src/domains/events/attendance-data'
+import { getEventPhotosBatch, type EventPhoto } from '@/src/domains/events/photo-actions'
 
 export interface GraphQLContext {
     supabase: SupabaseClient
     userId: string | null
     role: UserRole | null
+    attendanceLoader: DataLoader<string, EventAttendance | null>
+    photosLoader: DataLoader<string, EventPhoto[]>
 }
 
 export async function createGraphQLContext(): Promise<GraphQLContext> {
@@ -30,5 +35,14 @@ export async function createGraphQLContext(): Promise<GraphQLContext> {
         }
     }
 
-    return { supabase, userId, role }
+    const attendanceLoader = new DataLoader<string, EventAttendance | null>(async (keys) => {
+        if (!userId) return keys.map(() => null)
+        return getAttendanceForEventsBatch(keys, userId)
+    })
+
+    const photosLoader = new DataLoader<string, EventPhoto[]>(async (keys) => {
+        return getEventPhotosBatch(keys)
+    })
+
+    return { supabase, userId, role, attendanceLoader, photosLoader }
 }

--- a/src/graphql/events.test.ts
+++ b/src/graphql/events.test.ts
@@ -43,7 +43,7 @@ vi.mock('@/src/core/auth/session', () => ({
 
 import { getEvents, getEventsWithAttendance, getEventById } from '@/src/domains/events/data'
 import { getAttendanceForEvent, getAttendanceForEventsBatch } from '@/src/domains/events/attendance-data'
-import { getEventPhotos, getEventPhotosBatch, deleteEventPhoto } from '@/src/domains/events/photo-actions'
+import { getEventPhotosBatch, deleteEventPhoto } from '@/src/domains/events/photo-actions'
 import { insertEvent, modifyEvent, removeEvent, addExternalEvent } from '@/src/domains/events/service'
 import { getOrCreateAttendance, setAttendanceStatus, saveMemory } from '@/src/domains/events/attendance-actions'
 import { POST } from '@/app/api/graphql/route'
@@ -79,18 +79,22 @@ describe('events GraphQL schema', () => {
   it('resolves the plain events query with venue and lineup, no attendance call at all', async () => {
     vi.mocked(getEvents).mockResolvedValue([event])
 
-    const body = await query('{ events { id name venue { name city } lineups { artist { name } isHeadliner } } }')
+    const body = await query('{ events { edges { node { id name venue { name city } lineups { artist { name } isHeadliner } } } } }')
 
     expect(body.errors).toBeUndefined()
     expect(body.data).toEqual({
-      events: [
-        {
-          id: 'e1',
-          name: 'Show en Niceto',
-          venue: { name: 'Niceto', city: 'CABA' },
-          lineups: [{ artist: { name: 'Bandalos Chinos' }, isHeadliner: true }],
-        },
-      ],
+      events: {
+        edges: [
+          {
+            node: {
+              id: 'e1',
+              name: 'Show en Niceto',
+              venue: { name: 'Niceto', city: 'CABA' },
+              lineups: [{ artist: { name: 'Bandalos Chinos' }, isHeadliner: true }],
+            }
+          }
+        ]
+      },
     })
     expect(getAttendanceForEvent).not.toHaveBeenCalled()
   })
@@ -115,11 +119,17 @@ describe('events GraphQL schema', () => {
       },
     ])
 
-    const body = await query('{ eventsWithAttendance { id attendance { status rating } } }')
+    const body = await query('{ eventsWithAttendance { edges { node { id attendance { status rating } } } } }')
 
     expect(body.errors).toBeUndefined()
     expect(body.data).toEqual({
-      eventsWithAttendance: [{ id: 'e1', attendance: [{ status: 'went', rating: 5 }] }],
+      eventsWithAttendance: {
+        edges: [
+          {
+            node: { id: 'e1', attendance: [{ status: 'went', rating: 5 }] }
+          }
+        ]
+      },
     })
     expect(getAttendanceForEvent).not.toHaveBeenCalled()
   })
@@ -181,10 +191,18 @@ describe('events GraphQL schema', () => {
       { id: 'e2', name: null, date: '2026-04-01', venue_id: null, venues: null, lineups: null },
     ])
 
-    const body = await query('{ events { id name venue { name } lineups { artist { name } } } }')
+    const body = await query('{ events { edges { node { id name venue { name } lineups { artist { name } } } } } }')
 
     expect(body.errors).toBeUndefined()
-    expect(body.data).toEqual({ events: [{ id: 'e2', name: null, venue: null, lineups: [] }] })
+    expect(body.data).toEqual({
+      events: {
+        edges: [
+          {
+            node: { id: 'e2', name: null, venue: null, lineups: [] }
+          }
+        ]
+      }
+    })
   })
 })
 

--- a/src/graphql/events.test.ts
+++ b/src/graphql/events.test.ts
@@ -9,10 +9,12 @@ vi.mock('@/src/domains/events/data', () => ({
 
 vi.mock('@/src/domains/events/attendance-data', () => ({
   getAttendanceForEvent: vi.fn(),
+  getAttendanceForEventsBatch: vi.fn(),
 }))
 
 vi.mock('@/src/domains/events/photo-actions', () => ({
   getEventPhotos: vi.fn(),
+  getEventPhotosBatch: vi.fn(),
   deleteEventPhoto: vi.fn(),
 }))
 
@@ -30,16 +32,18 @@ vi.mock('@/src/domains/events/attendance-actions', () => ({
 }))
 
 vi.mock('@/src/core/lib/supabase/server', () => ({
-  createClient: vi.fn().mockResolvedValue({}),
+  createClient: vi.fn().mockResolvedValue({
+    rpc: vi.fn().mockResolvedValue({ data: 'usuario', error: null })
+  }),
 }))
 
 vi.mock('@/src/core/auth/session', () => ({
-  getCurrentUserId: vi.fn().mockResolvedValue(null),
+  getCurrentUserId: vi.fn().mockResolvedValue('u1'),
 }))
 
 import { getEvents, getEventsWithAttendance, getEventById } from '@/src/domains/events/data'
-import { getAttendanceForEvent } from '@/src/domains/events/attendance-data'
-import { getEventPhotos, deleteEventPhoto } from '@/src/domains/events/photo-actions'
+import { getAttendanceForEvent, getAttendanceForEventsBatch } from '@/src/domains/events/attendance-data'
+import { getEventPhotos, getEventPhotosBatch, deleteEventPhoto } from '@/src/domains/events/photo-actions'
 import { insertEvent, modifyEvent, removeEvent, addExternalEvent } from '@/src/domains/events/service'
 import { getOrCreateAttendance, setAttendanceStatus, saveMemory } from '@/src/domains/events/attendance-actions'
 import { POST } from '@/app/api/graphql/route'
@@ -120,18 +124,18 @@ describe('events GraphQL schema', () => {
     expect(getAttendanceForEvent).not.toHaveBeenCalled()
   })
 
-  it('resolves myAttendance and photos on a single event via their own per-event query', async () => {
+  it('resolves myAttendance and photos on a single event via the DataLoader batched queries', async () => {
     vi.mocked(getEventById).mockResolvedValue(event)
-    vi.mocked(getAttendanceForEvent).mockResolvedValue({
+    vi.mocked(getAttendanceForEventsBatch).mockResolvedValue([{
       id: 'att1',
       status: 'went',
       rating: 5,
       review: 'Buenísimo',
       notes: null,
-    })
-    vi.mocked(getEventPhotos).mockResolvedValue([
+    }])
+    vi.mocked(getEventPhotosBatch).mockResolvedValue([[
       { id: 'ph1', event_id: 'e1', storage_path: 'x.jpg', caption: 'Foto 1', created_at: '2026-03-02', url: 'https://x/x.jpg' },
-    ])
+    ]])
 
     const body = await query(`{
       event(id: "e1") {
@@ -149,8 +153,8 @@ describe('events GraphQL schema', () => {
         photos: [{ id: 'ph1', caption: 'Foto 1', url: 'https://x/x.jpg' }],
       },
     })
-    expect(getAttendanceForEvent).toHaveBeenCalledWith('e1')
-    expect(getEventPhotos).toHaveBeenCalledWith('e1')
+    expect(getAttendanceForEventsBatch).toHaveBeenCalledWith(['e1'], 'u1')
+    expect(getEventPhotosBatch).toHaveBeenCalledWith(['e1'])
   })
 
   it('resolves event(id) as null when it does not exist', async () => {
@@ -164,7 +168,7 @@ describe('events GraphQL schema', () => {
 
   it('resolves myAttendance as null when the user has no attendance for that event', async () => {
     vi.mocked(getEventById).mockResolvedValue(event)
-    vi.mocked(getAttendanceForEvent).mockResolvedValue(null)
+    vi.mocked(getAttendanceForEventsBatch).mockResolvedValue([null])
 
     const body = await query('{ event(id: "e1") { myAttendance { status } } }')
 
@@ -292,6 +296,8 @@ describe('events GraphQL mutations', () => {
   })
 
   it('returns null from getOrCreateAttendance when there is no session', async () => {
+    const { getCurrentUserId } = await import('@/src/core/auth/session')
+    vi.mocked(getCurrentUserId).mockResolvedValueOnce(null)
     vi.mocked(getOrCreateAttendance).mockResolvedValue(null)
 
     const body = await query('mutation { getOrCreateAttendance(eventId: "e1") { id } }')

--- a/src/graphql/events.ts
+++ b/src/graphql/events.ts
@@ -1,8 +1,8 @@
 import { builder } from './builder'
+import { resolveOffsetConnection } from '@pothos/plugin-relay'
 import { getEvents, getEventsWithAttendance, getEventById } from '@/src/domains/events/data'
 import type { EventWithAttendance } from '@/src/domains/events/data'
-import { getAttendanceForEvent } from '@/src/domains/events/attendance-data'
-import { getEventPhotos, deleteEventPhoto } from '@/src/domains/events/photo-actions'
+import { deleteEventPhoto } from '@/src/domains/events/photo-actions'
 import { insertEvent, modifyEvent, removeEvent, addExternalEvent } from '@/src/domains/events/service'
 import { getOrCreateAttendance, setAttendanceStatus, saveMemory } from '@/src/domains/events/attendance-actions'
 import type { EventWithRelations, LineupRow } from '@/src/core/types'
@@ -124,18 +124,24 @@ EventRef.implement({
 })
 
 builder.queryField('events', (t) =>
-    t.field({
-        type: [EventRef],
+    t.connection({
+        type: EventRef,
         description: 'Catálogo compartido de eventos, sin attendance.',
-        resolve: () => getEvents(),
+        resolve: (_root, args) =>
+            resolveOffsetConnection({ args }, ({ limit, offset }) =>
+                getEvents({ limit, offset })
+            ),
     })
 )
 
 builder.queryField('eventsWithAttendance', (t) =>
-    t.field({
-        type: [EventRef],
+    t.connection({
+        type: EventRef,
         description: 'Eventos con la attendance del usuario actual ya incluida (batch, sin N+1).',
-        resolve: () => getEventsWithAttendance(),
+        resolve: (_root, args) =>
+            resolveOffsetConnection({ args }, ({ limit, offset }) =>
+                getEventsWithAttendance({ limit, offset })
+            ),
     })
 )
 

--- a/src/graphql/events.ts
+++ b/src/graphql/events.ts
@@ -111,12 +111,12 @@ EventRef.implement({
         myAttendance: t.field({
             type: EventAttendanceRef,
             nullable: true,
-            resolve: (e) => getAttendanceForEvent(e.id),
+            resolve: (e, args, context) => context.attendanceLoader.load(e.id),
         }),
         photos: t.field({
             type: [EventPhotoRef],
-            resolve: (e) =>
-                getEventPhotos(e.id).then((photos) =>
+            resolve: (e, args, context) =>
+                context.photosLoader.load(e.id).then((photos) =>
                     photos.map((p) => ({ id: p.id, caption: p.caption, createdAt: p.created_at, url: p.url }))
                 ),
         }),

--- a/src/graphql/moderation.test.ts
+++ b/src/graphql/moderation.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@/src/domains/moderation/service', () => ({
+  getUnverifiedArtists: vi.fn(),
+  getUnverifiedVenues: vi.fn(),
+  getUnverifiedEvents: vi.fn(),
+  searchMergeTargets: vi.fn(),
+  approveArtist: vi.fn(),
+  approveVenue: vi.fn(),
+  approveEvent: vi.fn(),
+  mergeArtists: vi.fn(),
+  mergeVenues: vi.fn(),
+  mergeEvents: vi.fn(),
+}))
+
+const mocks = vi.hoisted(() => ({
+  rpc: vi.fn().mockResolvedValue({ data: 'usuario', error: null }),
+}))
+
+vi.mock('@/src/core/lib/supabase/server', () => ({
+  createClient: vi.fn().mockResolvedValue({ rpc: mocks.rpc }),
+}))
+
+vi.mock('@/src/core/auth/session', () => ({
+  getCurrentUserId: vi.fn().mockResolvedValue('u-1'),
+}))
+
+import {
+  getUnverifiedArtists,
+  searchMergeTargets,
+  approveArtist,
+  mergeArtists,
+} from '@/src/domains/moderation/service'
+import { getCurrentUserId } from '@/src/core/auth/session'
+import { POST } from '@/app/api/graphql/route'
+
+async function query(source: string) {
+  const response = await POST(
+    new Request('http://localhost/api/graphql', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query: source }),
+    })
+  )
+  return response.json()
+}
+
+function actAs(role: 'admin' | 'moderador' | 'usuario') {
+  mocks.rpc.mockResolvedValue({ data: role, error: null })
+}
+
+describe('moderation GraphQL schema', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getCurrentUserId).mockResolvedValue('u-1')
+    actAs('usuario')
+  })
+
+  // Las aserciones miran que el resolver corte y que la capa de servicio nunca
+  // se invoque, no el texto del mensaje: yoga sólo deja pasar sin enmascarar
+  // los GraphQLError que reconoce con `instanceof`, y bajo vitest el `graphql`
+  // que resuelve el archivo fuente no es la misma instancia de módulo que la
+  // que importa yoga desde node_modules, así que acá el mensaje siempre llega
+  // como "Unexpected error." aunque en un build real de Next.js no lo haga.
+  // Mismo enmascarado que ya documenta expenses.test.ts.
+  describe('role guard', () => {
+    it('rejects a plain usuario', async () => {
+      const body = await query('{ unverifiedArtists { id } }')
+
+      expect(body.errors).toHaveLength(1)
+      expect(getUnverifiedArtists).not.toHaveBeenCalled()
+    })
+
+    it('rejects an anonymous caller', async () => {
+      vi.mocked(getCurrentUserId).mockResolvedValue(null)
+
+      const body = await query('{ unverifiedArtists { id } }')
+
+      expect(body.errors).toHaveLength(1)
+      expect(getUnverifiedArtists).not.toHaveBeenCalled()
+    })
+
+    it.each(['admin', 'moderador'] as const)('lets %s through', async (role) => {
+      actAs(role)
+      vi.mocked(getUnverifiedArtists).mockResolvedValue([])
+
+      const body = await query('{ unverifiedArtists { id } }')
+
+      expect(body.errors).toBeUndefined()
+      expect(getUnverifiedArtists).toHaveBeenCalled()
+    })
+
+    it('guards mergeTargets too, not just the queue', async () => {
+      const body = await query('{ mergeTargets(entityType: artists, query: "x") { id } }')
+
+      expect(body.errors).toHaveLength(1)
+      expect(searchMergeTargets).not.toHaveBeenCalled()
+    })
+
+    it('guards the mutations', async () => {
+      const body = await query('mutation { approveArtist(id: "a-1") { success } }')
+
+      expect(body.errors).toHaveLength(1)
+      expect(approveArtist).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('mergeTargets', () => {
+    beforeEach(() => {
+      actAs('moderador')
+    })
+
+    it('forwards the entity type, term and exclusion to the service', async () => {
+      vi.mocked(searchMergeTargets).mockResolvedValue([])
+
+      await query('{ mergeTargets(entityType: venues, query: "river", excludeId: "v-9") { id } }')
+
+      expect(searchMergeTargets).toHaveBeenCalledWith('venues', 'river', 'v-9')
+    })
+
+    it('passes undefined when no exclusion is given', async () => {
+      vi.mocked(searchMergeTargets).mockResolvedValue([])
+
+      await query('{ mergeTargets(entityType: artists, query: "radio") { id } }')
+
+      expect(searchMergeTargets).toHaveBeenCalledWith('artists', 'radio', undefined)
+    })
+
+    it('exposes id, name and detail', async () => {
+      vi.mocked(searchMergeTargets).mockResolvedValue([
+        { id: 'a-1', name: 'Radiohead', detail: 'rock' },
+      ])
+
+      const body = await query('{ mergeTargets(entityType: artists, query: "radio") { id name detail } }')
+
+      expect(body.errors).toBeUndefined()
+      expect(body.data).toEqual({
+        mergeTargets: [{ id: 'a-1', name: 'Radiohead', detail: 'rock' }],
+      })
+    })
+  })
+
+  describe('mutation results', () => {
+    beforeEach(() => {
+      actAs('moderador')
+    })
+
+    it('reports success when the approval goes through', async () => {
+      vi.mocked(approveArtist).mockResolvedValue(undefined)
+
+      const body = await query('mutation { approveArtist(id: "a-1") { success error } }')
+
+      expect(body.data).toEqual({ approveArtist: { success: true, error: null } })
+    })
+
+    it('reports failure with the message when the RPC rejects the caller', async () => {
+      vi.mocked(approveArtist).mockRejectedValue(new Error('insufficient_privilege'))
+
+      const body = await query('mutation { approveArtist(id: "a-1") { success error } }')
+
+      expect(body.data).toEqual({
+        approveArtist: { success: false, error: 'insufficient_privilege' },
+      })
+    })
+
+    it('reports failure when a merge rejects', async () => {
+      vi.mocked(mergeArtists).mockRejectedValue(new Error('insufficient_privilege'))
+
+      const body = await query(
+        'mutation { mergeArtists(sourceId: "a-1", targetId: "a-2") { success error } }'
+      )
+
+      expect(body.data).toEqual({
+        mergeArtists: { success: false, error: 'insufficient_privilege' },
+      })
+    })
+  })
+})

--- a/src/graphql/moderation.ts
+++ b/src/graphql/moderation.ts
@@ -1,0 +1,213 @@
+import { GraphQLError } from 'graphql'
+import { builder } from './builder'
+import { ArtistRef } from './artists'
+import { VenueRef } from './venues'
+import { EventRef } from './events'
+import { MutationResultRef, toMutationResult } from './shared'
+import type { GraphQLContext } from './context'
+import {
+    getUnverifiedArtists,
+    getUnverifiedVenues,
+    getUnverifiedEvents,
+    searchMergeTargets,
+    approveArtist,
+    approveVenue,
+    approveEvent,
+    mergeArtists,
+    mergeVenues,
+    mergeEvents,
+    type MergeTarget,
+} from '@/src/domains/moderation/service'
+
+/**
+ * Se tira GraphQLError y no Error a secas: yoga enmascara cualquier throw que
+ * no sea GraphQLError como "Unexpected error.", y una denegación de permisos
+ * es accionable por el cliente, no una falla interna. Sin esto la UI de
+ * moderación no puede distinguir "no tenés permiso" de "se rompió el server".
+ */
+function requireModerator(context: GraphQLContext) {
+    if (context.role !== 'admin' && context.role !== 'moderador') {
+        throw new GraphQLError('Unauthorized', { extensions: { code: 'FORBIDDEN' } })
+    }
+}
+
+/**
+ * Un solo field con arg de tipo en vez de tres (`mergeArtistTargets`, …): las
+ * tres pantallas de moderación consumen el mismo combobox con la misma forma
+ * de resultado, así que separarlos multiplicaría el schema sin que el cliente
+ * gane nada. Los `unverified*` sí van separados porque cada uno devuelve un
+ * tipo de entidad distinto.
+ */
+export const ModeratedEntityEnum = builder.enumType('ModeratedEntity', {
+    values: ['artists', 'venues', 'events'] as const,
+})
+
+const MergeTargetRef = builder.objectRef<MergeTarget>('MergeTarget')
+MergeTargetRef.implement({
+    fields: (t) => ({
+        id: t.exposeID('id'),
+        name: t.exposeString('name'),
+        detail: t.exposeString('detail', { nullable: true }),
+    }),
+})
+
+builder.queryField('unverifiedArtists', (t) =>
+    t.field({
+        type: [ArtistRef],
+        resolve: async (_root, _args, context) => {
+            requireModerator(context)
+            return getUnverifiedArtists()
+        },
+    })
+)
+
+builder.queryField('unverifiedVenues', (t) =>
+    t.field({
+        type: [VenueRef],
+        resolve: async (_root, _args, context) => {
+            requireModerator(context)
+            return getUnverifiedVenues()
+        },
+    })
+)
+
+builder.queryField('unverifiedEvents', (t) =>
+    t.field({
+        type: [EventRef],
+        resolve: async (_root, _args, context) => {
+            requireModerator(context)
+            return getUnverifiedEvents()
+        },
+    })
+)
+
+builder.queryField('mergeTargets', (t) =>
+    t.field({
+        type: [MergeTargetRef],
+        description: 'Entidades verificadas que pueden recibir una fusión, buscadas por nombre.',
+        args: {
+            entityType: t.arg({ type: ModeratedEntityEnum, required: true }),
+            query: t.arg.string({ required: true }),
+            excludeId: t.arg.id(),
+        },
+        resolve: async (_root, args, context) => {
+            requireModerator(context)
+            return searchMergeTargets(
+                args.entityType,
+                args.query,
+                args.excludeId ? String(args.excludeId) : undefined
+            )
+        },
+    })
+)
+
+builder.mutationField('approveArtist', (t) =>
+    t.field({
+        type: MutationResultRef,
+        args: {
+            id: t.arg.id({ required: true }),
+        },
+        resolve: async (_root, args, context) => {
+            requireModerator(context)
+            try {
+                await approveArtist(String(args.id))
+                return toMutationResult({})
+            } catch (error) {
+                return toMutationResult({ error: (error as Error).message })
+            }
+        },
+    })
+)
+
+builder.mutationField('approveVenue', (t) =>
+    t.field({
+        type: MutationResultRef,
+        args: {
+            id: t.arg.id({ required: true }),
+        },
+        resolve: async (_root, args, context) => {
+            requireModerator(context)
+            try {
+                await approveVenue(String(args.id))
+                return toMutationResult({})
+            } catch (error) {
+                return toMutationResult({ error: (error as Error).message })
+            }
+        },
+    })
+)
+
+builder.mutationField('approveEvent', (t) =>
+    t.field({
+        type: MutationResultRef,
+        args: {
+            id: t.arg.id({ required: true }),
+        },
+        resolve: async (_root, args, context) => {
+            requireModerator(context)
+            try {
+                await approveEvent(String(args.id))
+                return toMutationResult({})
+            } catch (error) {
+                return toMutationResult({ error: (error as Error).message })
+            }
+        },
+    })
+)
+
+builder.mutationField('mergeArtists', (t) =>
+    t.field({
+        type: MutationResultRef,
+        args: {
+            sourceId: t.arg.id({ required: true }),
+            targetId: t.arg.id({ required: true }),
+        },
+        resolve: async (_root, args, context) => {
+            requireModerator(context)
+            try {
+                await mergeArtists(String(args.sourceId), String(args.targetId))
+                return toMutationResult({})
+            } catch (error) {
+                return toMutationResult({ error: (error as Error).message })
+            }
+        },
+    })
+)
+
+builder.mutationField('mergeVenues', (t) =>
+    t.field({
+        type: MutationResultRef,
+        args: {
+            sourceId: t.arg.id({ required: true }),
+            targetId: t.arg.id({ required: true }),
+        },
+        resolve: async (_root, args, context) => {
+            requireModerator(context)
+            try {
+                await mergeVenues(String(args.sourceId), String(args.targetId))
+                return toMutationResult({})
+            } catch (error) {
+                return toMutationResult({ error: (error as Error).message })
+            }
+        },
+    })
+)
+
+builder.mutationField('mergeEvents', (t) =>
+    t.field({
+        type: MutationResultRef,
+        args: {
+            sourceId: t.arg.id({ required: true }),
+            targetId: t.arg.id({ required: true }),
+        },
+        resolve: async (_root, args, context) => {
+            requireModerator(context)
+            try {
+                await mergeEvents(String(args.sourceId), String(args.targetId))
+                return toMutationResult({})
+            } catch (error) {
+                return toMutationResult({ error: (error as Error).message })
+            }
+        },
+    })
+)

--- a/src/graphql/provider.tsx
+++ b/src/graphql/provider.tsx
@@ -4,9 +4,10 @@ import { useMemo } from 'react'
 
 export function GraphQLProvider({ children }: { children: React.ReactNode }) {
   const [client, ssr] = useMemo(() => {
-    const ssr = ssrExchange()
+    const ssr = ssrExchange({ isClient: typeof window !== 'undefined' })
     const client = createClient({
       url: '/api/graphql',
+      suspense: true,
       exchanges: [cacheExchange, ssr, fetchExchange],
     })
     return [client, ssr]

--- a/src/graphql/schema.ts
+++ b/src/graphql/schema.ts
@@ -8,7 +8,8 @@ import './expenses'
 import './auth'
 import './stats'
 import './events'
-// Cada dominio nuevo se suma acá con su propio import de efecto lateral,
+import './moderation'
+// Cada dominio nuevo se suma aquí con su propio import de efecto lateral,
 // mismo patrón que health.ts — el archivo del dominio llama a
 // builder.queryField/mutationField y no exporta nada directamente.
 

--- a/src/graphql/venues.test.ts
+++ b/src/graphql/venues.test.ts
@@ -4,6 +4,7 @@ vi.mock('@/src/domains/venues/data', () => ({
   getVenues: vi.fn(),
   getVenueById: vi.fn(),
   getVenueEvents: vi.fn(),
+  getVenueEventsBatch: vi.fn(),
 }))
 
 vi.mock('@/src/domains/venues/service', () => ({
@@ -21,7 +22,7 @@ vi.mock('@/src/core/auth/session', () => ({
   getCurrentUserId: vi.fn().mockResolvedValue(null),
 }))
 
-import { getVenueEvents } from '@/src/domains/venues/data'
+import { getVenueEvents, getVenueEventsBatch } from '@/src/domains/venues/data'
 import {
   listVenues,
   findVenueById,
@@ -102,7 +103,7 @@ describe('venues GraphQL schema', () => {
         attendance: [{ status: 'went' }],
       },
     ])
-    expect(getVenueEvents).not.toHaveBeenCalled()
+    expect(getVenueEventsBatch).not.toHaveBeenCalled()
   })
 
   // La query de listado no trae la relacion, asi que el campo la carga bajo
@@ -111,15 +112,15 @@ describe('venues GraphQL schema', () => {
     vi.mocked(listVenues).mockResolvedValue([
       { id: 'v1', name: 'Niceto', city: null, country: null, address: null, lat: null, lng: null },
     ])
-    vi.mocked(getVenueEvents).mockResolvedValue([
+    vi.mocked(getVenueEventsBatch).mockResolvedValue([[
       { id: 'e1', name: 'Show', date: '2026-01-01', lineups: [], attendance: [] },
-    ])
+    ]])
 
     const body = await query('{ venues { id events { id } } }')
 
     expect(body.errors).toBeUndefined()
     expect(body.data).toEqual({ venues: [{ id: 'v1', events: [{ id: 'e1' }] }] })
-    expect(getVenueEvents).toHaveBeenCalledWith('v1')
+    expect(getVenueEventsBatch).toHaveBeenCalledWith(['v1'])
   })
 })
 

--- a/src/graphql/venues.ts
+++ b/src/graphql/venues.ts
@@ -56,7 +56,8 @@ VenueRef.implement({
         // real y no un array vacío silencioso.
         events: t.field({
             type: [VenueEventRef],
-            resolve: (venue) => ('events' in venue ? venue.events : getVenueEvents(venue.id)),
+            resolve: (venue, _args, context) =>
+                'events' in venue ? venue.events : context.venueEventsLoader.load(venue.id),
         }),
     }),
 })

--- a/src/graphql/venues.ts
+++ b/src/graphql/venues.ts
@@ -49,6 +49,7 @@ VenueRef.implement({
         country: t.exposeString('country', { nullable: true }),
         lat: t.exposeFloat('lat', { nullable: true }),
         lng: t.exposeFloat('lng', { nullable: true }),
+        status: t.exposeString('status', { nullable: true }),
         // `getVenues()` no trae la relación y `getVenueById()` sí, así que el
         // campo la carga bajo demanda solo cuando no vino ya resuelta — para
         // que pedir `events` desde la query de listado devuelva el historial

--- a/supabase/migrations/20260824000000_external_events_cache.sql
+++ b/supabase/migrations/20260824000000_external_events_cache.sql
@@ -7,6 +7,12 @@ CREATE TABLE external_events_cache (
     UNIQUE (source_id, dedup_key)
 );
 
+-- pg_trgm se habilita acá y no sólo en 20260824205500_performance_indexes.sql:
+-- esa migración es posterior, así que en un `supabase db reset` desde cero el
+-- índice de abajo fallaba con `operator class "gin_trgm_ops" does not exist` y
+-- cortaba toda la cadena de migraciones siguientes.
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
 CREATE INDEX external_events_cache_title_idx ON external_events_cache USING gin ((event_data->>'title') gin_trgm_ops);
 
 ALTER TABLE external_events_cache ENABLE ROW LEVEL SECURITY;

--- a/supabase/migrations/20260824202000_moderation_queue.sql
+++ b/supabase/migrations/20260824202000_moderation_queue.sql
@@ -1,0 +1,171 @@
+-- 1. Create Enum
+CREATE TYPE verification_status AS ENUM ('unverified', 'verified');
+
+-- 1.5 La columna `events.status` ya existía como `text default 'scheduled'`
+-- desde el dump inicial (20260216230841_remote_schema.sql), y ninguna
+-- migración la eliminó. Sin este drop, el ALTER de más abajo falla con
+-- `column "status" of relation "events" already exists` — y como es una sola
+-- sentencia, se cae también `events.created_by`, que el trigger de rate limit
+-- escribe en cada INSERT. Resultado: `supabase db reset` dejaba la base
+-- inutilizable.
+--
+-- Se puede dropear sin migrar datos: ningún archivo de `src/` ni de `app/`
+-- lee los valores 'scheduled'/'confirmed' de esa columna, y el `status` que
+-- expone `src/graphql/events.ts` pasa a ser el de verificación.
+ALTER TABLE events DROP COLUMN IF EXISTS status;
+
+-- 2. Add status and audit columns
+ALTER TABLE artists 
+  ADD COLUMN status verification_status DEFAULT 'unverified' NOT NULL,
+  ADD COLUMN created_by UUID REFERENCES auth.users(id) ON DELETE SET NULL;
+
+ALTER TABLE venues 
+  ADD COLUMN status verification_status DEFAULT 'unverified' NOT NULL,
+  ADD COLUMN created_by UUID REFERENCES auth.users(id) ON DELETE SET NULL;
+
+ALTER TABLE events 
+  ADD COLUMN status verification_status DEFAULT 'unverified' NOT NULL,
+  ADD COLUMN created_by UUID REFERENCES auth.users(id) ON DELETE SET NULL;
+
+-- 2.5 Rate Limiting & Auditing Trigger (Best Practice)
+-- Evita que un bot autenticado inunde la base de datos con spam
+CREATE OR REPLACE FUNCTION check_creation_rate_limit()
+RETURNS trigger 
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  recent_count INT;
+BEGIN
+  -- 1. Auto-asignar la autoría para auditoría (saber a quién banear si spamea)
+  NEW.created_by = auth.uid();
+
+  -- 2. Los admins y moderadores no tienen rate limit
+  IF public.get_user_role(auth.uid()) IN ('admin', 'moderador') THEN
+    RETURN NEW;
+  END IF;
+
+  -- 3. Contar cuántos registros creó este usuario en la última hora en la tabla actual
+  -- Usamos SQL dinámico para poder reusar este mismo trigger en venues, artists y events
+  EXECUTE format('SELECT count(*) FROM %I WHERE created_by = $1 AND created_at > now() - interval ''1 hour''', TG_TABLE_NAME)
+  INTO recent_count
+  USING auth.uid();
+
+  -- 4. Límite estricto: máximo 5 creaciones por hora por usuario
+  IF recent_count >= 5 THEN
+    RAISE EXCEPTION 'rate_limit_exceeded' USING HINT = 'Has alcanzado el límite máximo de creaciones por hora.';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+-- Aplicar el escudo a las 3 tablas de catálogo
+CREATE TRIGGER tr_artists_rate_limit
+  BEFORE INSERT ON artists
+  FOR EACH ROW EXECUTE FUNCTION check_creation_rate_limit();
+
+CREATE TRIGGER tr_venues_rate_limit
+  BEFORE INSERT ON venues
+  FOR EACH ROW EXECUTE FUNCTION check_creation_rate_limit();
+
+CREATE TRIGGER tr_events_rate_limit
+  BEFORE INSERT ON events
+  FOR EACH ROW EXECUTE FUNCTION check_creation_rate_limit();
+
+-- 3. Merge Artists RPC
+CREATE OR REPLACE FUNCTION merge_artists(source_id UUID, target_id UUID) 
+RETURNS void 
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  -- SEGURIDAD: Solo admins y moderadores pueden ejecutar esta fusión
+  IF public.get_user_role(auth.uid()) NOT IN ('admin', 'moderador') THEN
+    RAISE EXCEPTION 'insufficient_privilege' USING HINT = 'Only admins and moderators can merge entities';
+  END IF;
+
+  -- Reassign lineups, skipping if target already plays in that event
+  UPDATE lineups ea1
+  SET artist_id = target_id
+  WHERE artist_id = source_id
+    AND NOT EXISTS (
+      SELECT 1 FROM lineups ea2 WHERE ea2.artist_id = target_id AND ea2.event_id = ea1.event_id
+    );
+  DELETE FROM lineups WHERE artist_id = source_id;
+
+  -- Reassign wishlist, skipping if target is already in user's wishlist
+  UPDATE wishlist w1
+  SET artist_id = target_id
+  WHERE artist_id = source_id
+    AND NOT EXISTS (
+      SELECT 1 FROM wishlist w2 WHERE w2.artist_id = target_id AND w2.user_id = w1.user_id
+    );
+  DELETE FROM wishlist WHERE artist_id = source_id;
+
+  -- Delete the source artist
+  DELETE FROM artists WHERE id = source_id;
+END;
+$$;
+REVOKE EXECUTE ON FUNCTION merge_artists(UUID, UUID) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION merge_artists(UUID, UUID) TO authenticated;
+
+-- 4. Merge Venues RPC
+CREATE OR REPLACE FUNCTION merge_venues(source_id UUID, target_id UUID) 
+RETURNS void 
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  IF public.get_user_role(auth.uid()) NOT IN ('admin', 'moderador') THEN
+    RAISE EXCEPTION 'insufficient_privilege' USING HINT = 'Only admins and moderators can merge entities';
+  END IF;
+
+  -- Reassign events
+  UPDATE events SET venue_id = target_id WHERE venue_id = source_id;
+
+  -- Delete the source venue
+  DELETE FROM venues WHERE id = source_id;
+END;
+$$;
+REVOKE EXECUTE ON FUNCTION merge_venues(UUID, UUID) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION merge_venues(UUID, UUID) TO authenticated;
+
+-- 5. Merge Events RPC
+CREATE OR REPLACE FUNCTION merge_events(source_id UUID, target_id UUID) 
+RETURNS void 
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  IF public.get_user_role(auth.uid()) NOT IN ('admin', 'moderador') THEN
+    RAISE EXCEPTION 'insufficient_privilege' USING HINT = 'Only admins and moderators can merge entities';
+  END IF;
+
+  -- Reassign photos
+  UPDATE event_photos SET event_id = target_id WHERE event_id = source_id;
+
+  -- Reassign attendance, handling duplicates
+  UPDATE attendance a1
+  SET event_id = target_id
+  WHERE event_id = source_id
+    AND NOT EXISTS (
+      SELECT 1 FROM attendance a2 WHERE a2.event_id = target_id AND a2.user_id = a1.user_id
+    );
+  DELETE FROM attendance WHERE event_id = source_id;
+
+  -- Reassign lineups, handling duplicates
+  UPDATE lineups ea1
+  SET event_id = target_id
+  WHERE event_id = source_id
+    AND NOT EXISTS (
+      SELECT 1 FROM lineups ea2 WHERE ea2.event_id = target_id AND ea2.artist_id = ea1.artist_id
+    );
+  DELETE FROM lineups WHERE event_id = source_id;
+
+  -- Delete the source event
+  DELETE FROM events WHERE id = source_id;
+END;
+$$;
+REVOKE EXECUTE ON FUNCTION merge_events(UUID, UUID) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION merge_events(UUID, UUID) TO authenticated;

--- a/supabase/migrations/20260824205500_performance_indexes.sql
+++ b/supabase/migrations/20260824205500_performance_indexes.sql
@@ -1,0 +1,11 @@
+-- 1. B-Tree Indexes para escaneos y ordenamiento frecuente
+CREATE INDEX IF NOT EXISTS events_date_idx ON public.events (date DESC);
+CREATE INDEX IF NOT EXISTS event_photos_event_id_idx ON public.event_photos (event_id);
+
+-- 2. Habilitar extensión pg_trgm si no existe (requerido para gin_trgm_ops)
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- 3. GIN Trigram Indexes para optimizar las búsquedas de texto (ILIKE) en el catálogo
+CREATE INDEX IF NOT EXISTS events_name_trgm_idx ON public.events USING gin (name gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS artists_name_trgm_idx ON public.artists USING gin (name gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS venues_name_trgm_idx ON public.venues USING gin (name gin_trgm_ops);

--- a/supabase/migrations/20260824205600_expenses_aggregations.sql
+++ b/supabase/migrations/20260824205600_expenses_aggregations.sql
@@ -1,0 +1,91 @@
+-- RPC for getExpensesSummary
+CREATE OR REPLACE FUNCTION get_expenses_summary(user_uuid uuid)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  result json;
+BEGIN
+  SELECT json_build_object(
+    'total', COALESCE(SUM(amount), 0),
+    'count', COUNT(*),
+    'byCategory', COALESCE((
+      SELECT json_object_agg(category, cat_total)
+      FROM (
+        SELECT COALESCE(category, 'Otro') as category, SUM(amount) as cat_total
+        FROM expenses
+        WHERE user_id = user_uuid
+        GROUP BY COALESCE(category, 'Otro')
+      ) sub
+    ), '{}'::json),
+    'byYear', COALESCE((
+      SELECT json_object_agg(year_str, year_total)
+      FROM (
+        SELECT EXTRACT(YEAR FROM date)::text as year_str, SUM(amount) as year_total
+        FROM expenses
+        WHERE user_id = user_uuid
+        GROUP BY EXTRACT(YEAR FROM date)::text
+      ) sub2
+    ), '{}'::json)
+  ) INTO result
+  FROM expenses
+  WHERE user_id = user_uuid;
+  
+  RETURN result;
+END;
+$$;
+
+-- RPC for getVenueArtistSpendEstimate
+CREATE OR REPLACE FUNCTION get_venue_artist_spend_estimate(
+  p_user_id uuid,
+  p_venue_id uuid,
+  p_artist_ids uuid[],
+  p_exclude_event_id uuid
+)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  result json;
+  v_average numeric;
+  v_count integer;
+BEGIN
+  WITH matching_events AS (
+    SELECT id as event_id
+    FROM events
+    WHERE p_venue_id IS NOT NULL 
+      AND venue_id = p_venue_id
+      AND id != p_exclude_event_id
+    UNION
+    SELECT event_id
+    FROM lineups
+    WHERE p_artist_ids IS NOT NULL 
+      AND cardinality(p_artist_ids) > 0
+      AND artist_id = ANY(p_artist_ids)
+      AND event_id != p_exclude_event_id
+  ),
+  event_totals AS (
+    SELECT e.event_id, SUM(ex.amount) as total_amount
+    FROM matching_events e
+    JOIN expenses ex ON ex.event_id = e.event_id
+    WHERE ex.user_id = p_user_id
+    GROUP BY e.event_id
+  )
+  SELECT 
+    AVG(total_amount),
+    COUNT(*)
+  INTO v_average, v_count
+  FROM event_totals;
+
+  IF v_count = 0 OR v_count IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  RETURN json_build_object(
+    'averageTotal', v_average,
+    'eventsConsidered', v_count
+  );
+END;
+$$;

--- a/supabase/migrations/20260825060000_moderation_approve_and_status_guard.sql
+++ b/supabase/migrations/20260825060000_moderation_approve_and_status_guard.sql
@@ -1,0 +1,186 @@
+-- Cierra el camino de aprobación de la cola de moderación.
+--
+-- Antes de esto, approveArtist/Venue/Event hacían un UPDATE directo con el
+-- cliente de @supabase/ssr, que corre con el JWT del usuario:
+--
+--   * `artists` y `venues` no tienen ninguna policy de UPDATE, así que RLS
+--     denegaba. PostgREST responde a un UPDATE bloqueado por RLS afectando 0
+--     filas y devolviendo error null, no un error — la aprobación fallaba en
+--     silencio y el resolver reportaba success.
+--   * `events` sí tiene "Allow update events" con `using (true)`, necesaria
+--     para la edición legítima de recitales, así que ahí el UPDATE pasaba y
+--     cualquier autenticado podía auto-aprobarse un evento pegándole directo a
+--     PostgREST, salteando el guard de rol de GraphQL.
+
+-- ─── 1. Chequeo de rol NULL-safe, compartido ────────────────────────────────
+-- get_user_role() devuelve NULL cuando el usuario no tiene fila en profiles.
+-- `NULL IN ('admin','moderador')` es NULL, y `IF NULL THEN` es falsy en
+-- plpgsql, así que un chequeo escrito como `IF get_user_role(...) NOT IN (...)`
+-- se saltea y deja pasar la operación. Es el mismo trap que ya documenta
+-- assign_user_role() en 20260823202400_user_roles.sql, resuelto una sola vez
+-- acá para que los merge, el approve y el trigger compartan la misma semántica.
+
+CREATE OR REPLACE FUNCTION public.is_moderator()
+RETURNS boolean
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+STABLE
+AS $$
+  SELECT coalesce(public.get_user_role(auth.uid()) IN ('admin', 'moderador'), false);
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.is_moderator() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.is_moderator() TO authenticated;
+
+-- ─── 2. Los merge existentes pasan al chequeo NULL-safe ─────────────────────
+-- Sólo cambia la guarda de privilegio; el cuerpo de cada fusión queda igual
+-- que en 20260824202000_moderation_queue.sql.
+
+CREATE OR REPLACE FUNCTION merge_artists(source_id UUID, target_id UUID)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF NOT public.is_moderator() THEN
+    RAISE EXCEPTION 'insufficient_privilege' USING HINT = 'Only admins and moderators can merge entities';
+  END IF;
+
+  UPDATE lineups ea1
+  SET artist_id = target_id
+  WHERE artist_id = source_id
+    AND NOT EXISTS (
+      SELECT 1 FROM lineups ea2 WHERE ea2.artist_id = target_id AND ea2.event_id = ea1.event_id
+    );
+  DELETE FROM lineups WHERE artist_id = source_id;
+
+  UPDATE wishlist w1
+  SET artist_id = target_id
+  WHERE artist_id = source_id
+    AND NOT EXISTS (
+      SELECT 1 FROM wishlist w2 WHERE w2.artist_id = target_id AND w2.user_id = w1.user_id
+    );
+  DELETE FROM wishlist WHERE artist_id = source_id;
+
+  DELETE FROM artists WHERE id = source_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION merge_venues(source_id UUID, target_id UUID)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF NOT public.is_moderator() THEN
+    RAISE EXCEPTION 'insufficient_privilege' USING HINT = 'Only admins and moderators can merge entities';
+  END IF;
+
+  UPDATE events SET venue_id = target_id WHERE venue_id = source_id;
+
+  DELETE FROM venues WHERE id = source_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION merge_events(source_id UUID, target_id UUID)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF NOT public.is_moderator() THEN
+    RAISE EXCEPTION 'insufficient_privilege' USING HINT = 'Only admins and moderators can merge entities';
+  END IF;
+
+  UPDATE event_photos SET event_id = target_id WHERE event_id = source_id;
+
+  UPDATE attendance a1
+  SET event_id = target_id
+  WHERE event_id = source_id
+    AND NOT EXISTS (
+      SELECT 1 FROM attendance a2 WHERE a2.event_id = target_id AND a2.user_id = a1.user_id
+    );
+  DELETE FROM attendance WHERE event_id = source_id;
+
+  UPDATE lineups ea1
+  SET event_id = target_id
+  WHERE event_id = source_id
+    AND NOT EXISTS (
+      SELECT 1 FROM lineups ea2 WHERE ea2.event_id = target_id AND ea2.artist_id = ea1.artist_id
+    );
+  DELETE FROM lineups WHERE event_id = source_id;
+
+  DELETE FROM events WHERE id = source_id;
+END;
+$$;
+
+-- ─── 3. Aprobación por RPC ──────────────────────────────────────────────────
+-- SECURITY DEFINER para que la aprobación no dependa de una policy de UPDATE
+-- por tabla, igual que los merge. El whitelist de entity_type corre antes del
+-- format() y no después: format(%I) escapa el identificador, pero la lista
+-- explícita es la que garantiza que sólo se puedan tocar esas tres tablas.
+
+CREATE OR REPLACE FUNCTION public.approve_entity(entity_type text, entity_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF NOT public.is_moderator() THEN
+    RAISE EXCEPTION 'insufficient_privilege' USING HINT = 'Only admins and moderators can approve entities';
+  END IF;
+
+  IF entity_type NOT IN ('artists', 'venues', 'events') THEN
+    RAISE EXCEPTION 'invalid_entity_type' USING HINT = 'entity_type must be one of artists, venues, events';
+  END IF;
+
+  EXECUTE format('UPDATE public.%I SET status = %L WHERE id = $1', entity_type, 'verified')
+  USING entity_id;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.approve_entity(text, uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.approve_entity(text, uuid) TO authenticated;
+
+-- ─── 4. Guard de transiciones de status ─────────────────────────────────────
+-- "Allow update events" no se puede arreglar desde la policy: en una policy de
+-- UPDATE, USING ve la fila vieja y WITH CHECK la nueva, y no hay forma de
+-- correlacionarlas para escribir "permitido salvo que cambie status". El
+-- trigger es el único mecanismo que ve OLD y NEW juntos. Se aplica a las tres
+-- tablas por simetría, aunque hoy sólo events tenga policy de UPDATE: si
+-- mañana se agrega una para artists o venues, la protección ya está puesta.
+--
+-- Es BEFORE UPDATE únicamente. Las altas que nacen verificadas desde los
+-- adapters son INSERT, así que no las toca.
+
+CREATE OR REPLACE FUNCTION public.enforce_status_change_privilege()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF NEW.status IS DISTINCT FROM OLD.status AND NOT public.is_moderator() THEN
+    RAISE EXCEPTION 'insufficient_privilege' USING HINT = 'Only admins and moderators can change verification status';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER tr_artists_status_guard
+  BEFORE UPDATE ON artists
+  FOR EACH ROW EXECUTE FUNCTION public.enforce_status_change_privilege();
+
+CREATE TRIGGER tr_venues_status_guard
+  BEFORE UPDATE ON venues
+  FOR EACH ROW EXECUTE FUNCTION public.enforce_status_change_privilege();
+
+CREATE TRIGGER tr_events_status_guard
+  BEFORE UPDATE ON events
+  FOR EACH ROW EXECUTE FUNCTION public.enforce_status_change_privilege();

--- a/supabase/migrations/20260826000000_table_grants.sql
+++ b/supabase/migrations/20260826000000_table_grants.sql
@@ -1,0 +1,52 @@
+-- Privilegios de tabla para los roles de PostgREST.
+--
+-- Ninguna migración del repo otorgaba GRANTs explícitos. El proyecto remoto
+-- funciona porque Supabase aplica sus default privileges al crear el proyecto
+-- (anon/authenticated/service_role reciben todos los privilegios sobre las
+-- tablas de `public`, y RLS es la compuerta real). Una base levantada sólo
+-- desde estas migraciones no hereda eso: las tablas quedan sin privilegios y
+-- toda lectura falla con `42501 permission denied`, aunque las policies estén
+-- bien. Verificado en un `supabase start` local: la home no cargaba un solo
+-- evento y el cron insertaba cero filas.
+--
+-- Esta migración reproduce el estado del remoto para que ambos entornos
+-- coincidan, con una excepción deliberada en `external_events_cache`.
+
+-- ─── Acceso al schema ───────────────────────────────────────────────────────
+grant usage on schema public to anon, authenticated, service_role;
+
+-- ─── Catálogo y datos de usuario ────────────────────────────────────────────
+-- Se replica el default de Supabase a propósito: el control de acceso real
+-- vive en las policies de RLS, no acá. Cambiar esto a privilegio mínimo por
+-- tabla haría que local y remoto difieran, que es justamente la clase de
+-- divergencia que esta migración viene a cerrar. Si en algún momento se
+-- quiere ajustar, hay que hacerlo en los dos lados a la vez.
+grant select, insert, update, delete on all tables in schema public
+  to anon, authenticated, service_role;
+
+grant usage, select on all sequences in schema public
+  to anon, authenticated, service_role;
+
+alter default privileges in schema public
+  grant select, insert, update, delete on tables to anon, authenticated, service_role;
+
+alter default privileges in schema public
+  grant usage, select on sequences to anon, authenticated, service_role;
+
+-- ─── external_events_cache: privilegio mínimo ───────────────────────────────
+-- Excepción al bloque de arriba. Esta tabla la escribe únicamente el cron de
+-- fuentes externas, que corre con la service role key; nadie más tiene motivo
+-- para tocarla. Los clientes sólo la leen. Se revoca toda escritura y se deja
+-- únicamente SELECT.
+--
+-- Se revoca ALL y se re-otorga SELECT en vez de listar los verbos a quitar:
+-- un `revoke insert, update, delete` deja TRUNCATE en pie, y TRUNCATE no pasa
+-- por RLS — vacía la tabla sin importar las policies.
+revoke all on external_events_cache from anon, authenticated;
+grant select on external_events_cache to anon, authenticated;
+
+-- ─── PostGIS ────────────────────────────────────────────────────────────────
+-- `spatial_ref_sys` es una tabla de sistema de PostGIS y no forma parte del
+-- modelo de la app. Se le quita el acceso que el grant masivo le dio: no la
+-- consulta ningún código del proyecto.
+revoke all on spatial_ref_sys from anon, authenticated;

--- a/supabase/migrations/20260826010000_restrict_catalog_deletes.sql
+++ b/supabase/migrations/20260826010000_restrict_catalog_deletes.sql
@@ -1,0 +1,30 @@
+-- Restringe el borrado del catálogo compartido a admins y moderadores.
+--
+-- `"Allow delete events"` y `"Allow delete festivals"` estaban como
+-- `using (true)` para cualquier `authenticated`: una cuenta recién creada
+-- podía borrar cualquier recital o festival cargado por otra persona. La
+-- migración original lo dejó anotado como deuda ("Más adelante se puede
+-- restringir a auth.uid() o rol").
+--
+-- Se restringe el DELETE y no el UPDATE a propósito: el catálogo es
+-- colaborativo y editarlo entre varios es el comportamiento buscado, pero el
+-- borrado no tiene vuelta atrás. El cambio de `status` ya está cubierto
+-- aparte por el trigger de 20260825060000.
+--
+-- `lineups` queda editable por cualquier autenticado porque borrar y volver a
+-- insertar filas de lineup es parte del flujo normal de editar un recital.
+
+drop policy if exists "Allow delete events" on "public"."events";
+create policy "Moderators delete events"
+  on "public"."events" for delete to authenticated
+  using (public.is_moderator());
+
+drop policy if exists "Public delete festivals" on "public"."festivals";
+create policy "Moderators delete festivals"
+  on "public"."festivals" for delete to authenticated
+  using (public.is_moderator());
+
+drop policy if exists "Public delete festival_events" on "public"."festival_events";
+create policy "Moderators delete festival_events"
+  on "public"."festival_events" for delete to authenticated
+  using (public.is_moderator());

--- a/supabase/migrations/20260826020000_indexes_for_hot_paths.sql
+++ b/supabase/migrations/20260826020000_indexes_for_hot_paths.sql
@@ -1,0 +1,67 @@
+-- Índices para los caminos calientes que quedaron sin cobertura.
+--
+-- Cada uno responde a un patrón de consulta concreto que hoy hace seq scan.
+-- Se usan índices parciales donde el predicado es fijo: indexan sólo las filas
+-- que la consulta mira, así que quedan chicos y las filas dejan de ocupar
+-- lugar en cuanto salen del estado que se consulta.
+
+-- ─── 1. Trigger de rate limit ───────────────────────────────────────────────
+-- check_creation_rate_limit() corre en CADA INSERT de artists/venues/events y
+-- hace `select count(*) ... where created_by = $1 and created_at > now() -
+-- interval '1 hour'`. Sin índice sobre created_by eso es un seq scan completo
+-- de la tabla por cada alta — y no sólo del alta manual: findOrCreateByName
+-- pasa por el mismo camino dos veces (venue + artista) en cada importación de
+-- un evento externo.
+--
+-- Parcial sobre `created_by is not null` porque las altas que entran por el
+-- cron con service role dejan esa columna en null y nunca se consultan por
+-- este predicado.
+create index if not exists artists_created_by_recent_idx
+  on public.artists (created_by, created_at desc)
+  where created_by is not null;
+
+create index if not exists venues_created_by_recent_idx
+  on public.venues (created_by, created_at desc)
+  where created_by is not null;
+
+create index if not exists events_created_by_recent_idx
+  on public.events (created_by, created_at desc)
+  where created_by is not null;
+
+-- ─── 2. Cola de moderación ──────────────────────────────────────────────────
+-- Los tres getUnverified* filtran por `status = 'unverified'` y ordenan. El
+-- patrón esperado en régimen es una cola corta sobre una tabla grande (20
+-- pendientes sobre 50.000 artistas), que es justo el peor caso para un filtro
+-- sin índice: seq scan + sort de toda la tabla para devolver 20 filas.
+--
+-- El índice parcial es ideal acá: sólo contiene las filas pendientes, y
+-- aprobar una la saca del índice.
+create index if not exists artists_unverified_idx
+  on public.artists (created_at desc)
+  where status = 'unverified';
+
+create index if not exists venues_unverified_idx
+  on public.venues (created_at desc)
+  where status = 'unverified';
+
+create index if not exists events_unverified_idx
+  on public.events (date)
+  where status = 'unverified';
+
+-- ─── 3. attendance por evento ───────────────────────────────────────────────
+-- El único índice de attendance que menciona event_id es el único compuesto
+-- (user_id, event_id), con user_id como columna líder: un `where event_id = X`
+-- sin filtro de user_id no lo puede usar.
+--
+-- merge_events hace dos pasadas de ese tipo (el UPDATE y el DELETE) dentro de
+-- una transacción, manteniendo el lock mientras escanea la tabla entera.
+-- attendance es la que crece más rápido de todas: usuarios × shows.
+create index if not exists attendance_event_id_idx
+  on public.attendance (event_id);
+
+-- ─── 4. Cache de fuentes externas ───────────────────────────────────────────
+-- `expires_at > now()` es el único predicado presente en TODAS las lecturas de
+-- searchCachedExternalEvents, y era el único sin índice: el trigram sobre el
+-- título sólo entra en juego cuando hay término de búsqueda.
+create index if not exists external_events_cache_expires_at_idx
+  on public.external_events_cache (expires_at);

--- a/supabase/migrations/20260826030000_consolidate_owner_policies.sql
+++ b/supabase/migrations/20260826030000_consolidate_owner_policies.sql
@@ -1,0 +1,180 @@
+-- Consolida las policies de dueño y corrige un bypass en event_photos.
+--
+-- Dos problemas, uno de seguridad y uno de costo.
+--
+-- SEGURIDAD. `event_photos` tenía una policy "Auth insert event_photos" con
+-- `with check (true)` conviviendo con "Owner insert event_photos"
+-- (`auth.uid() = user_id`). Las policies permisivas se combinan con OR, así que
+-- la laxa ganaba y el chequeo de dueño no servía de nada: cualquier usuario
+-- autenticado podía insertar una foto atribuida a otro user_id.
+-- 20260721000000_fase0_security_blockers.sql intentó eliminarla, pero dropeaba
+-- el nombre "Authenticated insert event_photos" y la que existía se llamaba
+-- "Auth insert event_photos" — creada fuera de las migraciones, así que el
+-- `drop policy if exists` no matcheó y la dejó viva.
+--
+-- COSTO. Cada tabla acumulaba entre 3 y 9 policies equivalentes, restos de
+-- pasadas sucesivas cuyos `drop` no coincidían con los nombres reales:
+-- attendance tenía 7 y expenses 9, todas expresando "soy el dueño". Postgres
+-- evalúa cada policy permisiva por fila candidata.
+--
+-- Además, todas escribían `auth.uid() = user_id` sin envolver. En ese contexto
+-- Postgres trata la función como volátil y la ejecuta una vez POR FILA en vez
+-- de una por consulta. Envolverla en `(select auth.uid())` la convierte en un
+-- InitPlan que se evalúa una sola vez — es la recomendación explícita de
+-- Supabase y no cambia la semántica.
+--
+-- Se preserva exactamente el conjunto de comandos que cada tabla permitía: las
+-- tablas que tenían una policy FOR ALL quedan con FOR ALL, y las que sólo
+-- permitían algunos comandos (event_photos, profiles, user_preferences) los
+-- mantienen enumerados, para no habilitar un DELETE que antes no existía.
+
+-- ─── attendance ─────────────────────────────────────────────────────────────
+drop policy if exists "Manage own attendance" on public.attendance;
+drop policy if exists "Owner all attendance" on public.attendance;
+drop policy if exists "Owner delete attendance" on public.attendance;
+drop policy if exists "Owner insert attendance" on public.attendance;
+drop policy if exists "Owner select attendance" on public.attendance;
+drop policy if exists "Owner update attendance" on public.attendance;
+drop policy if exists "View own attendance" on public.attendance;
+
+create policy "Owner manages own attendance" on public.attendance
+  for all to authenticated
+  using ((select auth.uid()) = user_id)
+  with check ((select auth.uid()) = user_id);
+
+-- ─── expenses ───────────────────────────────────────────────────────────────
+drop policy if exists "Owner all expenses" on public.expenses;
+drop policy if exists "Owner delete expenses" on public.expenses;
+drop policy if exists "Owner insert expenses" on public.expenses;
+drop policy if exists "Owner select expenses" on public.expenses;
+drop policy if exists "Owner update expenses" on public.expenses;
+drop policy if exists "Users delete own expenses" on public.expenses;
+drop policy if exists "Users insert own expenses" on public.expenses;
+drop policy if exists "Users see own expenses" on public.expenses;
+drop policy if exists "Users update own expenses" on public.expenses;
+
+create policy "Owner manages own expenses" on public.expenses
+  for all to authenticated
+  using ((select auth.uid()) = user_id)
+  with check ((select auth.uid()) = user_id);
+
+-- ─── wishlist ───────────────────────────────────────────────────────────────
+drop policy if exists "Owner all wishlist" on public.wishlist;
+drop policy if exists "Owner delete wishlist" on public.wishlist;
+drop policy if exists "Owner insert wishlist" on public.wishlist;
+drop policy if exists "Owner select wishlist" on public.wishlist;
+
+create policy "Owner manages own wishlist" on public.wishlist
+  for all to authenticated
+  using ((select auth.uid()) = user_id)
+  with check ((select auth.uid()) = user_id);
+
+-- ─── festival_attendance ────────────────────────────────────────────────────
+drop policy if exists "Owner all festival_attendance" on public.festival_attendance;
+drop policy if exists "Owner delete festival_attendance" on public.festival_attendance;
+drop policy if exists "Owner insert festival_attendance" on public.festival_attendance;
+drop policy if exists "Owner select festival_attendance" on public.festival_attendance;
+drop policy if exists "Owner update festival_attendance" on public.festival_attendance;
+
+create policy "Owner manages own festival_attendance" on public.festival_attendance
+  for all to authenticated
+  using ((select auth.uid()) = user_id)
+  with check ((select auth.uid()) = user_id);
+
+-- ─── checklist del modo recital ─────────────────────────────────────────────
+drop policy if exists "Users delete own checklist template" on public.checklist_template_items;
+drop policy if exists "Users insert own checklist template" on public.checklist_template_items;
+drop policy if exists "Users see own checklist template" on public.checklist_template_items;
+drop policy if exists "Users update own checklist template" on public.checklist_template_items;
+
+create policy "Owner manages own checklist template" on public.checklist_template_items
+  for all to authenticated
+  using ((select auth.uid()) = user_id)
+  with check ((select auth.uid()) = user_id);
+
+drop policy if exists "Users delete own event checklist items" on public.event_checklist_items;
+drop policy if exists "Users insert own event checklist items" on public.event_checklist_items;
+drop policy if exists "Users see own event checklist items" on public.event_checklist_items;
+drop policy if exists "Users update own event checklist items" on public.event_checklist_items;
+
+create policy "Owner manages own event checklist items" on public.event_checklist_items
+  for all to authenticated
+  using ((select auth.uid()) = user_id)
+  with check ((select auth.uid()) = user_id);
+
+drop policy if exists "Users delete own template checks" on public.event_checklist_checks;
+drop policy if exists "Users insert own template checks" on public.event_checklist_checks;
+drop policy if exists "Users see own template checks" on public.event_checklist_checks;
+drop policy if exists "Users update own template checks" on public.event_checklist_checks;
+
+create policy "Owner manages own template checks" on public.event_checklist_checks
+  for all to authenticated
+  using ((select auth.uid()) = user_id)
+  with check ((select auth.uid()) = user_id);
+
+-- ─── event_photos ───────────────────────────────────────────────────────────
+-- La lectura es pública a propósito (mismo criterio que el catálogo), así que
+-- el dueño mantiene sólo insert/update/delete y no se agrega un SELECT propio.
+-- Se elimina el insert laxo descripto arriba y el SELECT redundante para
+-- authenticated, que ya cubre la policy pública.
+drop policy if exists "Auth insert event_photos" on public.event_photos;
+drop policy if exists "Authenticated insert event_photos" on public.event_photos;
+drop policy if exists "Authenticated select event_photos" on public.event_photos;
+drop policy if exists "Owner delete event_photos" on public.event_photos;
+drop policy if exists "Owner insert event_photos" on public.event_photos;
+drop policy if exists "Owner update event_photos" on public.event_photos;
+
+create policy "Owner inserts own event_photos" on public.event_photos
+  for insert to authenticated
+  with check ((select auth.uid()) = user_id);
+
+create policy "Owner updates own event_photos" on public.event_photos
+  for update to authenticated
+  using ((select auth.uid()) = user_id)
+  with check ((select auth.uid()) = user_id);
+
+create policy "Owner deletes own event_photos" on public.event_photos
+  for delete to authenticated
+  using ((select auth.uid()) = user_id);
+
+-- ─── profiles ───────────────────────────────────────────────────────────────
+-- El perfil es de lectura pública y el dueño sólo puede insertarlo y editarlo;
+-- no había DELETE y no se agrega. Las dos policies de lectura pública
+-- duplicadas se colapsan en una.
+drop policy if exists "Users can insert their own profile." on public.profiles;
+drop policy if exists "Users can update own profile." on public.profiles;
+drop policy if exists "Users update own profile" on public.profiles;
+drop policy if exists "Public profiles" on public.profiles;
+drop policy if exists "Public profiles are viewable by everyone." on public.profiles;
+
+create policy "Public read profiles" on public.profiles
+  for select to anon, authenticated
+  using (true);
+
+create policy "Owner inserts own profile" on public.profiles
+  for insert to authenticated
+  with check ((select auth.uid()) = id);
+
+create policy "Owner updates own profile" on public.profiles
+  for update to authenticated
+  using ((select auth.uid()) = id)
+  with check ((select auth.uid()) = id);
+
+-- ─── user_preferences ───────────────────────────────────────────────────────
+-- Sólo tenía insert/select/update; se mantiene así.
+drop policy if exists "Users insert own preferences" on public.user_preferences;
+drop policy if exists "Users see own preferences" on public.user_preferences;
+drop policy if exists "Users update own preferences" on public.user_preferences;
+
+create policy "Owner reads own preferences" on public.user_preferences
+  for select to authenticated
+  using ((select auth.uid()) = id);
+
+create policy "Owner inserts own preferences" on public.user_preferences
+  for insert to authenticated
+  with check ((select auth.uid()) = id);
+
+create policy "Owner updates own preferences" on public.user_preferences
+  for update to authenticated
+  using ((select auth.uid()) = id)
+  with check ((select auth.uid()) = id);

--- a/supabase/migrations/20260826040000_profiles_missing_columns.sql
+++ b/supabase/migrations/20260826040000_profiles_missing_columns.sql
@@ -1,0 +1,27 @@
+-- Agrega las columnas de `profiles` que nunca llegaron a crearse.
+--
+-- `20260218250000_create_profiles.sql` declara la tabla con username,
+-- full_name, avatar_url, website, bio, location y updated_at — pero lo hace con
+-- `create table if not exists`, y `profiles` ya existía desde el dump inicial
+-- (`20260216230841_remote_schema.sql:100`) con sólo id, username, avatar_url,
+-- bio y created_at. El `if not exists` convirtió el CREATE entero en un no-op y
+-- las cuatro columnas restantes nunca existieron.
+--
+-- Es el mismo patrón que la colisión de `events.status`: un `create ... if not
+-- exists` que aplica limpio y deja el esquema a medias, sin que ninguna
+-- migración falle.
+--
+-- Consecuencias que esto arregla:
+--   * `modifyProfile` (src/domains/auth/service.ts) escribe full_name, website
+--     y location, así que editar el perfil fallaba siempre contra la base.
+--   * `/profile` mostraba "Sin nombre" para todo el mundo, porque leía
+--     `profile.full_name`, y nunca renderizaba ubicación ni sitio web.
+--
+-- El tipo `Profile` de src/core/types ya declaraba las cuatro, así que el
+-- código estaba escrito contra el esquema que se pretendía, no contra el real.
+
+alter table public.profiles
+  add column if not exists full_name text,
+  add column if not exists website text,
+  add column if not exists location text,
+  add column if not exists updated_at timestamptz;

--- a/test-adapters.ts
+++ b/test-adapters.ts
@@ -1,0 +1,17 @@
+import { externalAdapters } from './src/core/lib/external-sources/adapters/index'
+
+async function run() {
+  const results = await Promise.allSettled(
+    externalAdapters.map(adapter => adapter.search({}))
+  )
+  for (let i = 0; i < externalAdapters.length; i++) {
+    const res = results[i]
+    if (res.status === 'fulfilled') {
+      console.log(`Adapter ${externalAdapters[i].id}: ${res.value.events?.length || 0} events. Error? ${res.value.error}`)
+    } else {
+      console.log(`Adapter ${externalAdapters[i].id}: REJECTED`, res.reason)
+    }
+  }
+}
+
+run()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "mcp", "scratch"]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "crons": [
+    {
+      "_comment": "Refresca external_events_cache. Diario porque el plan Hobby de Vercel dispara los crons una vez por día; el TTL del cache es de 7 días, así que una corrida diaria lo mantiene fresco con margen. En Pro se puede subir a '0 */6 * * *'.",
+      "path": "/api/cron/sync-external-sources",
+      "schedule": "0 7 * * *"
+    }
+  ]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,6 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "crons": [
     {
-      "_comment": "Refresca external_events_cache. Diario porque el plan Hobby de Vercel dispara los crons una vez por día; el TTL del cache es de 7 días, así que una corrida diaria lo mantiene fresco con margen. En Pro se puede subir a '0 */6 * * *'.",
       "path": "/api/cron/sync-external-sources",
       "schedule": "0 7 * * *"
     }


### PR DESCRIPTION
Auditoría del proyecto y corrección de lo que encontró. Arranca de una revisión en cuatro frentes (seguridad, carga sobre la base, scrapers, estructura) y termina arreglando todo lo verificable, más dos bugs que aparecieron al recorrer la app con datos reales.

Cada hallazgo está verificado contra una base local levantada desde cero, no sólo por lectura de código. El detalle completo, con el estado de cada ítem, está en `docs/auditoria-2026-08-25.md`.

## Lo que estaba roto

**Las migraciones no corrían desde cero.** Un `supabase db reset` limpio se cortaba en la novena: el índice GIN trigram de `external_events_cache` se creaba antes de habilitar `pg_trgm`, que aparecía en una migración posterior. Ninguna de las siguientes llegaba a aplicar. El CLI de Supabase devolvía exit 0 igual, así que el CI tampoco lo veía.

Debajo de eso había dos migraciones que aplicaban limpio y dejaban el esquema a medias:

- `20260824202000_moderation_queue` intentaba agregar `events.status` cuando la columna ya existía como `text` desde el dump inicial. Fallaba con "column already exists" y, por ser una sola sentencia, se caía también `events.created_by`, que el trigger de rate limit escribe en cada INSERT.
- `20260218250000_create_profiles` usa `create table if not exists` sobre una tabla que ya existía con menos columnas. `full_name`, `website`, `location` y `updated_at` **nunca se crearon**: editar el perfil fallaba siempre y `/profile` mostraba "Sin nombre" para todo el mundo.

**Los tres RPC de fusión apuntaban a tablas inexistentes** (`event_artists`, `user_wishlist`; las reales son `lineups` y `wishlist`). `plpgsql` no valida catálogos al crear la función, así que la migración aplicaba bien y el error sólo aparecía al ejecutar una fusión.

**Ninguna migración otorgaba GRANTs.** El proyecto remoto funciona porque Supabase los aplica al crear el proyecto; una base levantada sólo desde estas migraciones quedaba con toda lectura fallando con `42501`, aunque las policies estuvieran bien.

**Los scrapers no corrían.** No existía `vercel.json`, así que el cron nunca se disparaba y `external_events_cache` no se llenaba jamás. Con el cron agendado, 11 de 13 fuentes traen datos (517 eventos en una corrida). `venti` devuelve 404 — su endpoint estaba declarado como adivinado en el propio código.

## Seguridad

- **El cron fallaba abierto.** `if (CRON_SECRET && ...)` significaba que sin la variable el chequeo se salteaba entero, dejando el endpoint público corriendo con la service role key. Ahora falla cerrado y compara con `timingSafeEqual`.
- **Cualquier autenticado podía borrar cualquier recital o festival.** Restringido a moderadores, en RLS y en el service. La edición sigue abierta a propósito: el catálogo es colaborativo, el borrado es lo único sin vuelta.
- **`event_photos` tenía un `with check (true)`** conviviendo con la policy de dueño. Como las permisivas se combinan con OR, la laxa ganaba: se podía subir una foto atribuida a otro usuario. Sobrevivió porque un `drop policy if exists` apuntaba a un nombre que no coincidía con el real. Verificado con dos cuentas: 403 al intentar suplantar, 201 al subir la propia.
- **Guardas de rol NULL-unsafe.** `get_user_role()` devuelve NULL sin fila en `profiles`, y `NULL NOT IN (...)` es NULL, que en plpgsql es falsy: el chequeo se salteaba. Centralizado en `is_moderator()` con `coalesce`.
- **`ilike` sin escapar en tres lugares** — buscar `%` devolvía el catálogo entero, incluso justo antes de elegir el destino de una fusión destructiva. Helper unificado.

## Performance

Todo medido, no estimado.

- N+1 vivo en `Artist.events` y `Venue.events`, que el pase anterior de DataLoader no cubrió. Con `pg_stat_statements`: 3 artistas pasan de 3 selects anidados a **1 sentencia**.
- Cuatro índices faltantes, verificados con `EXPLAIN`. El del trigger de rate limit resuelve con **Index Only Scan** un `count(*)` que antes escaneaba la tabla entera en cada INSERT.
- `getPersonalStats` traía la tabla `events` completa y filtraba en JS. Invertida: parte de `attendance` del usuario.
- El home cargaba tres catálogos completos por request. Un render anónimo pasa a ejecutar **cero queries** contra el catálogo.
- Las 46 policies con `auth.uid()` sin envolver quedan en 17, todas con `(select auth.uid())`.

## Encontrado recorriendo la app

- **`formatDate` retrocedía un día** en columnas `date`: un gasto del 26 se mostraba como "25 may". Mismo trap que el repo ya había resuelto en `eventYear`/`eventMonth`, pero `formatDate` había quedado afuera.
- **El talón 3D no renderizaba dentro de la app.** `X-Frame-Options: DENY` bloquea el framing incluso same-origin. La request devolvía 200 y el navegador la descartaba sin error en consola, así que parecía un problema de three.js. Ahora `/tickets/` va en `SAMEORIGIN`; el resto del sitio conserva `DENY`.
- **Fechas de scrapers**: `entradaweb` manda prosa y `livepass` manda "13 SEP". Con `new Date()` a secas terminaban como el texto "Invalid Date" en la cartelera y rechazadas al importar. Detalle feo: `new Date('13 SEP')` devuelve el año **2001**, así que la rama nativa quedó restringida a ISO real.

## CI

Estaba en rojo: `lint` daba 190 errores y `tsc` fallaba con `relayOptions`, que es la API de Pothos **v3** y en v4 está tipada como `never` — la config nunca se aplicaba. Los dos tests de `showmode` que fallaban usaban el día UTC mientras la app ancla a Argentina, así que se rompían solos entre las 21:00 y medianoche.

Ahora: **lint 0, tsc 0, 1024 tests**.

## Verificado end-to-end

Ciclo de moderación completo contra la base: aprobar → aparece como target de fusión → fusionar. Con historial real, Divididos pasó de 1 a 2 lineups y de 1 a 2 en wishlist, el duplicado dejó de existir y quedaron **cero huérfanos**. Ése es el punto de fusionar en vez de borrar, y antes ni corría.

## Fuera de alcance, a propósito

- El seam `service.ts` sigue erosionado: `src/graphql/` y varias páginas importan `data.ts` directo, y `moderation` no tiene `data.ts` separado. Es un refactor de 23 archivos y merece su propia tanda; queda anotado en `src/README.md`.
- Crear festivales sigue abierto a cualquier autenticado, aunque el spec los reserva a Admin.
- La pasada de diseño del panel de admin y la versión mobile: inventariadas en `docs/design-backlog.md`.
- `pulsotickets` devuelve cero en silencio; sus selectores son clases de Tailwind. Anotado, no arreglado.
